### PR TITLE
Allow testng to be resolved via mavenCentral

### DIFF
--- a/constraintlayout/build.gradle
+++ b/constraintlayout/build.gradle
@@ -75,6 +75,7 @@ subprojects { Project project ->
     apply plugin: 'maven'
 
     repositories {
+        mavenCentral()
         maven { url "$rootProject.projectDir/../../prebuilts/tools/common/m2/repository" }
     }
 

--- a/constraintlayout/core/build.gradle
+++ b/constraintlayout/core/build.gradle
@@ -7,7 +7,7 @@ compileJava {
 }
 
 dependencies {
-    testCompile 'org.testng:testng:6.9.10'
+    testCompile 'org.testng:testng:7.3.0'
 }
 
 test {

--- a/constraintlayout/gradle.properties
+++ b/constraintlayout/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.daemon=true
 usePrebuilts=false
 android.enableD8.desugaring=true
+org.gradle.jvmargs=-Dtestng.dtd.http=true

--- a/projects/CarouselExperiments/core/build.gradle
+++ b/projects/CarouselExperiments/core/build.gradle
@@ -11,5 +11,5 @@ sourceSets{
 }
 
 dependencies {
-    testImplementation 'org.testng:testng:6.9.6'
+    testImplementation 'org.testng:testng:7.3.0'
 }

--- a/projects/ConstraintLayoutValidation/core/build.gradle
+++ b/projects/ConstraintLayoutValidation/core/build.gradle
@@ -11,5 +11,5 @@ sourceSets{
 }
 
 dependencies {
-    testImplementation 'org.testng:testng:6.9.6'
+    testImplementation 'org.testng:testng:7.3.0'
 }

--- a/projects/DeveloperTemplate/core/build.gradle
+++ b/projects/DeveloperTemplate/core/build.gradle
@@ -11,5 +11,5 @@ sourceSets{
 }
 
 dependencies {
-    testImplementation 'org.testng:testng:6.9.6'
+    testImplementation 'org.testng:testng:7.3.0'
 }

--- a/projects/FoldableExperiments/core/build.gradle
+++ b/projects/FoldableExperiments/core/build.gradle
@@ -11,5 +11,5 @@ sourceSets{
 }
 
 dependencies {
-    testImplementation 'org.testng:testng:6.9.6'
+    testImplementation 'org.testng:testng:7.3.0'
 }

--- a/projects/MotionLayoutExperiments/core/build.gradle
+++ b/projects/MotionLayoutExperiments/core/build.gradle
@@ -11,5 +11,5 @@ sourceSets{
 }
 
 dependencies {
-    testImplementation 'org.testng:testng:6.9.6'
+    testImplementation 'org.testng:testng:7.3.0'
 }

--- a/projects/MotionLayoutVerification/core/build.gradle
+++ b/projects/MotionLayoutVerification/core/build.gradle
@@ -11,5 +11,5 @@ sourceSets{
 }
 
 dependencies {
-    testImplementation 'org.testng:testng:6.9.6'
+    testImplementation 'org.testng:testng:7.3.0'
 }

--- a/projects/ViewTransitionExperiments/core/build.gradle
+++ b/projects/ViewTransitionExperiments/core/build.gradle
@@ -11,5 +11,5 @@ sourceSets{
 }
 
 dependencies {
-    testImplementation 'org.testng:testng:6.9.6'
+    testImplementation 'org.testng:testng:7.3.0'
 }


### PR DESCRIPTION
Also update it to latest stable version 7.3.0

That version change requires the `-Dtestng.dtd.http=true` flag to be added to `gradle.properties`, which allows for testng to read from local XML files.