### PR TITLE
Remove redundant transition check in bestTransitionFor

### DIFF
--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionScene.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionScene.java
@@ -62,7 +62,7 @@ import org.xmlpull.v1.XmlPullParserException;
 
 public class MotionScene {
     public static final String TAG = "MotionScene";
-    private static final boolean DEBUG = true;
+    private static final boolean DEBUG = false;
     final static int TRANSITION_BACKWARD = 0;
     final static int TRANSITION_FORWARD = 1;
     private static final int SPLINE_STRING = -1;

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionScene.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionScene.java
@@ -290,7 +290,7 @@ public class MotionScene {
         }
     }
 
-    public Transition bestTransitionFor(int currentState, float dx, float dy, MotionEvent mLastTouchDown) {
+    public Transition bestTransitionFor(int currentState, float dx, float dy, MotionEvent lastTouchDown) {
         List<Transition> candidates = null;
         if (currentState != -1) {
             candidates = getTransitionsWithState(currentState);
@@ -304,14 +304,14 @@ public class MotionScene {
                 if (transition.mTouchResponse != null) {
                     transition.mTouchResponse.setRTL(mRtl);
                     RectF region = transition.mTouchResponse.getTouchRegion(mMotionLayout, cache);
-                    if (region != null && mLastTouchDown != null && (!region.contains(mLastTouchDown.getX(), mLastTouchDown.getY()))) {
+                    if (region != null && lastTouchDown != null && (!region.contains(lastTouchDown.getX(), lastTouchDown.getY()))) {
                         continue;
                     }
 
                     float val = transition.mTouchResponse.dot(dx, dy);
-                    if (transition.mTouchResponse.mIsRotateMode && mLastTouchDown != null) {
-                        float startX = mLastTouchDown.getX() - transition.mTouchResponse.mRotateCenterX;
-                        float startY = mLastTouchDown.getY() - transition.mTouchResponse.mRotateCenterY;
+                    if (transition.mTouchResponse.mIsRotateMode && lastTouchDown != null) {
+                        float startX = lastTouchDown.getX() - transition.mTouchResponse.mRotateCenterX;
+                        float startY = lastTouchDown.getY() - transition.mTouchResponse.mRotateCenterY;
                         float endX = dx + startX;
                         float endY = dy + startY;
                         double endAngle = Math.atan2(endY, endX);

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionScene.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionScene.java
@@ -62,7 +62,7 @@ import org.xmlpull.v1.XmlPullParserException;
 
 public class MotionScene {
     public static final String TAG = "MotionScene";
-    private static final boolean DEBUG = false;
+    private static final boolean DEBUG = true;
     final static int TRANSITION_BACKWARD = 0;
     final static int TRANSITION_FORWARD = 1;
     private static final int SPLINE_STRING = -1;
@@ -304,10 +304,6 @@ public class MotionScene {
                 if (transition.mTouchResponse != null) {
                     transition.mTouchResponse.setRTL(mRtl);
                     RectF region = transition.mTouchResponse.getTouchRegion(mMotionLayout, cache);
-                    if (region != null && mLastTouchDown != null && (!region.contains(mLastTouchDown.getX(), mLastTouchDown.getY()))) {
-                        continue;
-                    }
-                    region = transition.mTouchResponse.getTouchRegion(mMotionLayout, cache);
                     if (region != null && mLastTouchDown != null && (!region.contains(mLastTouchDown.getX(), mLastTouchDown.getY()))) {
                         continue;
                     }

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionScene.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionScene.java
@@ -309,7 +309,7 @@ public class MotionScene {
                     }
 
                     float val = transition.mTouchResponse.dot(dx, dy);
-                    if (transition.mTouchResponse.mIsRotateMode) {
+                    if (transition.mTouchResponse.mIsRotateMode && mLastTouchDown != null) {
                         float startX = mLastTouchDown.getX() - transition.mTouchResponse.mRotateCenterX;
                         float startY = mLastTouchDown.getY() - transition.mTouchResponse.mRotateCenterY;
                         float endX = dx + startX;


### PR DESCRIPTION
* Addresses request to remove redundant check in https://github.com/androidx/constraintlayout/issues/11
* Noticed that `mLastTouchDown` is nullable so I added a null check before we use it
* Renamed method arg `mLastTouchDown` to `lastTouchDown` so it doesn't overshadow class member