### PR TITLE
Fix old Android version references

### DIFF
--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionLayout.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionLayout.java
@@ -2323,7 +2323,7 @@ public class MotionLayout extends ConstraintLayout implements
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
                     layoutParams.resolveLayoutDirection(getLayoutDirection());
                 } else {
-                    layoutParams.resolveLayoutDirection(View.LAYOUT_DIRECTION_LTR);
+                    layoutParams.resolveLayoutDirection(0);
                 }
                 applyConstraintsFromLayoutParams(false, view, child, layoutParams, mapIdToWidget);
                 if (cset.getVisibilityMode(view.getId()) == ConstraintSet.VISIBILITY_MODE_IGNORE) {

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionLayout.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionLayout.java
@@ -28,6 +28,7 @@ import android.os.Build;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.view.ViewCompat;
 import androidx.constraintlayout.widget.Barrier;
 import androidx.constraintlayout.widget.ConstraintHelper;
 import androidx.constraintlayout.widget.ConstraintLayout;
@@ -2323,7 +2324,7 @@ public class MotionLayout extends ConstraintLayout implements
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
                     layoutParams.resolveLayoutDirection(getLayoutDirection());
                 } else {
-                    layoutParams.resolveLayoutDirection(0);
+                    layoutParams.resolveLayoutDirection(ViewCompat.LAYOUT_DIRECTION_LTR);
                 }
                 applyConstraintsFromLayoutParams(false, view, child, layoutParams, mapIdToWidget);
                 if (cset.getVisibilityMode(view.getId()) == ConstraintSet.VISIBILITY_MODE_IGNORE) {

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/utils/widget/MotionLabel.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/utils/widget/MotionLabel.java
@@ -47,8 +47,7 @@ import androidx.annotation.RequiresApi;
 import androidx.constraintlayout.motion.widget.Debug;
 import androidx.constraintlayout.motion.widget.FloatLayout;
 import androidx.constraintlayout.widget.R;
-
-import static android.widget.TextView.AUTO_SIZE_TEXT_TYPE_NONE;
+import androidx.core.widget.TextViewCompat;
 
 /**
  * This class is designed to created Complex Animated Single Line Text in MotionLayout
@@ -87,7 +86,7 @@ public class MotionLabel extends View implements FloatLayout {
     private static final int SERIF = 2;
     private static final int MONOSPACE = 3;
     private int mGravity = Gravity.TOP | Gravity.START;
-    private int mAutoSizeTextType = 0;
+    private int mAutoSizeTextType = TextViewCompat.AUTO_SIZE_TEXT_TYPE_NONE;
     private boolean mAutoSize = false; // decided during measure
     private float mDeltaLeft;
     private float mFloatWidth, mFloatHeight;
@@ -153,9 +152,7 @@ public class MotionLabel extends View implements FloatLayout {
                 } else if (attr == R.styleable.MotionLabel_android_gravity) {
                     setGravity(a.getInt(attr, -1));
                 } else if (attr == R.styleable.MotionLabel_android_autoSizeTextType) {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                        mAutoSizeTextType = a.getInt(attr, AUTO_SIZE_TEXT_TYPE_NONE);
-                    }
+                    mAutoSizeTextType = a.getInt(attr, TextViewCompat.AUTO_SIZE_TEXT_TYPE_NONE);
                 } else if (attr == R.styleable.MotionLabel_textOutlineColor) {
                     mTextOutlineColor = a.getInt(attr, mTextOutlineColor);
                     mUseOutline = true;
@@ -607,7 +604,7 @@ public class MotionLabel extends View implements FloatLayout {
                 height += mPaddingTop + mPaddingBottom;
             }
         } else {
-            if (mAutoSizeTextType != AUTO_SIZE_TEXT_TYPE_NONE) {
+            if (mAutoSizeTextType != TextViewCompat.AUTO_SIZE_TEXT_TYPE_NONE) {
                 mAutoSize = true;
             }
 

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/utils/widget/MotionLabel.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/utils/widget/MotionLabel.java
@@ -16,6 +16,7 @@
 
 package androidx.constraintlayout.utils.widget;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
@@ -86,7 +87,7 @@ public class MotionLabel extends View implements FloatLayout {
     private static final int SERIF = 2;
     private static final int MONOSPACE = 3;
     private int mGravity = Gravity.TOP | Gravity.START;
-    private int mAutoSizeTextType = AUTO_SIZE_TEXT_TYPE_NONE;
+    private int mAutoSizeTextType = 0;
     private boolean mAutoSize = false; // decided during measure
     private float mDeltaLeft;
     private float mFloatWidth, mFloatHeight;
@@ -152,7 +153,9 @@ public class MotionLabel extends View implements FloatLayout {
                 } else if (attr == R.styleable.MotionLabel_android_gravity) {
                     setGravity(a.getInt(attr, -1));
                 } else if (attr == R.styleable.MotionLabel_android_autoSizeTextType) {
-                    mAutoSizeTextType = a.getInt(attr, AUTO_SIZE_TEXT_TYPE_NONE);
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        mAutoSizeTextType = a.getInt(attr, AUTO_SIZE_TEXT_TYPE_NONE);
+                    }
                 } else if (attr == R.styleable.MotionLabel_textOutlineColor) {
                     mTextOutlineColor = a.getInt(attr, mTextOutlineColor);
                     mUseOutline = true;
@@ -234,6 +237,7 @@ public class MotionLabel extends View implements FloatLayout {
      * @attr ref android.R.styleable#TextView_gravity
      * @see android.view.Gravity
      */
+    @SuppressLint("RtlHardcoded")
     public void setGravity(int gravity) {
         if ((gravity & Gravity.RELATIVE_HORIZONTAL_GRAVITY_MASK) == 0) {
             gravity |= Gravity.START;
@@ -261,10 +265,13 @@ public class MotionLabel extends View implements FloatLayout {
             default:
                 mTextPanY = 0;
         }
-        switch (mGravity & Gravity.HORIZONTAL_GRAVITY_MASK) {
+
+        switch (mGravity & Gravity.RELATIVE_HORIZONTAL_GRAVITY_MASK) {
+            case Gravity.START:
             case Gravity.LEFT:
                 mTextPanX = -1;
                 break;
+            case Gravity.END:
             case Gravity.RIGHT:
                 mTextPanX = 1;
                 break;
@@ -278,8 +285,7 @@ public class MotionLabel extends View implements FloatLayout {
         float boxWidth = ((Float.isNaN(mFloatWidth)) ? getMeasuredWidth() : mFloatWidth)
                 - getPaddingLeft()
                 - getPaddingRight();
-        float off = (boxWidth - textWidth) * (1 + mTextPanX) / 2.f;
-        return off;
+        return (boxWidth - textWidth) * (1 + mTextPanX) / 2.f;
     }
 
     private float getVerticalOffset() {

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintLayout.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintLayout.java
@@ -36,6 +36,8 @@ import androidx.constraintlayout.core.widgets.ConstraintWidget;
 import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer;
 import androidx.constraintlayout.core.widgets.Guideline;
 import androidx.constraintlayout.core.widgets.analyzer.BasicMeasure;
+import androidx.core.view.ViewCompat;
+
 import android.util.AttributeSet;
 import android.util.Log;
 import android.util.SparseArray;
@@ -966,7 +968,7 @@ public class ConstraintLayout extends ViewGroup {
                             mConstraintLayoutSpec = null;
                         }
                     }
-                } else if (attr == R.styleable.ConstraintLayout_constraintSet) {
+                } else if (attr == R.styleable.ConstraintLayout_Layout_constraintSet) {
                     int id = a.getResourceId(attr, 0);
                     try {
                         mConstraintSet = new ConstraintSet();
@@ -989,22 +991,6 @@ public class ConstraintLayout extends ViewGroup {
      */
     protected void parseLayoutDescription(int id) {
         mConstraintLayoutSpec = new ConstraintLayoutStates(getContext(), this, id);
-    }
-
-    /**
-     * {@hide}
-     */
-    @Override
-    public void addView(View child, int index, ViewGroup.LayoutParams params) {
-        super.addView(child, index, params);
-    }
-
-    /**
-     * {@hide}
-     */
-    @Override
-    public void removeView(View view) {
-        super.removeView(view);
     }
 
     /**
@@ -2578,7 +2564,7 @@ public class ConstraintLayout extends ViewGroup {
         float resolvedGuidePercent;
 
         boolean isRtl = false;
-        int layoutDirection = 0;
+        int layoutDirection = ViewCompat.LAYOUT_DIRECTION_LTR;
 
         ConstraintWidget widget = new ConstraintWidget();
 

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintLayout.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintLayout.java
@@ -966,7 +966,7 @@ public class ConstraintLayout extends ViewGroup {
                             mConstraintLayoutSpec = null;
                         }
                     }
-                } else if (attr == R.styleable.ConstraintLayout_Layout_constraintSet) {
+                } else if (attr == R.styleable.ConstraintLayout_constraintSet) {
                     int id = a.getResourceId(attr, 0);
                     try {
                         mConstraintSet = new ConstraintSet();
@@ -997,9 +997,6 @@ public class ConstraintLayout extends ViewGroup {
     @Override
     public void addView(View child, int index, ViewGroup.LayoutParams params) {
         super.addView(child, index, params);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-            onViewAdded(child);
-        }
     }
 
     /**
@@ -1008,9 +1005,6 @@ public class ConstraintLayout extends ViewGroup {
     @Override
     public void removeView(View view) {
         super.removeView(view);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-            onViewRemoved(view);
-        }
     }
 
     /**
@@ -1018,9 +1012,7 @@ public class ConstraintLayout extends ViewGroup {
      */
     @Override
     public void onViewAdded(View view) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-            super.onViewAdded(view);
-        }
+        super.onViewAdded(view);
         ConstraintWidget widget = getViewWidget(view);
         if (view instanceof androidx.constraintlayout.widget.Guideline) {
             if (!(widget instanceof Guideline)) {
@@ -1048,9 +1040,7 @@ public class ConstraintLayout extends ViewGroup {
      */
     @Override
     public void onViewRemoved(View view) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-            super.onViewRemoved(view);
-        }
+        super.onViewRemoved(view);
         mChildrenByIds.remove(view.getId());
         ConstraintWidget widget = getViewWidget(view);
         mLayoutWidget.remove(widget);
@@ -1638,28 +1628,22 @@ public class ConstraintLayout extends ViewGroup {
         int androidLayoutWidth = measuredWidth + widthPadding;
         int androidLayoutHeight = measuredHeight + heightPadding;
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-            int resolvedWidthSize = resolveSizeAndState(androidLayoutWidth, widthMeasureSpec, childState);
-            int resolvedHeightSize = resolveSizeAndState(androidLayoutHeight, heightMeasureSpec,
-                    childState << MEASURED_HEIGHT_STATE_SHIFT);
-            resolvedWidthSize &= MEASURED_SIZE_MASK;
-            resolvedHeightSize &= MEASURED_SIZE_MASK;
-            resolvedWidthSize = Math.min(mMaxWidth, resolvedWidthSize);
-            resolvedHeightSize = Math.min(mMaxHeight, resolvedHeightSize);
-            if (isWidthMeasuredTooSmall) {
-                resolvedWidthSize |= MEASURED_STATE_TOO_SMALL;
-            }
-            if (isHeightMeasuredTooSmall) {
-                resolvedHeightSize |= MEASURED_STATE_TOO_SMALL;
-            }
-            setMeasuredDimension(resolvedWidthSize, resolvedHeightSize);
-            mLastMeasureWidth = resolvedWidthSize;
-            mLastMeasureHeight = resolvedHeightSize;
-        } else {
-            setMeasuredDimension(androidLayoutWidth, androidLayoutHeight);
-            mLastMeasureWidth = androidLayoutWidth;
-            mLastMeasureHeight = androidLayoutHeight;
+        int resolvedWidthSize = resolveSizeAndState(androidLayoutWidth, widthMeasureSpec, childState);
+        int resolvedHeightSize = resolveSizeAndState(androidLayoutHeight, heightMeasureSpec,
+                childState << MEASURED_HEIGHT_STATE_SHIFT);
+        resolvedWidthSize &= MEASURED_SIZE_MASK;
+        resolvedHeightSize &= MEASURED_SIZE_MASK;
+        resolvedWidthSize = Math.min(mMaxWidth, resolvedWidthSize);
+        resolvedHeightSize = Math.min(mMaxHeight, resolvedHeightSize);
+        if (isWidthMeasuredTooSmall) {
+            resolvedWidthSize |= MEASURED_STATE_TOO_SMALL;
         }
+        if (isHeightMeasuredTooSmall) {
+            resolvedHeightSize |= MEASURED_STATE_TOO_SMALL;
+        }
+        setMeasuredDimension(resolvedWidthSize, resolvedHeightSize);
+        mLastMeasureWidth = resolvedWidthSize;
+        mLastMeasureHeight = resolvedHeightSize;
     }
 
     /**
@@ -2594,7 +2578,7 @@ public class ConstraintLayout extends ViewGroup {
         float resolvedGuidePercent;
 
         boolean isRtl = false;
-        int layoutDirection = View.LAYOUT_DIRECTION_LTR;
+        int layoutDirection = 0;
 
         ConstraintWidget widget = new ConstraintWidget();
 


### PR DESCRIPTION
* ConstraintLayout only supports back to API 14 - no need to refer to ice cream sandwich or honeycomb
* Some used APIs are only available in O or Jelly Bean - need to not refer to Android SDK constants that are only available in those versions. Definitely open to suggestions for better ways to handle these cases.