### PR TITLE
Document why Guideline doesn't call super.draw()

### DIFF
--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/Guideline.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/Guideline.java
@@ -83,6 +83,7 @@ public class Guideline extends View {
      */
     @Override
     public void draw(Canvas canvas) {
+        super.draw(canvas);
     }
 
     /**

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/Guideline.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/Guideline.java
@@ -16,6 +16,7 @@
 
 package androidx.constraintlayout.widget;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.util.AttributeSet;
@@ -79,11 +80,14 @@ public class Guideline extends View {
     }
 
     /**
+     * We are overriding draw and not calling super.draw() here because Helper objects are not displayed on device.
+     *
      * {@hide
      */
+    @SuppressLint("MissingSuperCall")
     @Override
     public void draw(Canvas canvas) {
-        super.draw(canvas);
+
     }
 
     /**


### PR DESCRIPTION
This was based on a lint check, but maybe there is an underlying reason for why `super.draw()` wasn't called in its draw override? If so I'm happy to turn this PR into a lint suppress + some documentation around why this is necessary.