### PR TITLE
Fix horizontal wrap min

### DIFF
--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/widgets/ConstraintWidget.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/widgets/ConstraintWidget.java
@@ -2252,7 +2252,7 @@ public class ConstraintWidget {
                 if (horizontalParentWrapContent && mParent != null) {
                     if (OPTIMIZE_WRAP_ON_RESOLVED) {
                         ConstraintWidgetContainer container = (ConstraintWidgetContainer) mParent;
-                        container.addVerticalWrapMinVariable(mLeft);
+                        container.addHorizontalWrapMinVariable(mLeft);
                         container.addHorizontalWrapMaxVariable(mRight);
                     } else {
                         int wrapStrength = SolverVariable.STRENGTH_EQUALITY;


### PR DESCRIPTION
`ConstraintWidget` was setting vertical wrap min instead of horizontal wrap min, which is probably the root cause for a number of horizontal wrap bugs.

From the code history it looks like this bug was introduced in 2.0.2.

Might be worth cherry picking and cutting a 2.0.5 build?