### PR TITLE
Fix missing constrained width and height

### DIFF
--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintSet.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintSet.java
@@ -1178,6 +1178,8 @@ public class ConstraintSet {
             mapToConstant.append(R.styleable.Layout_android_layout_height, LAYOUT_HEIGHT);
             mapToConstant.append(R.styleable.Layout_layout_constraintWidth, LAYOUT_CONSTRAINT_WIDTH);
             mapToConstant.append(R.styleable.Layout_layout_constraintHeight, LAYOUT_CONSTRAINT_HEIGHT);
+            mapToConstant.append(R.styleable.Layout_layout_constrainedWidth, LAYOUT_CONSTRAINT_WIDTH);
+            mapToConstant.append(R.styleable.Layout_layout_constrainedHeight, LAYOUT_CONSTRAINT_HEIGHT);
             mapToConstant.append(R.styleable.Layout_layout_wrapBehaviorInParent, LAYOUT_WRAP_BEHAVIOR);
 
             mapToConstant.append(R.styleable.Layout_layout_constraintCircle, CIRCLE);


### PR DESCRIPTION
This definitely fixes an issue where if `constrainedWidth` was used in a `<Layout>` tag within a `<Constraint>` it would not be picked up and used - but it would be picked up and used if it were set on the parent `Constraint` itself. I was able to reproduce the bug and check the same motion scene for the fix.

Not sure if `Layout_layout_constraintWidth` and height should just be deleted now since it doesn't seem to do anything in any case I can find.