### PR TITLE
Force remeasure when the layout expands vertically.

### DIFF
--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintLayout.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintLayout.java
@@ -1664,6 +1664,7 @@ public class ConstraintLayout extends ViewGroup {
                 if (newSize >= mLayoutWidget.getHeight()) {
                     mOnMeasureWidthMeasureSpec = widthMeasureSpec;
                     mOnMeasureHeightMeasureSpec = heightMeasureSpec;
+                    resolveSystem(mLayoutWidget, mOptimizationLevel, widthMeasureSpec, heightMeasureSpec);
                     resolveMeasuredDimension(widthMeasureSpec, heightMeasureSpec, mLayoutWidget.getWidth(), mLayoutWidget.getHeight(),
                             mLayoutWidget.isWidthMeasuredTooSmall(), mLayoutWidget.isHeightMeasuredTooSmall());
                     return;


### PR DESCRIPTION
ConstraintLayout seems not to remeasure it's childs properly when it expands vertically, for more details see https://stackoverflow.com/questions/65596552/troubles-with-changing-framelayout-size-with-constraintlayout-child 
I suggest this to be fixed in 2.0.X as well
