### PR TITLE
Fix Guideline accessor to be more Kotlin friendly

### DIFF
--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/Barrier.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/Barrier.java
@@ -216,8 +216,27 @@ public class Barrier extends ConstraintHelper {
         mBarrier.setAllowsGoneWidget(supportGone);
     }
 
+    /**
+     * Find if this barrier supports gone widgets.
+     *
+     * @return true if this barrier supports gone widgets, otherwise false
+     *
+     * @deprecated This method should be called {@code getAllowsGoneWidget} such that {@code allowsGoneWidget}
+     * can be accessed as a property from Kotlin; {@see https://android.github.io/kotlin-guides/interop.html#property-prefixes}.
+     * Use {@link #getAllowsGoneWidget()} instead.
+     */
+    @Deprecated
     public boolean allowsGoneWidget() {
-        return mBarrier.allowsGoneWidget();
+        return mBarrier.getAllowsGoneWidget();
+    }
+
+    /**
+     * Find if this barrier supports gone widgets.
+     *
+     * @return true if this barrier supports gone widgets, otherwise false
+     */
+    public boolean getAllowsGoneWidget() {
+        return mBarrier.getAllowsGoneWidget();
     }
 
     /**

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintSet.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintSet.java
@@ -609,7 +609,7 @@ public class ConstraintSet {
                     constraint.layout.mReferenceIds = ((ConstraintHelper) view).getReferencedIds();
                     if (view instanceof Barrier) {
                         Barrier barrier = (Barrier) view;
-                        constraint.layout.mBarrierAllowsGoneWidgets = barrier.allowsGoneWidget();
+                        constraint.layout.mBarrierAllowsGoneWidgets = barrier.getAllowsGoneWidget();
                         constraint.layout.mBarrierDirection = barrier.getType();
                         constraint.layout.mBarrierMargin = barrier.getMargin();
                     }
@@ -2158,7 +2158,7 @@ public class ConstraintSet {
             }
             if (view instanceof Barrier) {
                 Barrier barrier = ((Barrier) view);
-                constraint.layout.mBarrierAllowsGoneWidgets = barrier.allowsGoneWidget();
+                constraint.layout.mBarrierAllowsGoneWidgets = barrier.getAllowsGoneWidget();
                 constraint.layout.mReferenceIds = barrier.getReferencedIds();
                 constraint.layout.mBarrierDirection = barrier.getType();
                 constraint.layout.mBarrierMargin = barrier.getMargin();

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/widgets/Barrier.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/widgets/Barrier.java
@@ -57,7 +57,24 @@ public class Barrier extends HelperWidget {
 
     public void setAllowsGoneWidget(boolean allowsGoneWidget) { mAllowsGoneWidget = allowsGoneWidget; }
 
+    /**
+     * Find if this barrier supports gone widgets.
+     *
+     * @return true if this barrier supports gone widgets, otherwise false
+     *
+     * @deprecated This method should be called {@code getAllowsGoneWidget} such that {@code allowsGoneWidget}
+     * can be accessed as a property from Kotlin; {@see https://android.github.io/kotlin-guides/interop.html#property-prefixes}.
+     * Use {@link #getAllowsGoneWidget()} instead.
+     */
+    @Deprecated
     public boolean allowsGoneWidget() { return mAllowsGoneWidget; }
+
+    /**
+     * Find if this barrier supports gone widgets.
+     *
+     * @return true if this barrier supports gone widgets, otherwise false
+     */
+    public boolean getAllowsGoneWidget() { return mAllowsGoneWidget; }
 
     public boolean isResolvedHorizontally() {
         return resolved;

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/widgets/analyzer/HelperReferences.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/widgets/analyzer/HelperReferences.java
@@ -51,7 +51,7 @@ class HelperReferences extends WidgetRun {
             start.delegateToWidgetRun = true;
             Barrier barrier = (Barrier) widget;
             int type = barrier.getBarrierType();
-            boolean allowsGoneWidget = barrier.allowsGoneWidget();
+            boolean allowsGoneWidget = barrier.getAllowsGoneWidget();
             switch (type) {
                 case Barrier.LEFT: {
                     start.type = DependencyNode.Type.LEFT;


### PR DESCRIPTION
Fixing lint warning for Kotlin accessor by deprecating the old method and linking to a new one.