### PR TITLE
Fix LambdaLast lint warnings to be more Kotlin friendly

### DIFF
--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/ViewTransitionController.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/ViewTransitionController.java
@@ -232,39 +232,38 @@ public class ViewTransitionController {
         int listen_for_value = viewTransition.getSharedValue();
 
 
-        ConstraintLayout.getSharedValues().addListener((id, value, oldValue) -> {
-                    int current_value = viewTransition.getSharedValueCurrent();
-                    viewTransition.setSharedValueCurrent(value);
-                    if (listen_for_id == id && current_value != value) {
-                        if (isSet) {
-                            if (listen_for_value == value) {
-                                int count = mMotionLayout.getChildCount();
+        ConstraintLayout.getSharedValues().addListener(viewTransition.getSharedValueID(), (id, value, oldValue) -> {
+            int current_value = viewTransition.getSharedValueCurrent();
+            viewTransition.setSharedValueCurrent(value);
+            if (listen_for_id == id && current_value != value) {
+                if (isSet) {
+                    if (listen_for_value == value) {
+                        int count = mMotionLayout.getChildCount();
 
-                                for (int i = 0; i < count; i++) {
-                                    View view = mMotionLayout.getChildAt(i);
-                                    if (viewTransition.matchesView(view)) {
-                                        int currentId = mMotionLayout.getCurrentState();
-                                        ConstraintSet current = mMotionLayout.getConstraintSet(currentId);
-                                        viewTransition.applyTransition(this, mMotionLayout, currentId, current, view);
-                                    }
-                                }
-                            }
-                        } else { // not set
-                            if (listen_for_value != value) {
-                                int count = mMotionLayout.getChildCount();
-                                for (int i = 0; i < count; i++) {
-                                    View view = mMotionLayout.getChildAt(i);
-                                    if (viewTransition.matchesView(view)) {
-                                        int currentId = mMotionLayout.getCurrentState();
-                                        ConstraintSet current = mMotionLayout.getConstraintSet(currentId);
-                                        viewTransition.applyTransition(this, mMotionLayout, currentId, current, view);
-                                    }
-                                }
+                        for (int i = 0; i < count; i++) {
+                            View view = mMotionLayout.getChildAt(i);
+                            if (viewTransition.matchesView(view)) {
+                                int currentId = mMotionLayout.getCurrentState();
+                                ConstraintSet current = mMotionLayout.getConstraintSet(currentId);
+                                viewTransition.applyTransition(this, mMotionLayout, currentId, current, view);
                             }
                         }
                     }
-                }, viewTransition.getSharedValueID()
-        );
+                } else { // not set
+                    if (listen_for_value != value) {
+                        int count = mMotionLayout.getChildCount();
+                        for (int i = 0; i < count; i++) {
+                            View view = mMotionLayout.getChildAt(i);
+                            if (viewTransition.matchesView(view)) {
+                                int currentId = mMotionLayout.getCurrentState();
+                                ConstraintSet current = mMotionLayout.getConstraintSet(currentId);
+                                viewTransition.applyTransition(this, mMotionLayout, currentId, current, view);
+                            }
+                        }
+                    }
+                }
+            }
+        });
     }
 
 }

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ReactiveGuide.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ReactiveGuide.java
@@ -78,7 +78,7 @@ public class ReactiveGuide extends View implements SharedValues.SharedValuesList
         }
         if (mAttributeId != -1) {
             SharedValues sharedValues = ConstraintLayout.getSharedValues();
-            sharedValues.addListener(this, mAttributeId);
+            sharedValues.addListener(mAttributeId, this);
         }
     }
 
@@ -87,11 +87,11 @@ public class ReactiveGuide extends View implements SharedValues.SharedValuesList
     public void setAttributeId(int id) {
         SharedValues sharedValues = ConstraintLayout.getSharedValues();
         if (mAttributeId != -1) {
-            sharedValues.removeListener(this, mAttributeId);
+            sharedValues.removeListener(mAttributeId, this);
         }
         mAttributeId = id;
         if (mAttributeId != -1) {
-            sharedValues.addListener(this, mAttributeId);
+            sharedValues.addListener(mAttributeId, this);
         }
     }
 

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/SharedValues.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/SharedValues.java
@@ -37,7 +37,7 @@ public class SharedValues {
         void onNewValue(int key, int newValue, int oldValue);
     }
 
-    public void addListener(SharedValuesListener listener, int key) {
+    public void addListener(int key, SharedValuesListener listener) {
         HashSet<WeakReference<SharedValuesListener>> listeners = mValuesListeners.get(key);
         if (listeners == null) {
             listeners = new HashSet<>();
@@ -46,7 +46,7 @@ public class SharedValues {
         listeners.add(new WeakReference<>(listener));
     }
 
-    public void removeListener(SharedValuesListener listener, int key) {
+    public void removeListener(int key, SharedValuesListener listener) {
         HashSet<WeakReference<SharedValuesListener>> listeners = mValuesListeners.get(key);
         if (listeners == null) {
             return;
@@ -63,7 +63,7 @@ public class SharedValues {
 
     public void removeListener(SharedValuesListener listener) {
         for (Integer key : mValuesListeners.keySet()) {
-            removeListener(listener, key);
+            removeListener(key, listener);
         }
     }
 


### PR DESCRIPTION
Changed SharedValues API for adding and removing listeners to fix the LambdaLast lint warnings. I don't think this needs @Deprecated annotations on the old methods since these are brand new APIs introduced in `2.1.0-alpha`

Example:
> Functional interface parameters (such as parameter 1, "listener", in `androidx.constraintlayout.widget.SharedValues.removeListener)` should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions