### PR TITLE
Suppress memory allocations in Placeholder draw code

### DIFF
--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/Placeholder.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/Placeholder.java
@@ -115,6 +115,9 @@ public class Placeholder extends View {
   }
 
   /**
+   * Placeholder does not draw anything itself - therefore Paint and Rect allocations
+   * are fine to suppress and ignore.
+   *
    * @hide
    * @param canvas
    */

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/Placeholder.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/Placeholder.java
@@ -16,6 +16,7 @@
 
 package androidx.constraintlayout.widget;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Canvas;
@@ -120,11 +121,14 @@ public class Placeholder extends View {
   public void onDraw(Canvas canvas) {
     if (isInEditMode()) {
       canvas.drawRGB(223, 223, 223);
+
+      @SuppressLint("DrawAllocation")
       Paint paint = new Paint();
       paint.setARGB(255, 210, 210, 210);
       paint.setTextAlign(Paint.Align.CENTER);
       paint.setTypeface(Typeface.create(Typeface.DEFAULT, Typeface.NORMAL));
 
+      @SuppressLint("DrawAllocation")
       Rect r = new Rect();
       canvas.getClipBounds(r);
       paint.setTextSize(r.height());


### PR DESCRIPTION
Placeholder is never meant to draw anything so it is fine to ignore and suppress lint warnings about memory allocations in its `onDraw`