### PR TITLE
Report on all applicable lint checks

### DIFF
--- a/constraintlayout/constraintlayout/build.gradle
+++ b/constraintlayout/constraintlayout/build.gradle
@@ -13,6 +13,7 @@ android {
     }
 
     lintOptions {
+        lintConfig file("lint.xml")
         abortOnError false
     }
 

--- a/constraintlayout/constraintlayout/lint.xml
+++ b/constraintlayout/constraintlayout/lint.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="MinSdkTooLow" severity="warning" />
+
+    <!-- The following must be at the bottom of your file!
+         All lint issues (not listed above) will be treated as errors. -->
+    <issue id="all" severity="error" />
+</lint>


### PR DESCRIPTION
Lint normally hides a lot of things like unknown nullness, etc. It makes it easier to fix these issues by surfacing them in the linter.