### PR TITLE
Fix setEnable method typo

### DIFF
--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/helper/widget/Carousel.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/helper/widget/Carousel.java
@@ -170,7 +170,7 @@ public class Carousel extends MotionHelper {
     private void enableAllTransitions(boolean enable) {
         ArrayList<MotionScene.Transition> transitions = mMotionLayout.getDefinedTransitions();
         for (MotionScene.Transition transition : transitions) {
-            transition.setEnable(enable);
+            transition.setEnabled(enable);
         }
     }
 
@@ -188,7 +188,7 @@ public class Carousel extends MotionHelper {
         if (enable == transition.isEnabled()) {
             return false;
         }
-        transition.setEnable(enable);
+        transition.setEnabled(enable);
         return true;
     }
 

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionLayout.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionLayout.java
@@ -1100,7 +1100,7 @@ public class MotionLayout extends ConstraintLayout implements
     public void enableTransition(int transitionID, boolean enable) {
         MotionScene.Transition t = getTransition(transitionID);
         if (enable) {
-            t.setEnable(true);
+            t.setEnabled(true);
             return;
         } else {
             if (t == mScene.mCurrentTransition) { // disabling current transition
@@ -1112,7 +1112,7 @@ public class MotionLayout extends ConstraintLayout implements
                     }
                 }
             }
-            t.setEnable(false);
+            t.setEnabled(false);
         }
     }
 

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionScene.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionScene.java
@@ -648,7 +648,7 @@ public class MotionScene {
          *
          * @param enable
          */
-        public void setEnable(boolean enable) {
+        public void setEnabled(boolean enable) {
             mDisable = !enable;
         }
 

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionScene.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionScene.java
@@ -643,6 +643,20 @@ public class MotionScene {
         }
 
         /**
+         * Enable or disable the Transition. If a Transition is disabled it is not eligible
+         * for automatically switching to.
+         *
+         * @param enable
+         *
+         * @deprecated This method should be called {@code setEnabled}, so that {@code isEnabled}
+         * can be accessed as a <a href="https://developer.android.com/kotlin/interop#property_prefixes">property from Kotlin</a>.
+         * Use {@link #setEnabled(boolean)} instead.
+         */
+        public void setEnable(boolean enable) {
+            setEnabled(enable);
+        }
+
+        /**
          * enable or disable the Transition. If a Transition is disabled it is not eligible
          * for automatically switching to.
          *

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/ViewTransition.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/ViewTransition.java
@@ -502,7 +502,7 @@ public class ViewTransition {
         return !mDisabled;
     }
 
-    void setEnable(boolean enable) {
+    void setEnabled(boolean enable) {
         this.mDisabled = !enable;
     }
 

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/ViewTransitionController.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/ViewTransitionController.java
@@ -86,7 +86,7 @@ public class ViewTransitionController {
     void enableViewTransition(int id, boolean enable) {
         for (ViewTransition viewTransition : viewTransitions) {
             if (viewTransition.getId() == id) {
-                viewTransition.setEnable(enable);
+                viewTransition.setEnabled(enable);
                 break;
             }
         }


### PR DESCRIPTION
Getter and setter name don't share the same convention - _isEnable**d**_ vs _setEnable_,  therefore in kotlin, you can't call this as property.

Question is whether to keep `setEnable` method with deprecation for backwards compatibility.