### PR TITLE
Revert "Reusable styleables"

### DIFF
--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/helper/widget/Flow.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/helper/widget/Flow.java
@@ -198,7 +198,7 @@ public class Flow extends VirtualLayout {
         super.init(attrs);
         mFlow = new androidx.constraintlayout.core.widgets.Flow();
         if (attrs != null) {
-            TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.Flow);
+            TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.ConstraintLayout_Layout);
             final int N = a.getIndexCount();
             for (int i = 0; i < N; i++) {
                 int attr = a.getIndex(i);

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/helper/widget/Layer.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/helper/widget/Layer.java
@@ -55,7 +55,7 @@ public class Layer extends ConstraintHelper {
         super.init(attrs);
         mUseViewMeasure = false;
         if (attrs != null) {
-            TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.Layer);
+            TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.ConstraintLayout_Layout);
             final int N = a.getIndexCount();
             for (int i = 0; i < N; i++) {
                 int attr = a.getIndex(i);

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/Barrier.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/Barrier.java
@@ -193,7 +193,7 @@ public class Barrier extends ConstraintHelper {
         super.init(attrs);
         mBarrier = new androidx.constraintlayout.core.widgets.Barrier();
         if (attrs != null) {
-            TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.Barrier);
+            TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.ConstraintLayout_Layout);
             final int N = a.getIndexCount();
             for (int i = 0; i < N; i++) {
                 int attr = a.getIndex(i);

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintHelper.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintHelper.java
@@ -102,7 +102,7 @@ public abstract class ConstraintHelper extends View {
      */
     protected void init(AttributeSet attrs) {
         if (attrs != null) {
-            TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.ConstraintHelper);
+            TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.ConstraintLayout_Layout);
             final int N = a.getIndexCount();
             for (int i = 0; i < N; i++) {
                 int attr = a.getIndex(i);

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/Placeholder.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/Placeholder.java
@@ -71,14 +71,14 @@ public class Placeholder extends View {
     super.setVisibility(mEmptyVisibility);
     mContentId = -1;
     if (attrs != null) {
-      TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.Placeholder);
+      TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.ConstraintLayout_placeholder);
       final int N = a.getIndexCount();
       for (int i = 0; i < N; i++) {
         int attr = a.getIndex(i);
-        if (attr == R.styleable.Placeholder_content) {
+        if (attr == R.styleable.ConstraintLayout_placeholder_content) {
           mContentId = a.getResourceId(attr, mContentId);
         } else {
-          if (attr == R.styleable.Placeholder_placeholder_emptyVisibility) {
+          if (attr == R.styleable.ConstraintLayout_placeholder_placeholder_emptyVisibility) {
             mEmptyVisibility = a.getInt(attr, mEmptyVisibility);
           }
         }

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ReactiveGuide.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ReactiveGuide.java
@@ -60,17 +60,17 @@ public class ReactiveGuide extends View implements SharedValues.SharedValuesList
 
     private void init(AttributeSet attrs) {
         if (attrs != null) {
-            TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.ReactiveGuide);
+            TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.ConstraintLayout_ReactiveGuide);
             final int N = a.getIndexCount();
             for (int i = 0; i < N; i++) {
                 int attr = a.getIndex(i);
-                if (attr == R.styleable.ReactiveGuide_reactiveGuide_valueId) {
+                if (attr == R.styleable.ConstraintLayout_ReactiveGuide_reactiveGuide_valueId) {
                     mAttributeId = a.getResourceId(attr, mAttributeId);
-                } else if (attr == R.styleable.ReactiveGuide_reactiveGuide_animateChange) {
+                } else if (attr == R.styleable.ConstraintLayout_ReactiveGuide_reactiveGuide_animateChange) {
                     mAnimateChange = a.getBoolean(attr, mAnimateChange);
-                } else if (attr == R.styleable.ReactiveGuide_reactiveGuide_applyToConstraintSet) {
+                } else if (attr == R.styleable.ConstraintLayout_ReactiveGuide_reactiveGuide_applyToConstraintSet) {
                     mApplyToConstraintSetId = a.getResourceId(attr, mApplyToConstraintSetId);
-                } else if (attr == R.styleable.ReactiveGuide_reactiveGuide_applyToAllConstraintSets) {
+                } else if (attr == R.styleable.ConstraintLayout_ReactiveGuide_reactiveGuide_applyToAllConstraintSets) {
                     mApplyToAllConstraintSets = a.getBoolean(attr, mApplyToAllConstraintSets);
                 }
             }

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/VirtualLayout.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/VirtualLayout.java
@@ -47,7 +47,7 @@ public abstract class VirtualLayout extends ConstraintHelper {
     protected void init(AttributeSet attrs) {
         super.init(attrs);
         if (attrs != null) {
-            TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.VirtualLayout);
+            TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.ConstraintLayout_Layout);
             final int N = a.getIndexCount();
             for (int i = 0; i < N; i++) {
                 int attr = a.getIndex(i);

--- a/constraintlayout/constraintlayout/src/main/res/values/attrs.xml
+++ b/constraintlayout/constraintlayout/src/main/res/values/attrs.xml
@@ -409,12 +409,7 @@
     </attr>
     <attr name="layout_constraintHeight_percent" format="float" />
 
-    <declare-styleable name="Layer" parent="ConstraintLayout_Layout" />
-    <declare-styleable name="Flow" parent="ConstraintLayout_Layout" />
-    <declare-styleable name="Barrier" parent="ConstraintLayout_Layout" />
-    <declare-styleable name="VirtualLayout" parent="ConstraintLayout_Layout" />
-    <declare-styleable name="ConstraintHelper" parent="ConstraintLayout_Layout" />
-    <declare-styleable name="Placeholder" parent="ConstraintLayout_Layout">
+    <declare-styleable name="ConstraintLayout_placeholder">
         <attr name="placeholder_emptyVisibility" />
         <attr name="content" />
     </declare-styleable>
@@ -427,7 +422,7 @@
         <enum name="constraint" value="4" />
     </attr>
 
-    <declare-styleable name="ReactiveGuide" parent="ConstraintLayout_Layout">
+    <declare-styleable name="ConstraintLayout_ReactiveGuide">
         <attr name="reactiveGuide_valueId" format="reference" />
         <attr name="reactiveGuide_animateChange" format="boolean" />
         <attr name="reactiveGuide_applyToAllConstraintSets" format="boolean" />


### PR DESCRIPTION
Reverts androidx/constraintlayout#75

I found that the attrs we didn't rename such as `ConstraintLayout_Layout_constraint_referenced_ids` were completely broken by this change because they were not loaded into the `TypedArray`. Which means that Carousel, Barrier, Guideline, Group, VirtualLayout etc all had regressions.

Reverting for now, will find a better way to address the lint warnings in the future.