### PR TITLE
Fix issue #143

### DIFF
--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintLayout.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintLayout.java
@@ -494,6 +494,7 @@ public class ConstraintLayout extends ViewGroup {
     private static final boolean DEBUG = LinearSystem.FULL_DEBUG;
     private static final boolean DEBUG_DRAW_CONSTRAINTS = false;
     private static final boolean MEASURE = false;
+    private static final boolean OPTIMIZE_HEIGHT_CHANGE = false;
 
     SparseArray<View> mChildrenByIds = new SparseArray<>();
 
@@ -1661,7 +1662,8 @@ public class ConstraintLayout extends ViewGroup {
                         mLayoutWidget.isWidthMeasuredTooSmall(), mLayoutWidget.isHeightMeasuredTooSmall());
                 return;
             }
-            if (mOnMeasureWidthMeasureSpec == widthMeasureSpec
+            if (OPTIMIZE_HEIGHT_CHANGE
+                    && mOnMeasureWidthMeasureSpec == widthMeasureSpec
                     && MeasureSpec.getMode(widthMeasureSpec) == MeasureSpec.EXACTLY
                     && MeasureSpec.getMode(heightMeasureSpec) == MeasureSpec.AT_MOST
                     && MeasureSpec.getMode(mOnMeasureHeightMeasureSpec) == MeasureSpec.AT_MOST) {
@@ -1669,7 +1671,7 @@ public class ConstraintLayout extends ViewGroup {
                 if (DEBUG) {
                     System.out.println("### COMPATIBLE REQ " + newSize + " >= ? " + mLayoutWidget.getHeight());
                 }
-                if (newSize >= mLayoutWidget.getHeight()) {
+                if (newSize >= mLayoutWidget.getHeight() && !mLayoutWidget.isHeightMeasuredTooSmall()) {
                     mOnMeasureWidthMeasureSpec = widthMeasureSpec;
                     mOnMeasureHeightMeasureSpec = heightMeasureSpec;
                     resolveMeasuredDimension(widthMeasureSpec, heightMeasureSpec, mLayoutWidget.getWidth(), mLayoutWidget.getHeight(),

--- a/desktop/ValidationTool/references/check_420_MATCH_MATCH.json
+++ b/desktop/ValidationTool/references/check_420_MATCH_MATCH.json
@@ -1,0 +1,41 @@
+{
+  "duration": "135000",
+  "layout": {
+    "children": [{
+      "children": [{
+        "children": [{
+          "bounds": {
+            "top": "0",
+            "left": "0",
+            "bottom": "169",
+            "right": "649"
+          },
+          "class": "MaterialTextView"
+        }],
+        "bounds": {
+          "top": "0",
+          "left": "0",
+          "bottom": "169",
+          "right": "1080"
+        },
+        "class": "ConstraintLayout"
+      }],
+      "bounds": {
+        "top": "0",
+        "left": "0",
+        "bottom": "400",
+        "right": "1080"
+      },
+      "id": "issue",
+      "class": "FrameLayout"
+    }],
+    "bounds": {
+      "top": "0",
+      "left": "0",
+      "bottom": "1536",
+      "right": "1080"
+    },
+    "id": "root",
+    "class": "ConstraintLayout"
+  }
+}

--- a/desktop/ValidationTool/references/check_420_MATCH_WRAP.json
+++ b/desktop/ValidationTool/references/check_420_MATCH_WRAP.json
@@ -1,0 +1,41 @@
+{
+  "duration": "190500",
+  "layout": {
+    "children": [{
+      "children": [{
+        "children": [{
+          "bounds": {
+            "top": "0",
+            "left": "0",
+            "bottom": "169",
+            "right": "649"
+          },
+          "class": "MaterialTextView"
+        }],
+        "bounds": {
+          "top": "0",
+          "left": "0",
+          "bottom": "169",
+          "right": "1080"
+        },
+        "class": "ConstraintLayout"
+      }],
+      "bounds": {
+        "top": "0",
+        "left": "0",
+        "bottom": "400",
+        "right": "1080"
+      },
+      "id": "issue",
+      "class": "FrameLayout"
+    }],
+    "bounds": {
+      "top": "0",
+      "left": "0",
+      "bottom": "400",
+      "right": "1080"
+    },
+    "id": "root",
+    "class": "ConstraintLayout"
+  }
+}

--- a/desktop/ValidationTool/references/check_420_WRAP_MATCH.json
+++ b/desktop/ValidationTool/references/check_420_WRAP_MATCH.json
@@ -1,0 +1,41 @@
+{
+  "duration": "311500",
+  "layout": {
+    "children": [{
+      "children": [{
+        "children": [{
+          "bounds": {
+            "top": "0",
+            "left": "0",
+            "bottom": "169",
+            "right": "649"
+          },
+          "class": "MaterialTextView"
+        }],
+        "bounds": {
+          "top": "0",
+          "left": "0",
+          "bottom": "169",
+          "right": "649"
+        },
+        "class": "ConstraintLayout"
+      }],
+      "bounds": {
+        "top": "0",
+        "left": "0",
+        "bottom": "400",
+        "right": "649"
+      },
+      "id": "issue",
+      "class": "FrameLayout"
+    }],
+    "bounds": {
+      "top": "0",
+      "left": "0",
+      "bottom": "1536",
+      "right": "649"
+    },
+    "id": "root",
+    "class": "ConstraintLayout"
+  }
+}

--- a/desktop/ValidationTool/references/check_420_WRAP_WRAP.json
+++ b/desktop/ValidationTool/references/check_420_WRAP_WRAP.json
@@ -1,0 +1,41 @@
+{
+  "duration": "192000",
+  "layout": {
+    "children": [{
+      "children": [{
+        "children": [{
+          "bounds": {
+            "top": "0",
+            "left": "0",
+            "bottom": "169",
+            "right": "649"
+          },
+          "class": "MaterialTextView"
+        }],
+        "bounds": {
+          "top": "0",
+          "left": "0",
+          "bottom": "169",
+          "right": "649"
+        },
+        "class": "ConstraintLayout"
+      }],
+      "bounds": {
+        "top": "0",
+        "left": "0",
+        "bottom": "400",
+        "right": "649"
+      },
+      "id": "issue",
+      "class": "FrameLayout"
+    }],
+    "bounds": {
+      "top": "0",
+      "left": "0",
+      "bottom": "400",
+      "right": "649"
+    },
+    "id": "root",
+    "class": "ConstraintLayout"
+  }
+}

--- a/projects/ConstraintLayoutValidation/app/src/main/java/androidx/constraintlayout/validation/MainActivity.java
+++ b/projects/ConstraintLayoutValidation/app/src/main/java/androidx/constraintlayout/validation/MainActivity.java
@@ -71,6 +71,7 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
     Server mServer = new Server(4242);
     HashMap<String, Command> mCommands = new HashMap<>();
     HashMap<String, TestLayout> mTests = new HashMap<>();
+    HashMap<String, Integer> mTestsDelay = new HashMap<>();
 
     TestLayout testLayout_252 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams) -> {
         view.forceLayout();
@@ -229,6 +230,18 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
         return true;
     };
 
+    TestLayout testLayout_420 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams) -> {
+        view.forceLayout();
+        view.measure(widthMeasureSpec, heightMeasureSpec);
+        View viewToResize = findViewById(R.id.issue);
+        viewToResize.postDelayed(() -> {
+            FrameLayout.LayoutParams layoutParamsView = (FrameLayout.LayoutParams) viewToResize.getLayoutParams();
+            layoutParamsView.height = 400;
+            viewToResize.setLayoutParams(layoutParamsView);
+        }, 20);
+        return true;
+    };
+
     Command listCommand = (activity, server, writer, reader, out) -> {
         String[] layouts = getLayouts();
         for (int i = 0; i < layouts.length; i++) {
@@ -254,10 +267,12 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
         String[] result = new String[1];
         int[] measureSpecs = new int[2];
 
-        if (layoutName.equals("check_265")
-                || layoutName.equals("check_335")
-                || layoutName.equals("check_397")) { // only check 265 need UI driving for now, refactor when more
-            int timeout = 1500;
+        int delay = 0;
+        if (mTestsDelay.containsKey(layoutName)) {
+            delay = mTestsDelay.get(layoutName);
+        }
+        if (delay > 0) {
+            int timeout = delay;
             server.runOnUiAndWait(activity, () -> {
                 View view = setupLayout(activity, layoutName, mode, measureSpecs, optimization);
                 FrameLayout.LayoutParams layoutParams = (FrameLayout.LayoutParams) view.getLayoutParams();
@@ -610,6 +625,12 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
         mTests.put("check_398", testLayout_398);
         mTests.put("check_406", testLayout_406);
         mTests.put("check_408", testLayout_408);
+        mTests.put("check_420", testLayout_420);
+
+        mTestsDelay.put("check_265", 1500);
+        mTestsDelay.put("check_335", 1500);
+        mTestsDelay.put("check_397", 1500);
+        mTestsDelay.put("check_420", 500);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             Window window = getWindow();

--- a/projects/ConstraintLayoutValidation/app/src/main/res/layout/check_420.xml
+++ b/projects/ConstraintLayoutValidation/app/src/main/res/layout/check_420.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#0F0"
+    tools:ignore="MissingConstraints">
+
+   <!-- issue #143 -->
+
+   <FrameLayout
+       android:background="#00F"
+       android:id="@+id/issue"
+       android:layout_width="match_parent"
+       android:layout_height="20dp">
+      <androidx.constraintlayout.widget.ConstraintLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content">
+         <TextView android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+             android:textSize="42sp"
+            android:text="Hello World"
+            android:background="#F00"/>
+      </androidx.constraintlayout.widget.ConstraintLayout>
+   </FrameLayout>
+
+</FrameLayout>


### PR DESCRIPTION
We were optimizing when the height of the layout increased more than the actual layout height already computed, by skipping a remeasure. But it turns out that we don't correctly flag the case where the original measure was too small. Disabling the optimization for now as we need to keep track of "too small" not only for the container but also for individual widgets that have been measured.

- added a OPTIMIZE_HEIGHT_CHANGE flag
- added check 420

Closes #143