### PR TITLE
Add default value for radius and angle via XML for CircularFlow

### DIFF
--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/helper/widget/CircularFlow.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/helper/widget/CircularFlow.java
@@ -64,8 +64,8 @@ public class CircularFlow extends VirtualLayout {
     private static final String TAG = "CircularFlow";
     ConstraintLayout mContainer;
     int mViewCenter;
-    private static final int DEFAULT_RADIUS = 0;
-    private static final float DEFAULT_ANGLE = 0F;
+    private static int DEFAULT_RADIUS = 0;
+    private static float DEFAULT_ANGLE = 0F;
     /**
      * @hide
      */
@@ -95,6 +95,17 @@ public class CircularFlow extends VirtualLayout {
      * @hide
      */
     private String mReferenceRadius;
+
+    /**
+     * @hide
+     */
+    private Float mReferenceDefaultAngle;
+
+    /**
+     * @hide
+     */
+    private Integer mReferenceDefaultRadius;
+
 
     public CircularFlow(Context context) {
         super(context);
@@ -135,6 +146,12 @@ public class CircularFlow extends VirtualLayout {
                 } else if (attr == R.styleable.ConstraintLayout_Layout_circularflow_radiusInDP) {
                     mReferenceRadius = a.getString(attr);
                     setRadius(mReferenceRadius);
+                } else if (attr == R.styleable.ConstraintLayout_Layout_circularflow_defaultAngle) {
+                    mReferenceDefaultAngle = a.getFloat(attr, DEFAULT_ANGLE);
+                    setDefaultAngle(mReferenceDefaultAngle);
+                } else if (attr == R.styleable.ConstraintLayout_Layout_circularflow_defaultRadius) {
+                    mReferenceDefaultRadius = a.getInt(attr, DEFAULT_RADIUS);
+                    setDefaultRadius(mReferenceDefaultRadius);
                 }
             }
             a.recycle();
@@ -149,6 +166,12 @@ public class CircularFlow extends VirtualLayout {
         }
         if (mReferenceRadius != null) {
             setRadius(mReferenceRadius);
+        }
+        if (mReferenceDefaultAngle != null) {
+            setDefaultAngle(mReferenceDefaultAngle);
+        }
+        if (mReferenceDefaultRadius != null) {
+            setDefaultRadius(mReferenceDefaultRadius);
         }
         anchorReferences();
     }
@@ -165,13 +188,23 @@ public class CircularFlow extends VirtualLayout {
                 int radius = DEFAULT_RADIUS;
                 float angle = DEFAULT_ANGLE;
 
-                if (i < getRadius().length){
+                if (i < getRadius().length) {
+                    radius = getRadius()[i];
+                } else if (mReferenceDefaultRadius != -1) {
+                    mCountRadius++;
+                    mRadius = getRadius();
+                    mRadius[mCountRadius - 1] = (int) (radius * myContext.getResources().getDisplayMetrics().density);
                     radius = getRadius()[i];
                 } else {
                     Log.e("CircularFlow", "Added radius to view with id: " + mMap.get(view.getId()));
                 }
 
-                if (i < getAngles().length){
+                if (i < getAngles().length) {
+                    angle = getAngles()[i];
+                } else if (mReferenceDefaultAngle != -1) {
+                    mCountAngle++;
+                    mAngles = getAngles();
+                    mAngles[mCountAngle - 1] = angle;
                     angle = getAngles()[i];
                 } else {
                     Log.e("CircularFlow", "Added angle to view with id: " + mMap.get(view.getId()));
@@ -271,6 +304,26 @@ public class CircularFlow extends VirtualLayout {
             mRadius[indexView] = (int) (radius * myContext.getResources().getDisplayMetrics().density);
         }
         anchorReferences();
+    }
+
+    /**
+     * Set default Angle for CircularFlow.
+     *
+     * @param angle
+     * @return
+     */
+    public void setDefaultAngle(float angle) {
+        DEFAULT_ANGLE = angle;
+    }
+
+    /**
+     * Set default Radius for CircularFlow.
+     *
+     * @param radius
+     * @return
+     */
+    public void setDefaultRadius(int radius) {
+        DEFAULT_RADIUS = radius;
     }
 
     @Override

--- a/constraintlayout/constraintlayout/src/main/res/values/attrs.xml
+++ b/constraintlayout/constraintlayout/src/main/res/values/attrs.xml
@@ -261,10 +261,12 @@
     <attr name="flow_lastVerticalBias" format="float" />
     <attr name="flow_lastHorizontalBias" format="float" />
 
-    <!-- set the radius used by CircularFlow with your child views -->
+    <!-- set the radius and angles used by CircularFlow with your child views -->
     <attr name="circularflow_radiusInDP" format="string"/>
     <attr name="circularflow_angles" format="string"/>
     <attr name="circularflow_viewCenter" format="reference"/>
+    <attr name="circularflow_defaultAngle" format="float"/>
+    <attr name="circularflow_defaultRadius" format="integer"/>
 
 
     <!-- TODO allows to use a drawable as horizontal separator between elements -->
@@ -515,6 +517,9 @@
         <attr name="circularflow_radiusInDP"/>
         <attr name="circularflow_angles"/>
         <attr name="circularflow_viewCenter"/>
+        <attr name="circularflow_defaultRadius"/>
+        <attr name="circularflow_defaultAngle"/>
+
 
         <attr name="layout_constraintCircle" />
         <attr name="layout_constraintCircleRadius" />

--- a/projects/MotionLayoutVerification/app/src/main/res/layout/verification_922.xml
+++ b/projects/MotionLayoutVerification/app/src/main/res/layout/verification_922.xml
@@ -254,9 +254,9 @@
         android:id="@+id/circularFlow"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:circularflow_angles="0,0,15,30,45,60,75,90,105,120,135,150,165,180,195,210,225,240,255,270,285,300,315,330,345,360"
-        app:circularflow_radiusInDP="116,140,140,140,140,140,140,140,140,140,140,140,
-        140,140,140,140,140,140,140,140,140,140,140,140,140"
+        app:circularflow_defaultRadius="140"
+        app:circularflow_angles="0,0,15,30,45,60,75,90,105,120,135,150,165,180,195,210,225,240,255,270,285,300,315,330,345"
+        app:circularflow_radiusInDP="116"
         app:circularflow_viewCenter="@id/earth"
         app:constraint_referenced_ids="dial,item1,item2,item3,item4,item5,item6,item7,item8,item9,item10,item11,item12,item13,
          item14,item15,item16,item17,item18,item19,item20,item21, item22, item23,item24" />


### PR DESCRIPTION
# Default radius and angle for CircularFlow via XML

I add two attributes in xml to set the radius or angle for default (default it is 0 for both cases).


`app:circularflow_defaultRadius="140"` This attribute receives an integer value for set default radius.

`app:circularflow_defaultAngle="90"` This attribute receives an float value for set default angles.

# Demo in AS
https://user-images.githubusercontent.com/24611045/109325925-4750a780-7835-11eb-8b02-34da3fe55337.mov


https://user-images.githubusercontent.com/24611045/109326446-f7beab80-7835-11eb-888e-7214781e22a5.mov

