### PR TITLE
Compose: Reset widgets in State::reset

### DIFF
--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayout.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayout.kt
@@ -1122,6 +1122,9 @@ class State(val density: Density) : SolverState() {
 
     override fun reset() {
         // TODO(b/158197001): this should likely be done by the solver
+        mReferences.forEach { ref ->
+            ref.value?.constraintWidget?.reset()
+        }
         mReferences.clear()
         mReferences[PARENT] = mParent
         super.reset()


### PR DESCRIPTION
Disclaimer: I'm not familiar with the internals of ConstraintLayout, and this might not be a good way to solve the issue.

My team encountered a leak ([181589156](https://issuetracker.google.com/issues/181589156)) while working with ConstraintLayout in Compose. `ConstraintAnchor::mDependents` seems to hold old references to other anchors after being connected to a non-parent ref. After recomposition, `mDependents` keeps growing, never letting go of these refs.

Clearing `mReferences` in `State::reset` isn't enough to release these referenced dependents. As far as I can tell, this is because the base class' `mParent` is still reused, and its anchors still hold references to the previously connected anchors in `mDependents`. My fix calls `reset()` on each widget during `State::reset()`. This fixes the leak on my end.