### PR TITLE
Fix LayoutParams generation when dealing with includes

### DIFF
--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintLayout.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintLayout.java
@@ -2847,6 +2847,10 @@ public class ConstraintLayout extends ViewGroup {
             super(WRAP_CONTENT, WRAP_CONTENT);
             TypedArray a = c.obtainStyledAttributes(attrs, R.styleable.ConstraintLayout_Layout);
             final int N = a.getIndexCount();
+            if (N == 0) {
+                // check if it's an include
+                throw new IllegalArgumentException("Invalid LayoutParams supplied to " + this);
+            }
 
             // let's first apply full margins if they are present.
             int margin = a.getDimensionPixelSize(R.styleable.ConstraintLayout_Layout_android_layout_margin, -1);

--- a/desktop/ValidationTool/references/check_422_MATCH_MATCH.json
+++ b/desktop/ValidationTool/references/check_422_MATCH_MATCH.json
@@ -1,0 +1,34 @@
+{
+  "duration": "643895",
+  "layout": {
+    "children": [
+      {
+        "bounds": {
+          "top": "0",
+          "left": "216",
+          "bottom": "0",
+          "right": "216"
+        },
+        "id": "guide_title_start",
+        "class": "Guideline"
+      },
+      {
+        "bounds": {
+          "top": "0",
+          "left": "216",
+          "bottom": "57",
+          "right": "1080"
+        },
+        "id": "title",
+        "class": "MaterialTextView"
+      }
+    ],
+    "bounds": {
+      "top": "0",
+      "left": "0",
+      "bottom": "1536",
+      "right": "1080"
+    },
+    "class": "ConstraintLayout"
+  }
+}

--- a/desktop/ValidationTool/references/check_422_MATCH_WRAP.json
+++ b/desktop/ValidationTool/references/check_422_MATCH_WRAP.json
@@ -1,0 +1,34 @@
+{
+  "duration": "1989293",
+  "layout": {
+    "children": [
+      {
+        "bounds": {
+          "top": "0",
+          "left": "216",
+          "bottom": "0",
+          "right": "216"
+        },
+        "id": "guide_title_start",
+        "class": "Guideline"
+      },
+      {
+        "bounds": {
+          "top": "0",
+          "left": "216",
+          "bottom": "57",
+          "right": "1080"
+        },
+        "id": "title",
+        "class": "MaterialTextView"
+      }
+    ],
+    "bounds": {
+      "top": "0",
+      "left": "0",
+      "bottom": "57",
+      "right": "1080"
+    },
+    "class": "ConstraintLayout"
+  }
+}

--- a/desktop/ValidationTool/references/check_422_WRAP_MATCH.json
+++ b/desktop/ValidationTool/references/check_422_WRAP_MATCH.json
@@ -1,0 +1,34 @@
+{
+  "duration": "3324016",
+  "layout": {
+    "children": [
+      {
+        "bounds": {
+          "top": "0",
+          "left": "216",
+          "bottom": "0",
+          "right": "216"
+        },
+        "id": "guide_title_start",
+        "class": "Guideline"
+      },
+      {
+        "bounds": {
+          "top": "0",
+          "left": "216",
+          "bottom": "253",
+          "right": "216"
+        },
+        "id": "title",
+        "class": "MaterialTextView"
+      }
+    ],
+    "bounds": {
+      "top": "0",
+      "left": "0",
+      "bottom": "1536",
+      "right": "216"
+    },
+    "class": "ConstraintLayout"
+  }
+}

--- a/desktop/ValidationTool/references/check_422_WRAP_WRAP.json
+++ b/desktop/ValidationTool/references/check_422_WRAP_WRAP.json
@@ -1,0 +1,34 @@
+{
+  "duration": "3250317",
+  "layout": {
+    "children": [
+      {
+        "bounds": {
+          "top": "0",
+          "left": "216",
+          "bottom": "0",
+          "right": "216"
+        },
+        "id": "guide_title_start",
+        "class": "Guideline"
+      },
+      {
+        "bounds": {
+          "top": "0",
+          "left": "216",
+          "bottom": "253",
+          "right": "216"
+        },
+        "id": "title",
+        "class": "MaterialTextView"
+      }
+    ],
+    "bounds": {
+      "top": "0",
+      "left": "0",
+      "bottom": "253",
+      "right": "216"
+    },
+    "class": "ConstraintLayout"
+  }
+}

--- a/projects/ConstraintLayoutValidation/app/src/main/res/layout/check_422.xml
+++ b/projects/ConstraintLayoutValidation/app/src/main/res/layout/check_422.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    app:layout_optimizationLevel="none"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+   <!-- b/177338137 -->
+
+   <include layout="@layout/include_guideline_title_start" />
+
+   <TextView
+       android:id="@+id/title"
+       android:layout_width="0dp"
+       android:layout_height="wrap_content"
+       app:layout_constraintTop_toTopOf="parent"
+       app:layout_constraintStart_toStartOf="@+id/guide_title_start"
+       app:layout_constraintEnd_toEndOf="parent"
+       android:text="Title" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/projects/ConstraintLayoutValidation/app/src/main/res/layout/include_guideline_title_start.xml
+++ b/projects/ConstraintLayoutValidation/app/src/main/res/layout/include_guideline_title_start.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.Guideline
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@id/guide_title_start"
+    android:layout_width="0dp"
+    android:layout_height="0dp"
+    app:layout_constraintGuide_begin="72dp"
+    android:orientation="vertical" />


### PR DESCRIPTION
In order for include to work in LayoutInflater, we need to throw an exception if we don't have enough info for LayoutParams. Let's do that if we encounter 0 attributes...