### PR TITLE
add test support for material design timepicker dialog

### DIFF
--- a/desktop/ValidationTool/references/check_428_MATCH_MATCH.json
+++ b/desktop/ValidationTool/references/check_428_MATCH_MATCH.json
@@ -1,0 +1,342 @@
+{
+  "duration": "320310",
+  "layout": {
+    "children": [
+      {
+        "bounds": {
+          "top": "0",
+          "left": "0",
+          "bottom": "0",
+          "right": "0"
+        },
+        "id": "action_mode_bar_stub",
+        "class": "ViewStub"
+      },
+      {
+        "children": [{
+          "children": [
+            {
+              "bounds": {
+                "top": "48",
+                "left": "72",
+                "bottom": "89",
+                "right": "584"
+              },
+              "id": "header_title",
+              "class": "MaterialTextView"
+            },
+            {
+              "bounds": {
+                "top": "1344",
+                "left": "0",
+                "bottom": "1344",
+                "right": "0"
+              },
+              "id": "barrier",
+              "class": "Barrier"
+            },
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "bounds": {
+                        "top": "0",
+                        "left": "0",
+                        "bottom": "240",
+                        "right": "288"
+                      },
+                      "id": "material_hour_tv",
+                      "class": "Chip"
+                    },
+                    {
+                      "bounds": {
+                        "top": "12",
+                        "left": "288",
+                        "bottom": "209",
+                        "right": "360"
+                      },
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "0",
+                        "left": "360",
+                        "bottom": "240",
+                        "right": "648"
+                      },
+                      "id": "material_minute_tv",
+                      "class": "Chip"
+                    }
+                  ],
+                  "bounds": {
+                    "top": "24",
+                    "left": "0",
+                    "bottom": "264",
+                    "right": "648"
+                  },
+                  "id": "material_clock_display",
+                  "class": "LinearLayout"
+                },
+                {
+                  "children": [
+                    {
+                      "bounds": {
+                        "top": "0",
+                        "left": "0",
+                        "bottom": "144",
+                        "right": "156"
+                      },
+                      "id": "material_clock_period_am_button",
+                      "class": "MaterialButton"
+                    },
+                    {
+                      "bounds": {
+                        "top": "141",
+                        "left": "0",
+                        "bottom": "285",
+                        "right": "156"
+                      },
+                      "id": "material_clock_period_pm_button",
+                      "class": "MaterialButton"
+                    }
+                  ],
+                  "bounds": {
+                    "top": "0",
+                    "left": "684",
+                    "bottom": "288",
+                    "right": "840"
+                  },
+                  "id": "material_clock_period_toggle",
+                  "class": "MaterialButtonToggleGroup"
+                },
+                {
+                  "children": [
+                    {
+                      "bounds": {
+                        "top": "384",
+                        "left": "384",
+                        "bottom": "385",
+                        "right": "385"
+                      },
+                      "id": "circle_center",
+                      "class": "View"
+                    },
+                    {
+                      "bounds": {
+                        "top": "0",
+                        "left": "0",
+                        "bottom": "768",
+                        "right": "768"
+                      },
+                      "id": "material_clock_hand",
+                      "class": "ClockHandView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "6",
+                        "left": "312",
+                        "bottom": "163",
+                        "right": "458"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "46",
+                        "left": "474",
+                        "bottom": "203",
+                        "right": "595"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "156",
+                        "left": "584",
+                        "bottom": "313",
+                        "right": "705"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "306",
+                        "left": "624",
+                        "bottom": "463",
+                        "right": "745"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "456",
+                        "left": "584",
+                        "bottom": "613",
+                        "right": "705"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "566",
+                        "left": "474",
+                        "bottom": "723",
+                        "right": "595"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "606",
+                        "left": "324",
+                        "bottom": "763",
+                        "right": "445"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "566",
+                        "left": "174",
+                        "bottom": "723",
+                        "right": "295"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "456",
+                        "left": "64",
+                        "bottom": "613",
+                        "right": "185"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "306",
+                        "left": "24",
+                        "bottom": "463",
+                        "right": "145"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "156",
+                        "left": "52",
+                        "bottom": "313",
+                        "right": "198"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "46",
+                        "left": "161",
+                        "bottom": "203",
+                        "right": "308"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    }
+                  ],
+                  "bounds": {
+                    "top": "372",
+                    "left": "36",
+                    "bottom": "1140",
+                    "right": "804"
+                  },
+                  "id": "material_clock_face",
+                  "class": "ClockFaceView"
+                }
+              ],
+              "bounds": {
+                "top": "132",
+                "left": "120",
+                "bottom": "1272",
+                "right": "960"
+              },
+              "id": "material_timepicker_view",
+              "class": "TimePickerView"
+            },
+            {
+              "bounds": {
+                "top": "0",
+                "left": "0",
+                "bottom": "0",
+                "right": "0"
+              },
+              "id": "material_textinput_timepicker",
+              "class": "ViewStub"
+            },
+            {
+              "bounds": {
+                "top": "1344",
+                "left": "36",
+                "bottom": "1488",
+                "right": "180"
+              },
+              "id": "material_timepicker_mode_button",
+              "class": "MaterialButton"
+            },
+            {
+              "bounds": {
+                "top": "1350",
+                "left": "609",
+                "bottom": "1494",
+                "right": "840"
+              },
+              "id": "material_timepicker_cancel_button",
+              "class": "MaterialButton"
+            },
+            {
+              "bounds": {
+                "top": "1350",
+                "left": "864",
+                "bottom": "1494",
+                "right": "1056"
+              },
+              "id": "material_timepicker_ok_button",
+              "class": "MaterialButton"
+            }
+          ],
+          "bounds": {
+            "top": "0",
+            "left": "0",
+            "bottom": "1536",
+            "right": "1080"
+          },
+          "class": "ConstraintLayout"
+        }],
+        "bounds": {
+          "top": "0",
+          "left": "0",
+          "bottom": "1536",
+          "right": "1080"
+        },
+        "id": "content",
+        "class": "FrameLayout"
+      }
+    ],
+    "bounds": {
+      "top": "0",
+      "left": "0",
+      "bottom": "1536",
+      "right": "1080"
+    },
+    "class": "LinearLayout"
+  }
+}

--- a/desktop/ValidationTool/references/check_428_MATCH_WRAP.json
+++ b/desktop/ValidationTool/references/check_428_MATCH_WRAP.json
@@ -1,0 +1,342 @@
+{
+  "duration": "341379",
+  "layout": {
+    "children": [
+      {
+        "bounds": {
+          "top": "0",
+          "left": "0",
+          "bottom": "0",
+          "right": "0"
+        },
+        "id": "action_mode_bar_stub",
+        "class": "ViewStub"
+      },
+      {
+        "children": [{
+          "children": [
+            {
+              "bounds": {
+                "top": "48",
+                "left": "72",
+                "bottom": "89",
+                "right": "584"
+              },
+              "id": "header_title",
+              "class": "MaterialTextView"
+            },
+            {
+              "bounds": {
+                "top": "1344",
+                "left": "0",
+                "bottom": "1344",
+                "right": "0"
+              },
+              "id": "barrier",
+              "class": "Barrier"
+            },
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "bounds": {
+                        "top": "0",
+                        "left": "0",
+                        "bottom": "240",
+                        "right": "288"
+                      },
+                      "id": "material_hour_tv",
+                      "class": "Chip"
+                    },
+                    {
+                      "bounds": {
+                        "top": "12",
+                        "left": "288",
+                        "bottom": "209",
+                        "right": "360"
+                      },
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "0",
+                        "left": "360",
+                        "bottom": "240",
+                        "right": "648"
+                      },
+                      "id": "material_minute_tv",
+                      "class": "Chip"
+                    }
+                  ],
+                  "bounds": {
+                    "top": "24",
+                    "left": "0",
+                    "bottom": "264",
+                    "right": "648"
+                  },
+                  "id": "material_clock_display",
+                  "class": "LinearLayout"
+                },
+                {
+                  "children": [
+                    {
+                      "bounds": {
+                        "top": "0",
+                        "left": "0",
+                        "bottom": "144",
+                        "right": "156"
+                      },
+                      "id": "material_clock_period_am_button",
+                      "class": "MaterialButton"
+                    },
+                    {
+                      "bounds": {
+                        "top": "141",
+                        "left": "0",
+                        "bottom": "285",
+                        "right": "156"
+                      },
+                      "id": "material_clock_period_pm_button",
+                      "class": "MaterialButton"
+                    }
+                  ],
+                  "bounds": {
+                    "top": "0",
+                    "left": "684",
+                    "bottom": "288",
+                    "right": "840"
+                  },
+                  "id": "material_clock_period_toggle",
+                  "class": "MaterialButtonToggleGroup"
+                },
+                {
+                  "children": [
+                    {
+                      "bounds": {
+                        "top": "384",
+                        "left": "384",
+                        "bottom": "385",
+                        "right": "385"
+                      },
+                      "id": "circle_center",
+                      "class": "View"
+                    },
+                    {
+                      "bounds": {
+                        "top": "0",
+                        "left": "0",
+                        "bottom": "768",
+                        "right": "768"
+                      },
+                      "id": "material_clock_hand",
+                      "class": "ClockHandView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "6",
+                        "left": "312",
+                        "bottom": "163",
+                        "right": "458"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "46",
+                        "left": "474",
+                        "bottom": "203",
+                        "right": "595"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "156",
+                        "left": "584",
+                        "bottom": "313",
+                        "right": "705"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "306",
+                        "left": "624",
+                        "bottom": "463",
+                        "right": "745"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "456",
+                        "left": "584",
+                        "bottom": "613",
+                        "right": "705"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "566",
+                        "left": "474",
+                        "bottom": "723",
+                        "right": "595"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "606",
+                        "left": "324",
+                        "bottom": "763",
+                        "right": "445"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "566",
+                        "left": "174",
+                        "bottom": "723",
+                        "right": "295"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "456",
+                        "left": "64",
+                        "bottom": "613",
+                        "right": "185"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "306",
+                        "left": "24",
+                        "bottom": "463",
+                        "right": "145"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "156",
+                        "left": "52",
+                        "bottom": "313",
+                        "right": "198"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "46",
+                        "left": "161",
+                        "bottom": "203",
+                        "right": "308"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    }
+                  ],
+                  "bounds": {
+                    "top": "372",
+                    "left": "36",
+                    "bottom": "1140",
+                    "right": "804"
+                  },
+                  "id": "material_clock_face",
+                  "class": "ClockFaceView"
+                }
+              ],
+              "bounds": {
+                "top": "132",
+                "left": "120",
+                "bottom": "1272",
+                "right": "960"
+              },
+              "id": "material_timepicker_view",
+              "class": "TimePickerView"
+            },
+            {
+              "bounds": {
+                "top": "0",
+                "left": "0",
+                "bottom": "0",
+                "right": "0"
+              },
+              "id": "material_textinput_timepicker",
+              "class": "ViewStub"
+            },
+            {
+              "bounds": {
+                "top": "1344",
+                "left": "36",
+                "bottom": "1488",
+                "right": "180"
+              },
+              "id": "material_timepicker_mode_button",
+              "class": "MaterialButton"
+            },
+            {
+              "bounds": {
+                "top": "1350",
+                "left": "609",
+                "bottom": "1494",
+                "right": "840"
+              },
+              "id": "material_timepicker_cancel_button",
+              "class": "MaterialButton"
+            },
+            {
+              "bounds": {
+                "top": "1350",
+                "left": "864",
+                "bottom": "1494",
+                "right": "1056"
+              },
+              "id": "material_timepicker_ok_button",
+              "class": "MaterialButton"
+            }
+          ],
+          "bounds": {
+            "top": "0",
+            "left": "0",
+            "bottom": "1500",
+            "right": "1080"
+          },
+          "class": "ConstraintLayout"
+        }],
+        "bounds": {
+          "top": "0",
+          "left": "0",
+          "bottom": "1500",
+          "right": "1080"
+        },
+        "id": "content",
+        "class": "FrameLayout"
+      }
+    ],
+    "bounds": {
+      "top": "0",
+      "left": "0",
+      "bottom": "1500",
+      "right": "1080"
+    },
+    "class": "LinearLayout"
+  }
+}

--- a/desktop/ValidationTool/references/check_428_WRAP_MATCH.json
+++ b/desktop/ValidationTool/references/check_428_WRAP_MATCH.json
@@ -1,0 +1,342 @@
+{
+  "duration": "509048",
+  "layout": {
+    "children": [
+      {
+        "bounds": {
+          "top": "0",
+          "left": "0",
+          "bottom": "0",
+          "right": "0"
+        },
+        "id": "action_mode_bar_stub",
+        "class": "ViewStub"
+      },
+      {
+        "children": [{
+          "children": [
+            {
+              "bounds": {
+                "top": "48",
+                "left": "72",
+                "bottom": "89",
+                "right": "584"
+              },
+              "id": "header_title",
+              "class": "MaterialTextView"
+            },
+            {
+              "bounds": {
+                "top": "1344",
+                "left": "0",
+                "bottom": "1344",
+                "right": "0"
+              },
+              "id": "barrier",
+              "class": "Barrier"
+            },
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "bounds": {
+                        "top": "0",
+                        "left": "0",
+                        "bottom": "240",
+                        "right": "288"
+                      },
+                      "id": "material_hour_tv",
+                      "class": "Chip"
+                    },
+                    {
+                      "bounds": {
+                        "top": "12",
+                        "left": "288",
+                        "bottom": "209",
+                        "right": "360"
+                      },
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "0",
+                        "left": "360",
+                        "bottom": "240",
+                        "right": "648"
+                      },
+                      "id": "material_minute_tv",
+                      "class": "Chip"
+                    }
+                  ],
+                  "bounds": {
+                    "top": "24",
+                    "left": "0",
+                    "bottom": "264",
+                    "right": "648"
+                  },
+                  "id": "material_clock_display",
+                  "class": "LinearLayout"
+                },
+                {
+                  "children": [
+                    {
+                      "bounds": {
+                        "top": "0",
+                        "left": "0",
+                        "bottom": "144",
+                        "right": "156"
+                      },
+                      "id": "material_clock_period_am_button",
+                      "class": "MaterialButton"
+                    },
+                    {
+                      "bounds": {
+                        "top": "141",
+                        "left": "0",
+                        "bottom": "285",
+                        "right": "156"
+                      },
+                      "id": "material_clock_period_pm_button",
+                      "class": "MaterialButton"
+                    }
+                  ],
+                  "bounds": {
+                    "top": "0",
+                    "left": "684",
+                    "bottom": "288",
+                    "right": "840"
+                  },
+                  "id": "material_clock_period_toggle",
+                  "class": "MaterialButtonToggleGroup"
+                },
+                {
+                  "children": [
+                    {
+                      "bounds": {
+                        "top": "384",
+                        "left": "384",
+                        "bottom": "385",
+                        "right": "385"
+                      },
+                      "id": "circle_center",
+                      "class": "View"
+                    },
+                    {
+                      "bounds": {
+                        "top": "0",
+                        "left": "0",
+                        "bottom": "768",
+                        "right": "768"
+                      },
+                      "id": "material_clock_hand",
+                      "class": "ClockHandView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "6",
+                        "left": "312",
+                        "bottom": "163",
+                        "right": "458"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "46",
+                        "left": "474",
+                        "bottom": "203",
+                        "right": "595"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "156",
+                        "left": "584",
+                        "bottom": "313",
+                        "right": "705"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "306",
+                        "left": "624",
+                        "bottom": "463",
+                        "right": "745"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "456",
+                        "left": "584",
+                        "bottom": "613",
+                        "right": "705"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "566",
+                        "left": "474",
+                        "bottom": "723",
+                        "right": "595"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "606",
+                        "left": "324",
+                        "bottom": "763",
+                        "right": "445"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "566",
+                        "left": "174",
+                        "bottom": "723",
+                        "right": "295"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "456",
+                        "left": "64",
+                        "bottom": "613",
+                        "right": "185"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "306",
+                        "left": "24",
+                        "bottom": "463",
+                        "right": "145"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "156",
+                        "left": "52",
+                        "bottom": "313",
+                        "right": "198"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "46",
+                        "left": "161",
+                        "bottom": "203",
+                        "right": "308"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    }
+                  ],
+                  "bounds": {
+                    "top": "372",
+                    "left": "36",
+                    "bottom": "1140",
+                    "right": "804"
+                  },
+                  "id": "material_clock_face",
+                  "class": "ClockFaceView"
+                }
+              ],
+              "bounds": {
+                "top": "132",
+                "left": "72",
+                "bottom": "1272",
+                "right": "912"
+              },
+              "id": "material_timepicker_view",
+              "class": "TimePickerView"
+            },
+            {
+              "bounds": {
+                "top": "0",
+                "left": "0",
+                "bottom": "0",
+                "right": "0"
+              },
+              "id": "material_textinput_timepicker",
+              "class": "ViewStub"
+            },
+            {
+              "bounds": {
+                "top": "1344",
+                "left": "36",
+                "bottom": "1488",
+                "right": "180"
+              },
+              "id": "material_timepicker_mode_button",
+              "class": "MaterialButton"
+            },
+            {
+              "bounds": {
+                "top": "1350",
+                "left": "513",
+                "bottom": "1494",
+                "right": "744"
+              },
+              "id": "material_timepicker_cancel_button",
+              "class": "MaterialButton"
+            },
+            {
+              "bounds": {
+                "top": "1350",
+                "left": "768",
+                "bottom": "1494",
+                "right": "960"
+              },
+              "id": "material_timepicker_ok_button",
+              "class": "MaterialButton"
+            }
+          ],
+          "bounds": {
+            "top": "0",
+            "left": "0",
+            "bottom": "1536",
+            "right": "984"
+          },
+          "class": "ConstraintLayout"
+        }],
+        "bounds": {
+          "top": "0",
+          "left": "0",
+          "bottom": "1536",
+          "right": "984"
+        },
+        "id": "content",
+        "class": "FrameLayout"
+      }
+    ],
+    "bounds": {
+      "top": "0",
+      "left": "0",
+      "bottom": "1536",
+      "right": "984"
+    },
+    "class": "LinearLayout"
+  }
+}

--- a/desktop/ValidationTool/references/check_428_WRAP_WRAP.json
+++ b/desktop/ValidationTool/references/check_428_WRAP_WRAP.json
@@ -1,0 +1,342 @@
+{
+  "duration": "454110",
+  "layout": {
+    "children": [
+      {
+        "bounds": {
+          "top": "0",
+          "left": "0",
+          "bottom": "0",
+          "right": "0"
+        },
+        "id": "action_mode_bar_stub",
+        "class": "ViewStub"
+      },
+      {
+        "children": [{
+          "children": [
+            {
+              "bounds": {
+                "top": "48",
+                "left": "72",
+                "bottom": "89",
+                "right": "584"
+              },
+              "id": "header_title",
+              "class": "MaterialTextView"
+            },
+            {
+              "bounds": {
+                "top": "1344",
+                "left": "0",
+                "bottom": "1344",
+                "right": "0"
+              },
+              "id": "barrier",
+              "class": "Barrier"
+            },
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "bounds": {
+                        "top": "0",
+                        "left": "0",
+                        "bottom": "240",
+                        "right": "288"
+                      },
+                      "id": "material_hour_tv",
+                      "class": "Chip"
+                    },
+                    {
+                      "bounds": {
+                        "top": "12",
+                        "left": "288",
+                        "bottom": "209",
+                        "right": "360"
+                      },
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "0",
+                        "left": "360",
+                        "bottom": "240",
+                        "right": "648"
+                      },
+                      "id": "material_minute_tv",
+                      "class": "Chip"
+                    }
+                  ],
+                  "bounds": {
+                    "top": "24",
+                    "left": "0",
+                    "bottom": "264",
+                    "right": "648"
+                  },
+                  "id": "material_clock_display",
+                  "class": "LinearLayout"
+                },
+                {
+                  "children": [
+                    {
+                      "bounds": {
+                        "top": "0",
+                        "left": "0",
+                        "bottom": "144",
+                        "right": "156"
+                      },
+                      "id": "material_clock_period_am_button",
+                      "class": "MaterialButton"
+                    },
+                    {
+                      "bounds": {
+                        "top": "141",
+                        "left": "0",
+                        "bottom": "285",
+                        "right": "156"
+                      },
+                      "id": "material_clock_period_pm_button",
+                      "class": "MaterialButton"
+                    }
+                  ],
+                  "bounds": {
+                    "top": "0",
+                    "left": "684",
+                    "bottom": "288",
+                    "right": "840"
+                  },
+                  "id": "material_clock_period_toggle",
+                  "class": "MaterialButtonToggleGroup"
+                },
+                {
+                  "children": [
+                    {
+                      "bounds": {
+                        "top": "384",
+                        "left": "384",
+                        "bottom": "385",
+                        "right": "385"
+                      },
+                      "id": "circle_center",
+                      "class": "View"
+                    },
+                    {
+                      "bounds": {
+                        "top": "0",
+                        "left": "0",
+                        "bottom": "768",
+                        "right": "768"
+                      },
+                      "id": "material_clock_hand",
+                      "class": "ClockHandView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "6",
+                        "left": "312",
+                        "bottom": "163",
+                        "right": "458"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "46",
+                        "left": "474",
+                        "bottom": "203",
+                        "right": "595"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "156",
+                        "left": "584",
+                        "bottom": "313",
+                        "right": "705"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "306",
+                        "left": "624",
+                        "bottom": "463",
+                        "right": "745"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "456",
+                        "left": "584",
+                        "bottom": "613",
+                        "right": "705"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "566",
+                        "left": "474",
+                        "bottom": "723",
+                        "right": "595"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "606",
+                        "left": "324",
+                        "bottom": "763",
+                        "right": "445"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "566",
+                        "left": "174",
+                        "bottom": "723",
+                        "right": "295"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "456",
+                        "left": "64",
+                        "bottom": "613",
+                        "right": "185"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "306",
+                        "left": "24",
+                        "bottom": "463",
+                        "right": "145"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "156",
+                        "left": "52",
+                        "bottom": "313",
+                        "right": "198"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    },
+                    {
+                      "bounds": {
+                        "top": "46",
+                        "left": "161",
+                        "bottom": "203",
+                        "right": "308"
+                      },
+                      "id": "NOT_FOUND",
+                      "class": "MaterialTextView"
+                    }
+                  ],
+                  "bounds": {
+                    "top": "372",
+                    "left": "36",
+                    "bottom": "1140",
+                    "right": "804"
+                  },
+                  "id": "material_clock_face",
+                  "class": "ClockFaceView"
+                }
+              ],
+              "bounds": {
+                "top": "132",
+                "left": "72",
+                "bottom": "1272",
+                "right": "912"
+              },
+              "id": "material_timepicker_view",
+              "class": "TimePickerView"
+            },
+            {
+              "bounds": {
+                "top": "0",
+                "left": "0",
+                "bottom": "0",
+                "right": "0"
+              },
+              "id": "material_textinput_timepicker",
+              "class": "ViewStub"
+            },
+            {
+              "bounds": {
+                "top": "1344",
+                "left": "36",
+                "bottom": "1488",
+                "right": "180"
+              },
+              "id": "material_timepicker_mode_button",
+              "class": "MaterialButton"
+            },
+            {
+              "bounds": {
+                "top": "1350",
+                "left": "513",
+                "bottom": "1494",
+                "right": "744"
+              },
+              "id": "material_timepicker_cancel_button",
+              "class": "MaterialButton"
+            },
+            {
+              "bounds": {
+                "top": "1350",
+                "left": "768",
+                "bottom": "1494",
+                "right": "960"
+              },
+              "id": "material_timepicker_ok_button",
+              "class": "MaterialButton"
+            }
+          ],
+          "bounds": {
+            "top": "0",
+            "left": "0",
+            "bottom": "1500",
+            "right": "984"
+          },
+          "class": "ConstraintLayout"
+        }],
+        "bounds": {
+          "top": "0",
+          "left": "0",
+          "bottom": "1500",
+          "right": "984"
+        },
+        "id": "content",
+        "class": "FrameLayout"
+      }
+    ],
+    "bounds": {
+      "top": "0",
+      "left": "0",
+      "bottom": "1500",
+      "right": "984"
+    },
+    "class": "LinearLayout"
+  }
+}

--- a/projects/ConstraintLayoutValidation/app/build.gradle
+++ b/projects/ConstraintLayoutValidation/app/build.gradle
@@ -41,10 +41,11 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.3.1'
     implementation 'androidx.recyclerview:recyclerview:1.2.0-alpha06'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.2.1'
-//    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation project(path: ':constraintlayout')
-    implementation project(path: ':core')
+    implementation 'com.google.android.material:material:1.4.0-alpha01'
+
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.0-alpha3'
+//    implementation project(path: ':constraintlayout')
+//    implementation project(path: ':core')
     implementation 'androidx.gridlayout:gridlayout:1.0.0'
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
     implementation "androidx.cardview:cardview:1.0.0"

--- a/projects/ConstraintLayoutValidation/app/src/main/java/androidx/constraintlayout/validation/MainActivity.java
+++ b/projects/ConstraintLayoutValidation/app/src/main/java/androidx/constraintlayout/validation/MainActivity.java
@@ -15,8 +15,10 @@
  */
 package androidx.constraintlayout.validation;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
+import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.os.Build;
@@ -36,16 +38,19 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.constraintlayout.core.Metrics;
+//import androidx.constraintlayout.core.Metrics;
 import androidx.constraintlayout.widget.ConstraintLayout;
 //import androidx.constraintlayout.core.Metrics;
 import androidx.core.view.ViewCompat;
+import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
+import com.google.android.material.timepicker.MaterialTimePicker;
+import com.google.android.material.timepicker.TimeFormat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -75,7 +80,7 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
     HashMap<String, Integer> mTestsDelay = new HashMap<>();
     HashSet<String> mSkippedTests = new HashSet<>();
 
-    TestLayout testLayout_252 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams) -> {
+    TestLayout testLayout_252 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams, rootView) -> {
         view.forceLayout();
         view.measure(widthMeasureSpec, heightMeasureSpec);
         int left = ((ViewGroup) view.getParent()).getPaddingLeft() + layoutParams.leftMargin;
@@ -89,7 +94,7 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
         return false;
     };
 
-    TestLayout testLayout_253 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams) -> {
+    TestLayout testLayout_253 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams, rootView) -> {
         view.forceLayout();
         view.measure(widthMeasureSpec, heightMeasureSpec);
         int left = ((ViewGroup) view.getParent()).getPaddingLeft() + layoutParams.leftMargin;
@@ -104,7 +109,7 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
         return false;
     };
 
-    TestLayout testLayout_265 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams) -> {
+    TestLayout testLayout_265 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams, rootView) -> {
         view.forceLayout();
         view.measure(widthMeasureSpec, heightMeasureSpec);
         int left = ((ViewGroup) view.getParent()).getPaddingLeft() + layoutParams.leftMargin;
@@ -125,7 +130,7 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
         return true;
     };
 
-    TestLayout testLayout_335 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams) -> {
+    TestLayout testLayout_335 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams, rootView) -> {
         view.forceLayout();
         view.measure(widthMeasureSpec, heightMeasureSpec);
         View view1 = view.findViewById(R.id.button1);
@@ -138,7 +143,7 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
         return true;
     };
 
-    TestLayout testLayout_339 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams) -> {
+    TestLayout testLayout_339 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams, rootView) -> {
         RecyclerView list_view = view.findViewById(R.id.list_view);
         ArrayList<String> xVals = new ArrayList<String>();
         xVals.add("Test String 1");
@@ -152,7 +157,7 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
         return false;
     };
 
-    TestLayout testLayout_376 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams) -> {
+    TestLayout testLayout_376 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams, rootView) -> {
         ConstraintLayout root = findViewById(R.id.root);
         root.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
                 View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION);
@@ -188,7 +193,7 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
         return false;
     };
 
-    TestLayout testLayout_397 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams) -> {
+    TestLayout testLayout_397 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams, rootView) -> {
         Fragment fragment = new CLBugFragment();
         view.postDelayed(() -> {
             getSupportFragmentManager().beginTransaction().add(R.id.host, fragment).commit();
@@ -196,7 +201,7 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
         return true;
     };
 
-    TestLayout testLayout_398 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams) -> {
+    TestLayout testLayout_398 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams, rootView) -> {
         view.forceLayout();
         view.measure(widthMeasureSpec, heightMeasureSpec);
         View button = view.findViewById(R.id.button2);
@@ -207,7 +212,7 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
         return true;
     };
 
-    TestLayout testLayout_406 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams) -> {
+    TestLayout testLayout_406 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams, rootView) -> {
         view.forceLayout();
         view.measure(widthMeasureSpec, heightMeasureSpec);
         //Layer layer = view.findViewById(R.id.layer);
@@ -221,7 +226,7 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
         return true;
     };
 
-    TestLayout testLayout_408 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams) -> {
+    TestLayout testLayout_408 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams, rootView) -> {
         view.forceLayout();
         view.measure(widthMeasureSpec, heightMeasureSpec);
         View viewToRemove = findViewById(R.id.issue);
@@ -232,7 +237,7 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
         return true;
     };
 
-    TestLayout testLayout_420 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams) -> {
+    TestLayout testLayout_420 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams, rootView) -> {
         view.forceLayout();
         view.measure(widthMeasureSpec, heightMeasureSpec);
         View viewToResize = findViewById(R.id.issue);
@@ -241,6 +246,19 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
             layoutParamsView.height = 400;
             viewToResize.setLayoutParams(layoutParamsView);
         }, 20);
+        return true;
+    };
+
+    TestLayout testLayout_428 = (view, mode, widthMeasureSpec, heightMeasureSpec, layoutParams, rootView) -> {
+        MaterialTimePicker picker = new MaterialTimePicker.Builder().setTimeFormat(TimeFormat.CLOCK_12H)
+                .setHour(12)
+                .setMinute(10)
+                .setTitleText("Select Appointment time")
+                .build();
+        picker.show(getSupportFragmentManager(), "time");
+        if (rootView != null) {
+            rootView[0] = picker;//.getDialog().getWindow().getDecorView();
+        }
         return true;
     };
 
@@ -268,6 +286,7 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
 
         String[] result = new String[1];
         int[] measureSpecs = new int[2];
+        Fragment[] fragment = new Fragment[1];
 
         int delay = 0;
         if (mTestsDelay.containsKey(layoutName)) {
@@ -280,7 +299,7 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
                 FrameLayout.LayoutParams layoutParams = (FrameLayout.LayoutParams) view.getLayoutParams();
                 if (mTests.containsKey(layoutName)) {
                     TestLayout testLayout = mTests.get(layoutName);
-                    if (testLayout.apply(view, mode, measureSpecs[0], measureSpecs[1], layoutParams)) {
+                    if (testLayout.apply(view, mode, measureSpecs[0], measureSpecs[1], layoutParams, fragment)) {
                         return;
                     }
                 }
@@ -291,6 +310,13 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
                     Thread.sleep(timeout);
                     server.runOnUiAndWait(activity, () -> {
                         ViewGroup host = activity.findViewById(android.R.id.content);
+                        if (fragment[0] != null && fragment[0] instanceof DialogFragment) {
+                            DialogFragment dialogFragment = (DialogFragment) fragment[0];
+                            View decorView = dialogFragment.getDialog().getWindow().getDecorView();
+                            if (decorView != null && decorView instanceof ViewGroup) {
+                                host = (ViewGroup) decorView;
+                            }
+                        }
                         View view = host.getChildAt(0);
                         FrameLayout.LayoutParams layoutParams = (FrameLayout.LayoutParams) view.getLayoutParams();
                         result[0] = measureLayout(view, layoutParams, measureSpecs[0], measureSpecs[1]);
@@ -306,7 +332,7 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
                 boolean validTest = true;
                 if (mTests.containsKey(layoutName)) {
                     TestLayout testLayout = mTests.get(layoutName);
-                    validTest = testLayout.apply(view, mode, measureSpecs[0], measureSpecs[1], layoutParams);
+                    validTest = testLayout.apply(view, mode, measureSpecs[0], measureSpecs[1], layoutParams, fragment);
                     validTest = true;
                 }
                 if (validTest) {
@@ -386,9 +412,9 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
     private String measureLayout(View view, FrameLayout.LayoutParams layoutParams, int widthMeasureSpec, int heightMeasureSpec) {
         long start = System.nanoTime();
         int iterations = ITERATIONS;
-        androidx.constraintlayout.core.Metrics metrics = new Metrics();
+//        androidx.constraintlayout.core.Metrics metrics = new Metrics();
         if (view instanceof ConstraintLayout) {
-            ((ConstraintLayout) view).fillMetrics(metrics);
+//            ((ConstraintLayout) view).fillMetrics(metrics);
             //metrics.measuresLayoutDuration = 0;
 //            metrics.grouping = 0;
 //            metrics.layouts = 0;
@@ -405,12 +431,12 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
 //        totalGrouping += metrics.grouping;
 //        totalLayouts += metrics.layouts;
 
-        long measuresDuration = metrics.measuresWidgetsDuration / iterations;
-        long layoutDuration = metrics.measuresLayoutDuration / iterations;
-        //System.out.println("total duration = " + duration + " layout " + layoutDuration + " measures " + measuresDuration);
-        //duration = layoutDuration;// - measuresDuration;
-        totalMeasuredWidgets += (metrics.measuredWidgets / iterations);
-        totalMeasuredMatchWidgets += (metrics.measuredMatchWidgets / iterations);
+//        long measuresDuration = metrics.measuresWidgetsDuration / iterations;
+//        long layoutDuration = metrics.measuresLayoutDuration / iterations;
+//        //System.out.println("total duration = " + duration + " layout " + layoutDuration + " measures " + measuresDuration);
+//        //duration = layoutDuration;// - measuresDuration;
+//        totalMeasuredWidgets += (metrics.measuredWidgets / iterations);
+//        totalMeasuredMatchWidgets += (metrics.measuredMatchWidgets / iterations);
 //        System.out.println("Total Measures: " + totalMeasuredWidgets
         //              + " matched " + totalMeasuredMatchWidgets);
 
@@ -562,12 +588,18 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
         return result;
     }
 
+    @SuppressLint("ResourceType")
     private String serialize(View view) {
         String result = "{";
         String name = view.getClass().getSimpleName();
         result += pair("class", name) + ", ";
-        if (view.getId() != View.NO_ID) {
-            String viewId = view.getResources().getResourceName(view.getId());
+        if (view.getId() != View.NO_ID && view.getId() > 1) {
+            String viewId;
+            try {
+                viewId = view.getResources().getResourceName(view.getId());
+            } catch (Resources.NotFoundException e) {
+                viewId = "NOT_FOUND";
+            }
             viewId = stripId(viewId);
             result += pair("id", viewId) + ", ";
         }
@@ -628,11 +660,13 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
         mTests.put("check_406", testLayout_406);
         mTests.put("check_408", testLayout_408);
         mTests.put("check_420", testLayout_420);
+        mTests.put("check_428", testLayout_428);
 
         mTestsDelay.put("check_265", 1500);
         mTestsDelay.put("check_335", 1500);
         mTestsDelay.put("check_397", 1500);
         mTestsDelay.put("check_420", 500);
+        mTestsDelay.put("check_428", 500);
 
         // We skip those for now
         // (depends on moving to LayoutParams instead of MarginLayoutParams)
@@ -718,6 +752,6 @@ public class MainActivity extends AppCompatActivity implements Server.Requests {
     }
 
     interface TestLayout {
-        boolean apply(View view, String mode, int widthMeasureSpec, int heightMeasureSpec, FrameLayout.LayoutParams layoutParams);
+        boolean apply(View view, String mode, int widthMeasureSpec, int heightMeasureSpec, FrameLayout.LayoutParams layoutParams, Fragment[] fragment);
     }
 }

--- a/projects/ConstraintLayoutValidation/app/src/main/res/layout/check_411.xml
+++ b/projects/ConstraintLayoutValidation/app/src/main/res/layout/check_411.xml
@@ -7,45 +7,45 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-   <TextView
-       android:id="@+id/textview1"
-       android:layout_width="wrap_content"
-       android:layout_height="wrap_content"
-       android:background="#FF0"
-       android:textSize="32sp"
-       app:layout_constraintStart_toStartOf="parent"
-       app:layout_constraintBaseline_toTopOf="@+id/view"
-       android:text="This Ppq..." />
+<!--   <TextView-->
+<!--       android:id="@+id/textview1"-->
+<!--       android:layout_width="wrap_content"-->
+<!--       android:layout_height="wrap_content"-->
+<!--       android:background="#FF0"-->
+<!--       android:textSize="32sp"-->
+<!--       app:layout_constraintStart_toStartOf="parent"-->
+<!--       app:layout_constraintBaseline_toTopOf="@+id/view"-->
+<!--       android:text="This Ppq..." />-->
 
-   <TextView
-       android:id="@+id/textview2"
-       android:layout_width="wrap_content"
-       android:layout_height="wrap_content"
-       android:background="#FF0"
-       android:textSize="32sp"
-       app:layout_constraintStart_toStartOf="parent"
-       app:layout_constraintBaseline_toBottomOf="@+id/view"
-       android:text="This Ppq..." />
+<!--   <TextView-->
+<!--       android:id="@+id/textview2"-->
+<!--       android:layout_width="wrap_content"-->
+<!--       android:layout_height="wrap_content"-->
+<!--       android:background="#FF0"-->
+<!--       android:textSize="32sp"-->
+<!--       app:layout_constraintStart_toStartOf="parent"-->
+<!--       app:layout_constraintBaseline_toBottomOf="@+id/view"-->
+<!--       android:text="This Ppq..." />-->
 
-   <TextView
-       android:id="@+id/textview3"
-       android:layout_width="wrap_content"
-       android:layout_height="wrap_content"
-       android:background="#FF0"
-       android:textSize="32sp"
-       app:layout_constraintStart_toStartOf="parent"
-       app:layout_constraintBaseline_toBaselineOf="@+id/view"
-       android:text="This Ppq..." />
+<!--   <TextView-->
+<!--       android:id="@+id/textview3"-->
+<!--       android:layout_width="wrap_content"-->
+<!--       android:layout_height="wrap_content"-->
+<!--       android:background="#FF0"-->
+<!--       android:textSize="32sp"-->
+<!--       app:layout_constraintStart_toStartOf="parent"-->
+<!--       app:layout_constraintBaseline_toBaselineOf="@+id/view"-->
+<!--       android:text="This Ppq..." />-->
 
-   <TextView
-      android:id="@+id/view"
-      android:layout_width="100dp"
-      android:layout_height="100dp"
-      android:background="#F00"
-      android:textSize="32sp"
-      android:text="AbPpq"
-      app:layout_constraintTop_toTopOf="parent"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintEnd_toEndOf="parent"/>
+<!--   <TextView-->
+<!--      android:id="@+id/view"-->
+<!--      android:layout_width="100dp"-->
+<!--      android:layout_height="100dp"-->
+<!--      android:background="#F00"-->
+<!--      android:textSize="32sp"-->
+<!--      android:text="AbPpq"-->
+<!--      app:layout_constraintTop_toTopOf="parent"-->
+<!--      app:layout_constraintBottom_toBottomOf="parent"-->
+<!--      app:layout_constraintEnd_toEndOf="parent"/>-->
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/projects/ConstraintLayoutValidation/app/src/main/res/layout/check_412.xml
+++ b/projects/ConstraintLayoutValidation/app/src/main/res/layout/check_412.xml
@@ -7,70 +7,70 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-   <TextView
-       android:id="@+id/textview1"
-       android:layout_width="wrap_content"
-       android:layout_height="wrap_content"
-       android:background="#FF0"
-       android:textSize="32sp"
-       app:layout_marginBaseline="-20dp"
-       app:layout_constraintStart_toStartOf="parent"
-       app:layout_constraintBaseline_toTopOf="@+id/view"
-       android:text="This Ppq..." />
+<!--   <TextView-->
+<!--       android:id="@+id/textview1"-->
+<!--       android:layout_width="wrap_content"-->
+<!--       android:layout_height="wrap_content"-->
+<!--       android:background="#FF0"-->
+<!--       android:textSize="32sp"-->
+<!--       app:layout_marginBaseline="-20dp"-->
+<!--       app:layout_constraintStart_toStartOf="parent"-->
+<!--       app:layout_constraintBaseline_toTopOf="@+id/view"-->
+<!--       android:text="This Ppq..." />-->
 
-   <TextView
-       android:id="@+id/textview2"
-       android:layout_width="wrap_content"
-       android:layout_height="wrap_content"
-       android:background="#FF0"
-       android:textSize="32sp"
-       app:layout_marginBaseline="20dp"
-       app:layout_constraintStart_toStartOf="parent"
-       app:layout_constraintBaseline_toBottomOf="@+id/view"
-       android:text="This Ppq..." />
+<!--   <TextView-->
+<!--       android:id="@+id/textview2"-->
+<!--       android:layout_width="wrap_content"-->
+<!--       android:layout_height="wrap_content"-->
+<!--       android:background="#FF0"-->
+<!--       android:textSize="32sp"-->
+<!--       app:layout_marginBaseline="20dp"-->
+<!--       app:layout_constraintStart_toStartOf="parent"-->
+<!--       app:layout_constraintBaseline_toBottomOf="@+id/view"-->
+<!--       android:text="This Ppq..." />-->
 
-   <TextView
-       android:id="@+id/textview3"
-       android:layout_width="wrap_content"
-       android:layout_height="wrap_content"
-       android:background="#FF0"
-       android:textSize="32sp"
-       app:layout_marginBaseline="10dp"
-       app:layout_constraintStart_toStartOf="parent"
-       app:layout_constraintBaseline_toBaselineOf="@+id/view"
-       android:text="This Ppq..." />
+<!--   <TextView-->
+<!--       android:id="@+id/textview3"-->
+<!--       android:layout_width="wrap_content"-->
+<!--       android:layout_height="wrap_content"-->
+<!--       android:background="#FF0"-->
+<!--       android:textSize="32sp"-->
+<!--       app:layout_marginBaseline="10dp"-->
+<!--       app:layout_constraintStart_toStartOf="parent"-->
+<!--       app:layout_constraintBaseline_toBaselineOf="@+id/view"-->
+<!--       android:text="This Ppq..." />-->
 
-   <TextView
-      android:id="@+id/view"
-      android:layout_width="100dp"
-      android:layout_height="100dp"
-      android:background="#F00"
-      android:textSize="32sp"
-      android:text="AbPpq"
-      app:layout_marginBaseline="10dp"
-      android:layout_marginEnd="-20dp"
-      app:layout_constraintTop_toTopOf="parent"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintEnd_toEndOf="parent"/>
+<!--   <TextView-->
+<!--      android:id="@+id/view"-->
+<!--      android:layout_width="100dp"-->
+<!--      android:layout_height="100dp"-->
+<!--      android:background="#F00"-->
+<!--      android:textSize="32sp"-->
+<!--      android:text="AbPpq"-->
+<!--      app:layout_marginBaseline="10dp"-->
+<!--      android:layout_marginEnd="-20dp"-->
+<!--      app:layout_constraintTop_toTopOf="parent"-->
+<!--      app:layout_constraintBottom_toBottomOf="parent"-->
+<!--      app:layout_constraintEnd_toEndOf="parent"/>-->
 
-   <Button
-       android:id="@+id/button129"
-       android:layout_width="wrap_content"
-       android:layout_height="wrap_content"
-       android:text="Button"
-       android:layout_marginStart="-20dp"
-       android:layout_marginBottom="-20dp"
-       app:layout_constraintBottom_toBottomOf="parent"
-       app:layout_constraintStart_toStartOf="parent" />
+<!--   <Button-->
+<!--       android:id="@+id/button129"-->
+<!--       android:layout_width="wrap_content"-->
+<!--       android:layout_height="wrap_content"-->
+<!--       android:text="Button"-->
+<!--       android:layout_marginStart="-20dp"-->
+<!--       android:layout_marginBottom="-20dp"-->
+<!--       app:layout_constraintBottom_toBottomOf="parent"-->
+<!--       app:layout_constraintStart_toStartOf="parent" />-->
 
-   <Button
-       android:id="@+id/button130"
-       android:layout_width="wrap_content"
-       android:layout_height="wrap_content"
-       android:text="Button"
-       android:layout_marginStart="-20dp"
-       android:layout_marginTop="-20dp"
-       app:layout_constraintTop_toTopOf="parent"
-       app:layout_constraintStart_toStartOf="parent" />
+<!--   <Button-->
+<!--       android:id="@+id/button130"-->
+<!--       android:layout_width="wrap_content"-->
+<!--       android:layout_height="wrap_content"-->
+<!--       android:text="Button"-->
+<!--       android:layout_marginStart="-20dp"-->
+<!--       android:layout_marginTop="-20dp"-->
+<!--       app:layout_constraintTop_toTopOf="parent"-->
+<!--       app:layout_constraintStart_toStartOf="parent" />-->
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/projects/ConstraintLayoutValidation/app/src/main/res/layout/check_413.xml
+++ b/projects/ConstraintLayoutValidation/app/src/main/res/layout/check_413.xml
@@ -7,60 +7,60 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-   <TextView
-       android:id="@+id/textview1"
-       android:background="#FF0"
-       android:textSize="32sp"
-       app:layout_marginBaseline="-20dp"
-       app:layout_constraintStart_toStartOf="parent"
-       app:layout_constraintBaseline_toTopOf="@+id/view"
-       android:text="This Ppq..." />
+<!--   <TextView-->
+<!--       android:id="@+id/textview1"-->
+<!--       android:background="#FF0"-->
+<!--       android:textSize="32sp"-->
+<!--       app:layout_marginBaseline="-20dp"-->
+<!--       app:layout_constraintStart_toStartOf="parent"-->
+<!--       app:layout_constraintBaseline_toTopOf="@+id/view"-->
+<!--       android:text="This Ppq..." />-->
 
-   <TextView
-       android:id="@+id/textview2"
-       android:background="#FF0"
-       android:textSize="32sp"
-       app:layout_marginBaseline="20dp"
-       app:layout_constraintStart_toStartOf="parent"
-       app:layout_constraintBaseline_toBottomOf="@+id/view"
-       android:text="This Ppq..." />
+<!--   <TextView-->
+<!--       android:id="@+id/textview2"-->
+<!--       android:background="#FF0"-->
+<!--       android:textSize="32sp"-->
+<!--       app:layout_marginBaseline="20dp"-->
+<!--       app:layout_constraintStart_toStartOf="parent"-->
+<!--       app:layout_constraintBaseline_toBottomOf="@+id/view"-->
+<!--       android:text="This Ppq..." />-->
 
-   <TextView
-       android:id="@+id/textview3"
-       android:background="#FF0"
-       android:textSize="32sp"
-       app:layout_marginBaseline="10dp"
-       app:layout_constraintStart_toStartOf="parent"
-       app:layout_constraintBaseline_toBaselineOf="@+id/view"
-       android:text="This Ppq..." />
+<!--   <TextView-->
+<!--       android:id="@+id/textview3"-->
+<!--       android:background="#FF0"-->
+<!--       android:textSize="32sp"-->
+<!--       app:layout_marginBaseline="10dp"-->
+<!--       app:layout_constraintStart_toStartOf="parent"-->
+<!--       app:layout_constraintBaseline_toBaselineOf="@+id/view"-->
+<!--       android:text="This Ppq..." />-->
 
-   <TextView
-      android:id="@+id/view"
-      android:layout_width="100dp"
-      android:layout_height="100dp"
-      android:background="#F00"
-      android:textSize="32sp"
-      android:text="AbPpq"
-      app:layout_marginBaseline="10dp"
-      android:layout_marginEnd="-20dp"
-      app:layout_constraintTop_toTopOf="parent"
-      app:layout_constraintBottom_toBottomOf="parent"
-      app:layout_constraintEnd_toEndOf="parent"/>
+<!--   <TextView-->
+<!--      android:id="@+id/view"-->
+<!--      android:layout_width="100dp"-->
+<!--      android:layout_height="100dp"-->
+<!--      android:background="#F00"-->
+<!--      android:textSize="32sp"-->
+<!--      android:text="AbPpq"-->
+<!--      app:layout_marginBaseline="10dp"-->
+<!--      android:layout_marginEnd="-20dp"-->
+<!--      app:layout_constraintTop_toTopOf="parent"-->
+<!--      app:layout_constraintBottom_toBottomOf="parent"-->
+<!--      app:layout_constraintEnd_toEndOf="parent"/>-->
 
-   <Button
-       android:id="@+id/button129"
-       android:text="Button"
-       android:layout_marginStart="-20dp"
-       android:layout_marginBottom="-20dp"
-       app:layout_constraintBottom_toBottomOf="parent"
-       app:layout_constraintStart_toStartOf="parent" />
+<!--   <Button-->
+<!--       android:id="@+id/button129"-->
+<!--       android:text="Button"-->
+<!--       android:layout_marginStart="-20dp"-->
+<!--       android:layout_marginBottom="-20dp"-->
+<!--       app:layout_constraintBottom_toBottomOf="parent"-->
+<!--       app:layout_constraintStart_toStartOf="parent" />-->
 
-   <Button
-       android:id="@+id/button130"
-       android:text="Button"
-       android:layout_marginStart="-20dp"
-       android:layout_marginTop="-20dp"
-       app:layout_constraintTop_toTopOf="parent"
-       app:layout_constraintStart_toStartOf="parent" />
+<!--   <Button-->
+<!--       android:id="@+id/button130"-->
+<!--       android:text="Button"-->
+<!--       android:layout_marginStart="-20dp"-->
+<!--       android:layout_marginTop="-20dp"-->
+<!--       app:layout_constraintTop_toTopOf="parent"-->
+<!--       app:layout_constraintStart_toStartOf="parent" />-->
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/projects/ConstraintLayoutValidation/app/src/main/res/layout/check_414.xml
+++ b/projects/ConstraintLayoutValidation/app/src/main/res/layout/check_414.xml
@@ -7,17 +7,17 @@
     android:layout_height="match_parent"
     tools:ignore="MissingConstraints">
 
-   <TextView
-       android:id="@+id/textview1"
-       android:background="#FF0"
-       android:gravity="center"
-       android:text="This ABC..."
-       android:textSize="32sp"
-       app:layout_constraintStart_toStartOf="parent"
-       app:layout_constraintEnd_toEndOf="parent"
-       app:layout_constraintBottom_toBottomOf="parent"
-       app:layout_constraintTop_toTopOf="parent"
-       app:layout_constraintWidth="parent=0.8"
-       app:layout_constraintHeight="ratio=1:1"/>
+<!--   <TextView-->
+<!--       android:id="@+id/textview1"-->
+<!--       android:background="#FF0"-->
+<!--       android:gravity="center"-->
+<!--       android:text="This ABC..."-->
+<!--       android:textSize="32sp"-->
+<!--       app:layout_constraintStart_toStartOf="parent"-->
+<!--       app:layout_constraintEnd_toEndOf="parent"-->
+<!--       app:layout_constraintBottom_toBottomOf="parent"-->
+<!--       app:layout_constraintTop_toTopOf="parent"-->
+<!--       app:layout_constraintWidth="parent=0.8"-->
+<!--       app:layout_constraintHeight="ratio=1:1"/>-->
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/projects/ConstraintLayoutValidation/app/src/main/res/layout/check_415.xml
+++ b/projects/ConstraintLayoutValidation/app/src/main/res/layout/check_415.xml
@@ -9,69 +9,69 @@
     tools:ignore="MissingConstraints">
 
 
-   <androidx.constraintlayout.widget.ConstraintLayout
-       android:id="@+id/layout"
-       android:clipChildren="false"
-       android:layout_width="wrap_content"
-       android:layout_height="wrap_content"
-       app:layout_constraintBottom_toBottomOf="parent"
-       app:layout_constraintEnd_toEndOf="parent"
-       app:layout_constraintHorizontal_bias="0.5"
-       app:layout_constraintStart_toStartOf="parent"
-       app:layout_constraintTop_toTopOf="parent">
+<!--   <androidx.constraintlayout.widget.ConstraintLayout-->
+<!--       android:id="@+id/layout"-->
+<!--       android:clipChildren="false"-->
+<!--       android:layout_width="wrap_content"-->
+<!--       android:layout_height="wrap_content"-->
+<!--       app:layout_constraintBottom_toBottomOf="parent"-->
+<!--       app:layout_constraintEnd_toEndOf="parent"-->
+<!--       app:layout_constraintHorizontal_bias="0.5"-->
+<!--       app:layout_constraintStart_toStartOf="parent"-->
+<!--       app:layout_constraintTop_toTopOf="parent">-->
 
-      <TextView
-          android:id="@+id/textview1"
-          android:background="#FF0"
-          android:gravity="center"
-          android:text="This ABC..."
-          android:textSize="32sp"
-          app:layout_constraintBottom_toBottomOf="parent"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toTopOf="parent" />
+<!--      <TextView-->
+<!--          android:id="@+id/textview1"-->
+<!--          android:background="#FF0"-->
+<!--          android:gravity="center"-->
+<!--          android:text="This ABC..."-->
+<!--          android:textSize="32sp"-->
+<!--          app:layout_constraintBottom_toBottomOf="parent"-->
+<!--          app:layout_constraintStart_toStartOf="parent"-->
+<!--          app:layout_constraintTop_toTopOf="parent" />-->
 
-      <TextView
-          android:id="@+id/textview2"
-          android:background="#F00"
-          android:text="*"
-          android:textSize="32sp"
-          app:layout_constraintCircleAngle="45"
-          app:layout_constraintCircle="@id/textview1"
-          app:layout_constraintCircleRadius="80dp"
-          app:layout_wrapBehaviorInParent="skipped" />
+<!--      <TextView-->
+<!--          android:id="@+id/textview2"-->
+<!--          android:background="#F00"-->
+<!--          android:text="*"-->
+<!--          android:textSize="32sp"-->
+<!--          app:layout_constraintCircleAngle="45"-->
+<!--          app:layout_constraintCircle="@id/textview1"-->
+<!--          app:layout_constraintCircleRadius="80dp"-->
+<!--          app:layout_wrapBehaviorInParent="skipped" />-->
 
-   </androidx.constraintlayout.widget.ConstraintLayout>
+<!--   </androidx.constraintlayout.widget.ConstraintLayout>-->
 
-   <androidx.constraintlayout.widget.ConstraintLayout
-       android:id="@+id/layout2"
-       android:layout_width="70dp"
-       android:layout_height="wrap_content"
-       app:layout_constraintBottom_toBottomOf="parent"
-       app:layout_constraintEnd_toEndOf="parent"
-       app:layout_constraintHorizontal_bias="0.5"
-       app:layout_constraintStart_toStartOf="parent"
-       app:layout_constraintTop_toTopOf="parent"
-       app:layout_constraintVertical_bias="0.69">
+<!--   <androidx.constraintlayout.widget.ConstraintLayout-->
+<!--       android:id="@+id/layout2"-->
+<!--       android:layout_width="70dp"-->
+<!--       android:layout_height="wrap_content"-->
+<!--       app:layout_constraintBottom_toBottomOf="parent"-->
+<!--       app:layout_constraintEnd_toEndOf="parent"-->
+<!--       app:layout_constraintHorizontal_bias="0.5"-->
+<!--       app:layout_constraintStart_toStartOf="parent"-->
+<!--       app:layout_constraintTop_toTopOf="parent"-->
+<!--       app:layout_constraintVertical_bias="0.69">-->
 
-      <TextView
-          android:id="@+id/textview1"
-          android:background="#FF0"
-          android:gravity="center"
-          android:text="This ABC..."
-          android:textSize="32sp"
-          app:layout_constraintStart_toStartOf="parent"
-          app:layout_constraintTop_toTopOf="parent" />
+<!--      <TextView-->
+<!--          android:id="@+id/textview1"-->
+<!--          android:background="#FF0"-->
+<!--          android:gravity="center"-->
+<!--          android:text="This ABC..."-->
+<!--          android:textSize="32sp"-->
+<!--          app:layout_constraintStart_toStartOf="parent"-->
+<!--          app:layout_constraintTop_toTopOf="parent" />-->
 
-      <TextView
-          android:id="@+id/textview2"
-          android:background="#F00"
-          android:text="*"
-          android:textSize="32sp"
-          app:layout_constraintCircle="@id/textview1"
-          app:layout_constraintCircleAngle="45"
-          app:layout_constraintCircleRadius="80dp"
-          app:layout_wrapBehaviorInParent="included" />
+<!--      <TextView-->
+<!--          android:id="@+id/textview2"-->
+<!--          android:background="#F00"-->
+<!--          android:text="*"-->
+<!--          android:textSize="32sp"-->
+<!--          app:layout_constraintCircle="@id/textview1"-->
+<!--          app:layout_constraintCircleAngle="45"-->
+<!--          app:layout_constraintCircleRadius="80dp"-->
+<!--          app:layout_wrapBehaviorInParent="included" />-->
 
-   </androidx.constraintlayout.widget.ConstraintLayout>
+<!--   </androidx.constraintlayout.widget.ConstraintLayout>-->
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/projects/ConstraintLayoutValidation/app/src/main/res/layout/check_428.xml
+++ b/projects/ConstraintLayoutValidation/app/src/main/res/layout/check_428.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    android:id="@+id/container"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+   <!-- b/175936038 -->
+   <!-- calling the material picker dialog... -->
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/projects/ConstraintLayoutValidation/build.gradle
+++ b/projects/ConstraintLayoutValidation/build.gradle
@@ -16,6 +16,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenLocal()
         google()
         jcenter()
     }


### PR DESCRIPTION
covers b/175936038

NOTE: don't submit for now, as the material library 1.4 introduces a dependency on the released constraintlayout library. We should instead create a separate validation tool that takes the library directly, in addition to ConstraintLayoutValidation (which is useful to quickly iterate)