### PR TITLE
Check whether we can scroll vertically in the drag direction

### DIFF
--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionLayout.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionLayout.java
@@ -2920,7 +2920,7 @@ public class MotionLayout extends ConstraintLayout implements
 
         if (scene.getMoveWhenScrollAtTop()) {
             // This blocks transition during scrolling
-            if ((mTransitionPosition == 1 || mTransitionPosition == 0) && target.canScrollVertically(-1)) {
+            if ((mTransitionPosition == 1 || mTransitionPosition == 0) && target.canScrollVertically(dy)) {
                 return;
             }
         }


### PR DESCRIPTION
I'm not familiar with the internals and I'm not sure if this has side-effects, I found this problem while testing `MotionLayout`. In all the examples, scrolling up triggers a layout transition, but I noticed it is not possible to trigger a layout transition scrolling down. Looks like`MotionLayout` is always checking if we can scroll upwards, so if we scroll to the bottom of a `RecyclerView` the transition will never be triggered because `target.canScrollVertically(-1)` will always be true.

Here you can see a video with the fix: 
https://github.com/dtvc87/constraintlayout/blob/drag_video/constraintlayout/device-2021-03-10-151947.webm
The red `RecylerView` pulls down the blue one and the blue `RecylerView` pushes up the red one, once all its scroll is consumed.
