### PR TITLE
Calls applyLayoutFeatures() when applying ConstraintSets

### DIFF
--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/helper/widget/Layer.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/helper/widget/Layer.java
@@ -330,4 +330,13 @@ public class Layer extends ConstraintHelper {
             }
         }
     }
+
+    /**
+     * @hide
+     * @param container
+     */
+    @Override
+    protected void applyLayoutFeaturesInConstraintSet(ConstraintLayout container) {
+        applyLayoutFeatures(container);
+    }
 }

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionHelper.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionHelper.java
@@ -36,6 +36,7 @@ public class MotionHelper extends ConstraintHelper implements MotionHelperInterf
         super(context, attrs, defStyleAttr);
         init(attrs);
     }
+
     /**
      * @hide
      */

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintHelper.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintHelper.java
@@ -470,6 +470,11 @@ public abstract class ConstraintHelper extends View {
 
     /**
      * @hide
+     */
+    protected void applyLayoutFeaturesInConstraintSet(ConstraintLayout container) {}
+
+    /**
+     * @hide
      * Allows a helper a chance to update its internal object pre layout or set up connections for the pointed elements
      *
      * @param container

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintSet.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintSet.java
@@ -2315,7 +2315,6 @@ public class ConstraintSet {
         int count = constraintLayout.getChildCount();
         HashSet<Integer> used = new HashSet<Integer>(mConstraints.keySet());
         for (int i = 0; i < count; i++) {
-
             View view = constraintLayout.getChildAt(i);
             int id = view.getId();
             if (!mConstraints.containsKey(id)) {
@@ -2434,6 +2433,13 @@ public class ConstraintSet {
                 ConstraintLayout.LayoutParams param = constraintLayout.generateDefaultLayoutParams();
                 constraint.applyTo(param);
                 constraintLayout.addView(g, param);
+            }
+        }
+        for (int i = 0; i < count; i++) {
+            View view = constraintLayout.getChildAt(i);
+            if (view instanceof ConstraintHelper) {
+                ConstraintHelper constraintHelper = (ConstraintHelper) view;
+                constraintHelper.applyLayoutFeaturesInConstraintSet(constraintLayout);
             }
         }
     }

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/Group.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/Group.java
@@ -79,6 +79,15 @@ public class Group extends ConstraintHelper {
      * @param container
      */
     @Override
+    protected void applyLayoutFeaturesInConstraintSet(ConstraintLayout container) {
+        applyLayoutFeatures(container);
+    }
+    
+    /**
+     * @hide
+     * @param container
+     */
+    @Override
     public void updatePostLayout(ConstraintLayout container) {
         ConstraintLayout.LayoutParams params = (ConstraintLayout.LayoutParams) getLayoutParams();
         params.widget.setWidth(0);

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/VirtualLayout.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/VirtualLayout.java
@@ -116,4 +116,12 @@ public abstract class VirtualLayout extends ConstraintHelper {
         applyLayoutFeatures();
     }
 
+    /**
+     * @hide
+     * @param container
+     */
+    @Override
+    protected void applyLayoutFeaturesInConstraintSet(ConstraintLayout container) {
+        applyLayoutFeatures(container);
+    }
 }


### PR DESCRIPTION
If a ConstraintHelper is calling applyLayoutFeatures() *before* the constraintset apply values, they won't work. Make sure that we call those helpers again after having applied the ConstraintSet.

Fixes  b/160714159