### PR TITLE
Make ConstraintLayout an inline composable

### DIFF
--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/ConstraintLayoutTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/ConstraintLayoutTest.kt
@@ -19,7 +19,9 @@ package androidx.constraintlayout.compose
 import android.content.Context
 import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.boundsInParent
@@ -1118,6 +1120,25 @@ class ConstraintLayoutTest {
         }
         rule.runOnIdle {
             first.value = false
+        }
+        rule.waitForIdle()
+    }
+
+    @Test
+    fun testConstraintLayout_doesNotCrashWhenOnlyContentIsRecomposed() {
+        var smallSize by mutableStateOf(true)
+        rule.setContent {
+            Box {
+                ConstraintLayout {
+                    val (box1, box2) = createRefs()
+                    val barrier = createBottomBarrier(box1)
+                    Box(Modifier.height(if (smallSize) 30.dp else 40.dp).constrainAs(box1) {})
+                    Box(Modifier)
+                }
+            }
+        }
+        rule.runOnIdle {
+            smallSize = false
         }
         rule.waitForIdle()
     }


### PR DESCRIPTION
This is consistent with how most layouts in foundation-layout are
implemented. In addition, it implicitly fixes issue 181717954, which was
happening because the content lambda could previously be recomposed
without recomposing the parent content lambda given to
MultiMeasureLayout - therefore, the scope was not reset() but it was
added the barrier again causing unexpected behavior.

Fixes: 181717954
Test: ConstraintLayoutTest