### PR TITLE
Updates sample to Jetpack WindowManager v1.0.0-alpha05

### DIFF
--- a/projects/FoldableExperiments/app/build.gradle
+++ b/projects/FoldableExperiments/app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation project(path: ':constraintlayout')
     //implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
-    implementation "androidx.window:window:1.0.0-alpha01"
+    implementation 'androidx.window:window:1.0.0-alpha05'
     testImplementation 'junit:junit:4.13'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/projects/FoldableExperiments/app/src/main/java/com/example/experiments/MainActivity.kt
+++ b/projects/FoldableExperiments/app/src/main/java/com/example/experiments/MainActivity.kt
@@ -21,75 +21,52 @@ import android.graphics.Rect
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
-import android.transition.TransitionManager
 import android.view.View
 import androidx.constraintlayout.motion.widget.MotionLayout
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.constraintlayout.widget.Guideline
 import androidx.core.util.Consumer
-import androidx.window.DeviceState
 import androidx.window.DisplayFeature
-import androidx.window.DisplayFeature.TYPE_FOLD
+import androidx.window.FoldingFeature
+import androidx.window.WindowLayoutInfo
 import androidx.window.WindowManager
 import java.util.concurrent.Executor
 
 class MainActivity : Activity() {
     private lateinit var motionLayout: MotionLayout
+    private lateinit var windowManager: WindowManager
+    private val handler = Handler(Looper.getMainLooper())
+    private val mainThreadExecutor = Executor { r: Runnable -> handler.post(r) }
+    private val stateContainer = StateContainer()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val windowManager = WindowManager(this, null)
-
-        val handler = Handler(Looper.getMainLooper())
-        val mainThreadExecutor = Executor { r -> handler.post(r) }
-        val callback = Consumer<DeviceState> { deviceState ->
-            when (deviceState.posture) {
-                DeviceState.POSTURE_UNKNOWN -> {
-                    // Unknown state of the device. May mean that either this device doesn't support different postures or doesn't provide any information about its state at all.
-                }
-                DeviceState.POSTURE_CLOSED -> {
-                    // The foldable device is closed, its primary screen area is not accessible.
-                }
-                DeviceState.POSTURE_HALF_OPENED -> {
-                    // The foldable device's hinge is in an intermediate position between opened and closed state.
-                    var fold = foldPosition(motionLayout, windowManager.windowLayoutInfo.displayFeatures)
-                    ConstraintLayout.getSharedValues().fireNewValue(R.id.fold, fold)
-                }
-                DeviceState.POSTURE_OPENED -> {
-                    // The foldable device is completely open, the screen space that is presented to the user is flat.
-                    ConstraintLayout.getSharedValues().fireNewValue(R.id.fold, 0);
-                }
-                DeviceState.POSTURE_FLIPPED -> {
-                    // The foldable device is flipped with the flexible screen parts or physical screens facing opposite directions.
-                }
-                else -> {
-                    // etc
-                }
-            }
-        }
-        windowManager.registerDeviceStateChangeCallback(
-            mainThreadExecutor,
-            callback
-        )
+        windowManager = WindowManager(this)
 
         setContentView(R.layout.activity_main2)
         motionLayout = findViewById<MotionLayout>(R.id.root)
     }
 
+
+    override fun onStart() {
+        super.onStart()
+        windowManager.registerLayoutChangeCallback(mainThreadExecutor, stateContainer)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        windowManager.unregisterLayoutChangeCallback(stateContainer)
+    }
+
     /**
      * Returns the position of the fold relative to the view
      */
-    fun foldPosition(view: View, displayFeatures: List<DisplayFeature>) : Int {
-        for (feature in displayFeatures) {
-            if (feature.type != TYPE_FOLD) {
-                continue
-            }
-            val splitRect = getFeatureBoundsInWindow(feature, view)
-            splitRect?.let {
-                return view.height.minus(splitRect.top)
-            }
+    fun foldPosition(view: View, foldingFeature: FoldingFeature): Int {
+        val splitRect = getFeatureBoundsInWindow(foldingFeature, view)
+        splitRect?.let {
+            return view.height.minus(splitRect.top)
         }
+
         return 0
     }
 
@@ -136,4 +113,27 @@ class MainActivity : Activity() {
         return featureRectInView
     }
 
+    inner class StateContainer : Consumer<WindowLayoutInfo> {
+        var lastLayoutInfo: WindowLayoutInfo? = null
+
+        override fun accept(newLayoutInfo: WindowLayoutInfo) {
+
+            // Add views that represent display features
+            for (displayFeature in newLayoutInfo.displayFeatures) {
+                val foldFeature = displayFeature as? FoldingFeature
+                if (foldFeature != null) {
+                    if (foldFeature.isSeparating) {
+                        // The foldable device's hinge is in an intermediate position
+                        // between opened and closed state.
+                        val fold = foldPosition(motionLayout, foldFeature)
+                        ConstraintLayout.getSharedValues().fireNewValue(R.id.fold, fold)
+                    } else {
+                        // The foldable device is completely open,
+                        // the screen space that is presented to the user is flat.
+                        ConstraintLayout.getSharedValues().fireNewValue(R.id.fold, 0);
+                    }
+                }
+            }
+        }
+    }
 }

--- a/projects/FoldableExperiments/app/src/main/res/layout/activity_main2.xml
+++ b/projects/FoldableExperiments/app/src/main/res/layout/activity_main2.xml
@@ -25,7 +25,9 @@
         app:reactiveGuide_animateChange="true"
         app:reactiveGuide_applyToAllConstraintSets="true"
         android:orientation="horizontal"
-        app:layout_constraintGuide_end="0dp" />
+        app:layout_constraintGuide_end="0dp"
+        android:layout_height="0dp"
+        android:layout_width="0dp" />
 
     <View
         android:id="@+id/background"

--- a/projects/FoldableExperiments/build.gradle
+++ b/projects/FoldableExperiments/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Updates the sample from alpha01 to alpha05 of the Jetpack WindowManager library removing the deprecated `FoldingFeature.type` and moving away from the direct handling of the posture using the new `isSeparating()` method. 

**Note**
- Some of the postures used are no more available (`POSTURE_CLOSED` and `POSTURE_UNKNOWN`). These may also change in the future as more devices are introduced on the market.
- `DeviceState` has been deprecated.