### PR TITLE
Limit fold animation to tabletop mode.

### DIFF
--- a/projects/FoldableExperiments/app/src/main/java/com/example/experiments/MainActivity.kt
+++ b/projects/FoldableExperiments/app/src/main/java/com/example/experiments/MainActivity.kt
@@ -122,14 +122,13 @@ class MainActivity : Activity() {
             for (displayFeature in newLayoutInfo.displayFeatures) {
                 val foldFeature = displayFeature as? FoldingFeature
                 if (foldFeature != null) {
-                    if (foldFeature.isSeparating) {
-                        // The foldable device's hinge is in an intermediate position
-                        // between opened and closed state.
+                    if (foldFeature.isSeparating &&
+                        foldFeature.orientation == FoldingFeature.ORIENTATION_HORIZONTAL
+                    ) {
+                        // The foldable device is in tabletop mode
                         val fold = foldPosition(motionLayout, foldFeature)
                         ConstraintLayout.getSharedValues().fireNewValue(R.id.fold, fold)
                     } else {
-                        // The foldable device is completely open,
-                        // the screen space that is presented to the user is flat.
                         ConstraintLayout.getSharedValues().fireNewValue(R.id.fold, 0);
                     }
                 }


### PR DESCRIPTION
The current animation is intended to be used when a folding device is in TableTop mode. This update uses the new [`FoldingFeature#getOrientation()`](https://developer.android.com/reference/androidx/window/FoldingFeature#getOrientation()) method to verify if the device is in the correct state.