### PR TITLE
Fix ConstraintLayout.LayoutParams.guideEnd Javadoc.

### DIFF
--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintLayout.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintLayout.java
@@ -2201,7 +2201,7 @@ public class ConstraintLayout extends ViewGroup {
         public int guideBegin = UNSET;
 
         /**
-         * The distance of child (guideline) to the top or left edge of its parent.
+         * The distance of child (guideline) to the bottom or right edge of its parent.
          */
         public int guideEnd = UNSET;
 


### PR DESCRIPTION
The ConstraintLayout.LayoutParams.guideEnd  refers to the distance to the bottom or to the right of the parent, not to the top or the left.