### PR TITLE
bump release numbers for core and compose

### DIFF
--- a/constraintlayout/gradle.properties
+++ b/constraintlayout/gradle.properties
@@ -6,5 +6,5 @@ android.enableD8.desugaring=true
 android.useAndroidX=true
 
 constraintlayout.version=2.1.0-beta02
-core.version=1.0.0-beta02
-compose.version=1.0.0-alpha07
+core.version=1.0.0-beta03
+compose.version=1.0.0-alpha08

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/test.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/test.kt
@@ -989,7 +989,8 @@ public fun ScreenExample13() {
                 bottom: ['parent', 'bottom', 16],
                 custom: {
                   background: '#FFFF00',
-                  textColor: '#000000'
+                  textColor: '#000000',
+                  textSize: 64
                 }
               }
             }
@@ -1001,10 +1002,11 @@ public fun ScreenExample13() {
               a: {
                 end: ['parent', 'end', 16],
                 top: ['parent', 'top', 16],
-                rotationZ: 360,
+                rotationZ: 0,
                 custom: {
                   background: '#0000FF',
-                  textColor: '#FFFFFF'
+                  textColor: '#FFFFFF',
+                  textSize: 12
                 }
               }
             }
@@ -1017,6 +1019,7 @@ public fun ScreenExample13() {
                 .layoutId(properties.value.id())
                 .background(properties.value.color("background"))
                 ,color = properties.value.color("textColor")
+                ,fontSize = properties.value.fontSize("textSize")
             )
         }
 


### PR DESCRIPTION
move to 1.0-alpha8 (compose) and 1.0-beta3 (core)