### PR TITLE
Add a MotionLayout that animates between changing ConstraintSets

### DIFF
--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/MotionComposeExamples.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/MotionComposeExamples.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -19,10 +18,8 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -34,13 +31,8 @@ import java.util.*
 @Composable
 public fun MotionExample1() {
     var animateToEnd by remember { mutableStateOf(false) }
-    val progress by animateFloatAsState(
-        targetValue = if (animateToEnd) 1f else 0f,
-        animationSpec = tween(1000)
-    )
 
-
-    var baseConstraintSetStart = """
+    val baseConstraintSetStart = """
             {
                 Variables: {
                   angle: { start: 0},
@@ -59,7 +51,7 @@ public fun MotionExample1() {
             }
         """
 
-    var baseConstraintSetEnd = """
+    val baseConstraintSetEnd = """
             {
                 Variables: {
                   angle: { from: 0, to: 10 },
@@ -78,17 +70,16 @@ public fun MotionExample1() {
             }
         """
 
-    var cs1 = ConstraintSet(baseConstraintSetStart)
-    var cs2 = ConstraintSet(baseConstraintSetEnd)
+    val cs1 = ConstraintSet(baseConstraintSetStart)
+    val cs2 = ConstraintSet(baseConstraintSetEnd)
 
-
+    val constraints = if (animateToEnd) cs2 else cs1
     Column {
         Button(onClick = { animateToEnd = !animateToEnd }) {
             Text(text = "Run")
         }
         MotionLayout(
-            cs1, cs2,
-            progress = progress,
+            constraints,
             modifier = Modifier
                 .fillMaxSize()
                 .background(Color.White)


### PR DESCRIPTION
This PR adds a MotionLayout that animates between changing ConstraintSets. This provides an easy way to animate layouts that change without having to worry about updating a progress variable yourself.

On recomposition if the constraint set has changed the changes will be animated using the `animationSpec`. On completion of the animation the `finishListener` will fire. This mimics the `animateValueAsState` API that already exists in Compose.

I changed `MotionExample1` to use the new API and to provide an example of it's usage.

Happy to make changes and thanks for your help!