### PR TITLE
Add getter to the MotionScene in MotionLayout

### DIFF
--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionLayout.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionLayout.java
@@ -3868,6 +3868,15 @@ public class MotionLayout extends ConstraintLayout implements
         rebuildScene();
     }
 
+    /**
+     * Get the motion scene of the layout.
+     *
+     * @return the motion scene
+     */
+    public MotionScene getScene() {
+        return mScene;
+    }
+
     private void checkStructure() {
         if (mScene == null) {
             Log.e(TAG, "CHECK: motion scene not set! set \"app:layoutDescription=\"@xml/file\"");


### PR DESCRIPTION
This pull request adds a getter to the MotionScene object in the MotionLayout. This is useful when we want to modify the scene that was loaded from an xml.
Fixes #370 