### PR TITLE
Add MotionPlaceholder

### DIFF
--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/helper/widget/MotionPlaceholder.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/helper/widget/MotionPlaceholder.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.helper.widget;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.util.AttributeSet;
+import android.util.SparseArray;
+import android.view.ViewParent;
+
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer;
+import androidx.constraintlayout.core.widgets.Helper;
+import androidx.constraintlayout.core.widgets.Placeholder;
+import androidx.constraintlayout.widget.VirtualLayout;
+
+public class MotionPlaceholder extends VirtualLayout {
+    private static final String TAG = "MotionPlaceholder";
+    Placeholder mPlaceholder;
+
+    public MotionPlaceholder(Context context) {
+        super(context);
+    }
+
+    public MotionPlaceholder(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public MotionPlaceholder(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    public MotionPlaceholder(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @SuppressLint("WrongCall")
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        onMeasure(mPlaceholder, widthMeasureSpec, heightMeasureSpec);
+    }
+
+    @Override
+    public void onMeasure(androidx.constraintlayout.core.widgets.VirtualLayout layout, int widthMeasureSpec, int heightMeasureSpec) {
+        int widthMode = MeasureSpec.getMode(widthMeasureSpec);
+        int widthSize = MeasureSpec.getSize(widthMeasureSpec);
+        int heightMode = MeasureSpec.getMode(heightMeasureSpec);
+        int heightSize = MeasureSpec.getSize(heightMeasureSpec);
+        if (layout != null) {
+            layout.measure(widthMode, widthSize, heightMode, heightSize);
+            setMeasuredDimension(layout.getMeasuredWidth(), layout.getMeasuredHeight());
+        } else {
+            setMeasuredDimension(0,0);
+        }
+    }
+
+    @Override
+    public void updatePreLayout(ConstraintWidgetContainer container,
+                                Helper helper,
+                                SparseArray<ConstraintWidget> map) {
+        // override to block the ids being replaced
+    }
+
+    @Override
+    protected void init(AttributeSet attrs) {
+        super.init(attrs);
+        mHelperWidget = new Placeholder();
+        validateParams();
+    }
+}

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionLayout.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/widget/MotionLayout.java
@@ -50,6 +50,7 @@ import androidx.constraintlayout.core.widgets.ConstraintWidget;
 import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer;
 import androidx.constraintlayout.core.widgets.Flow;
 import androidx.constraintlayout.core.widgets.Helper;
+import androidx.constraintlayout.core.widgets.Placeholder;
 import androidx.constraintlayout.motion.utils.StopLogic;
 import androidx.constraintlayout.motion.utils.ViewState;
 import androidx.constraintlayout.widget.Barrier;
@@ -2512,6 +2513,8 @@ public class MotionLayout extends ConstraintLayout implements
                     child_d = new androidx.constraintlayout.core.widgets.Guideline();
                 } else if (child_s instanceof Flow) {
                     child_d = new Flow();
+                } else if (child_s instanceof Placeholder) {
+                    child_d = new Placeholder();
                 } else if (child_s instanceof androidx.constraintlayout.core.widgets.Helper) {
                     child_d = new androidx.constraintlayout.core.widgets.HelperWidget();
                 } else {

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintHelper.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintHelper.java
@@ -562,18 +562,23 @@ public abstract class ConstraintHelper extends View {
         // as this makes changing referenced views tricky at runtime
         if (constraint.layout.mReferenceIds != null) {
             setReferencedIds(constraint.layout.mReferenceIds);
-        } else if (constraint.layout.mReferenceIdString != null
-            && constraint.layout.mReferenceIdString.length() > 0) {
-            constraint.layout.mReferenceIds = convertReferenceString(this,
-                    constraint.layout.mReferenceIdString);
+        } else if (constraint.layout.mReferenceIdString != null) {
+            if (constraint.layout.mReferenceIdString.length() > 0) {
+                constraint.layout.mReferenceIds = convertReferenceString(this,
+                        constraint.layout.mReferenceIdString);
+            } else {
+                constraint.layout.mReferenceIds = null;
+            }
         }
-        child.removeAllIds();
-        if (constraint.layout.mReferenceIds != null) {
-            for (int i = 0; i < constraint.layout.mReferenceIds.length; i++) {
-                int id = constraint.layout.mReferenceIds[i];
-                ConstraintWidget widget = mapIdToWidget.get(id);
-                if (widget != null) {
-                    child.add(widget);
+        if (child != null) {
+            child.removeAllIds();
+            if (constraint.layout.mReferenceIds != null) {
+                for (int i = 0; i < constraint.layout.mReferenceIds.length; i++) {
+                    int id = constraint.layout.mReferenceIds[i];
+                    ConstraintWidget widget = mapIdToWidget.get(id);
+                    if (widget != null) {
+                        child.add(widget);
+                    }
                 }
             }
         }

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintSet.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintSet.java
@@ -1101,7 +1101,7 @@ public class ConstraintSet {
             mHelperType = src.mHelperType;
             mConstraintTag = src.mConstraintTag;
 
-            if (src.mReferenceIds != null) {
+            if (src.mReferenceIds != null && src.mReferenceIdString == null) {
                 mReferenceIds = Arrays.copyOf(src.mReferenceIds, src.mReferenceIds.length);
             } else {
                 mReferenceIds = null;
@@ -4798,6 +4798,8 @@ public class ConstraintSet {
                 break;
             case CONSTRAINT_REFERENCED_IDS:
                 c.layout.mReferenceIdString = value;
+                // If a string is defined, clear up the reference ids array
+                c.layout.mReferenceIds = null;
                 break;
             case CONSTRAINT_TAG:
                 c.layout.mConstraintTag = value;
@@ -5218,6 +5220,10 @@ public class ConstraintSet {
                             "Unknown attribute 0x" + Integer.toHexString(attr) + "   " + mapToConstant.get(attr));
             }
         }
+        if (c.layout.mReferenceIdString != null) {
+            // in case the strings are set, make sure to clear up the cached ids
+            c.layout.mReferenceIds = null;
+        };
     }
 
     private int[] convertReferenceString(View view, String referenceIdString) {

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/widgets/ConstraintWidget.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/widgets/ConstraintWidget.java
@@ -2049,7 +2049,8 @@ public class ConstraintWidget {
     /**
      * Reset all the constraints set on this widget
      */
-    public void resetAllConstraints() { resetAnchors();
+    public void resetAllConstraints() {
+        resetAnchors();
         setVerticalBiasPercent(DEFAULT_BIAS);
         setHorizontalBiasPercent(DEFAULT_BIAS);
     }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/widgets/Placeholder.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/widgets/Placeholder.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.widgets;
+
+import static androidx.constraintlayout.core.widgets.analyzer.BasicMeasure.AT_MOST;
+import static androidx.constraintlayout.core.widgets.analyzer.BasicMeasure.EXACTLY;
+import static androidx.constraintlayout.core.widgets.analyzer.BasicMeasure.UNSPECIFIED;
+
+import androidx.constraintlayout.core.LinearSystem;
+
+/**
+ * Simple VirtualLayout that center the first referenced widget onto itself.
+ */
+public class Placeholder extends VirtualLayout {
+
+    public void measure(int widthMode, int widthSize, int heightMode, int heightSize) {
+        int width = 0;
+        int height = 0;
+        int paddingLeft = getPaddingLeft();
+        int paddingRight = getPaddingRight();
+        int paddingTop = getPaddingTop();
+        int paddingBottom = getPaddingBottom();
+
+        width += paddingLeft + paddingRight;
+        height += paddingTop + paddingBottom;
+
+        if (mWidgetsCount > 0) {
+            // grab the first referenced widget size in case we are ourselves in wrap_content
+            width += mWidgets[0].getWidth();
+            height += mWidgets[0].getHeight();
+        }
+        width = Math.max(getMinWidth(), width);
+        height = Math.max(getMinHeight(), height);
+
+        int measuredWidth = 0;
+        int measuredHeight = 0;
+
+        if (widthMode == EXACTLY) {
+            measuredWidth = widthSize;
+        } else if (widthMode == AT_MOST) {
+            measuredWidth = Math.min(width, widthSize);
+        } else if (widthMode == UNSPECIFIED) {
+            measuredWidth = width;
+        }
+
+        if (heightMode == EXACTLY) {
+            measuredHeight = heightSize;
+        } else if (heightMode == AT_MOST) {
+            measuredHeight = Math.min(height, heightSize);
+        } else if (heightMode == UNSPECIFIED) {
+            measuredHeight = height;
+        }
+
+        setMeasure(measuredWidth, measuredHeight);
+        setWidth(measuredWidth);
+        setHeight(measuredHeight);
+        needsCallbackFromSolver(mWidgetsCount > 0);
+    }
+
+    @Override
+    public void addToSolver(LinearSystem system, boolean optimize) {
+        super.addToSolver(system, optimize);
+
+        if (mWidgetsCount > 0) {
+            ConstraintWidget widget = mWidgets[0];
+            widget.resetAllConstraints();
+            widget.connect(ConstraintAnchor.Type.LEFT, this, ConstraintAnchor.Type.LEFT);
+            widget.connect(ConstraintAnchor.Type.RIGHT, this, ConstraintAnchor.Type.RIGHT);
+            widget.connect(ConstraintAnchor.Type.TOP, this, ConstraintAnchor.Type.TOP);
+            widget.connect(ConstraintAnchor.Type.BOTTOM, this, ConstraintAnchor.Type.BOTTOM);
+        }
+    }
+}

--- a/projects/MotionLayoutVerification/app/src/main/java/android/support/constraint/app/VerificationActivity.java
+++ b/projects/MotionLayoutVerification/app/src/main/java/android/support/constraint/app/VerificationActivity.java
@@ -107,7 +107,7 @@ public class VerificationActivity extends AppCompatActivity implements View.OnCl
     private static boolean REVERSE = false;
 
 
-    private static final String RUN_FIRST = (true) ? "verification_360" : "bug_005";
+    private static final String RUN_FIRST = (true) ? "verification_131" : "bug_005";
     private final String LAYOUTS_MATCHES = "v.*_.*";
 
     private static String SHOW_FIRST = "";

--- a/projects/MotionLayoutVerification/app/src/main/res/layout/verification_130.xml
+++ b/projects/MotionLayoutVerification/app/src/main/res/layout/verification_130.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.motion.widget.MotionLayout  xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root"
+    android:background="#CFC"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:motionDebug="SHOW_ALL"
+    app:layoutDescription="@xml/verification_scene_130"
+>
+
+    <androidx.constraintlayout.helper.widget.MotionPlaceholder
+        android:id="@+id/p0"
+        android:layout_width="64dp"
+        android:layout_height="64dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="parent"/>
+
+    <androidx.constraintlayout.helper.widget.MotionPlaceholder
+        android:id="@+id/p1"
+        android:layout_width="128dp"
+        android:layout_height="128dp"
+        android:background="#777"
+        android:visibility="invisible"
+        app:constraint_referenced_ids="view_a"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        />
+
+    <androidx.constraintlayout.helper.widget.MotionPlaceholder
+        android:id="@+id/p2"
+        android:layout_width="128dp"
+        android:layout_height="256dp"
+        android:background="#777"
+        android:visibility="invisible"
+        app:constraint_referenced_ids="view_b"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@id/p1"
+        app:layout_constraintEnd_toStartOf="@id/p3"
+        />
+
+
+    <androidx.constraintlayout.helper.widget.MotionPlaceholder
+        android:id="@+id/p3"
+        android:layout_width="128dp"
+        android:layout_height="128dp"
+        android:background="#777"
+        android:visibility="invisible"
+        app:constraint_referenced_ids="view_c"
+
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <androidx.constraintlayout.helper.widget.MotionPlaceholder
+        android:id="@+id/p4"
+        android:layout_width="64dp"
+        android:layout_height="64dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="parent"/>
+
+    <TextView
+        android:id="@+id/info"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="placeholder test 5"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        />
+
+    <TextView
+        android:id="@+id/view_a"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#F44336"
+        android:gravity="center"
+        android:text="A"
+        android:textSize="42sp"
+        tools:layout_editor_absoluteX="156dp"
+        tools:layout_editor_absoluteY="34dp" />
+
+    <TextView
+        android:id="@+id/view_b"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#00BCD4"
+        android:gravity="center"
+        android:text="B"
+        android:textSize="42sp"
+        android:visibility="visible"
+        tools:layout_editor_absoluteX="156dp"
+        tools:layout_editor_absoluteY="182dp" />
+
+    <TextView
+        android:id="@+id/view_c"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#8BC34A"
+        android:gravity="center"
+        android:text="C"
+        android:textSize="42sp"
+        tools:layout_editor_absoluteX="156dp"
+        tools:layout_editor_absoluteY="331dp" />
+</androidx.constraintlayout.motion.widget.MotionLayout >

--- a/projects/MotionLayoutVerification/app/src/main/res/layout/verification_130cl.xml
+++ b/projects/MotionLayoutVerification/app/src/main/res/layout/verification_130cl.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout  xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root"
+    android:background="#CFC"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:motionDebug="SHOW_ALL"
+    app:layoutDescription="@xml/verification_scene_130"
+>
+
+    <androidx.constraintlayout.helper.widget.MotionPlaceholder
+        android:id="@+id/p1"
+        android:layout_width="match_parent"
+        android:layout_height="128dp"
+        android:layout_marginTop="20dp"
+        android:background="#777"
+        app:constraint_referenced_ids="view_a"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.constraintlayout.helper.widget.MotionPlaceholder
+        android:id="@+id/p2"
+        android:layout_width="match_parent"
+        android:layout_height="128dp"
+        android:layout_marginTop="20dp"
+        android:background="#777"
+        app:layout_constraintTop_toBottomOf="@id/p1"
+        app:constraint_referenced_ids="view_b"
+        />
+
+    <androidx.constraintlayout.helper.widget.MotionPlaceholder
+        android:id="@+id/p3"
+        android:layout_width="match_parent"
+        android:layout_height="128dp"
+        android:layout_marginTop="20dp"
+        android:background="#777"
+        app:layout_constraintTop_toBottomOf="@id/p2"
+        app:constraint_referenced_ids="view_c"
+        />
+
+    <TextView
+        android:id="@+id/view_a"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#F44336"
+        android:gravity="center"
+        android:text="a"
+        />
+
+    <TextView
+        android:id="@+id/view_b"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#00BCD4"
+        android:gravity="center"
+        android:text="b"
+        android:visibility="visible"
+        />
+
+
+    <TextView
+        android:id="@+id/view_c"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#8BC34A"
+        android:gravity="center"
+        android:text="c"
+        />
+
+    <TextView
+        android:id="@+id/info"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="placeholder test 5"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/projects/MotionLayoutVerification/app/src/main/res/layout/verification_131.xml
+++ b/projects/MotionLayoutVerification/app/src/main/res/layout/verification_131.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.motion.widget.MotionLayout  xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root"
+    android:background="#CFC"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:motionDebug="SHOW_ALL"
+    app:layoutDescription="@xml/verification_scene_131"
+>
+
+    <androidx.constraintlayout.helper.widget.MotionPlaceholder
+        android:id="@+id/p0"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="parent"/>
+
+    <androidx.constraintlayout.helper.widget.MotionPlaceholder
+        android:id="@+id/p1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="#777"
+        android:visibility="invisible"
+        app:constraint_referenced_ids="view_a"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        />
+
+    <androidx.constraintlayout.helper.widget.MotionPlaceholder
+        android:id="@+id/p2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="#777"
+        android:visibility="invisible"
+        app:constraint_referenced_ids="view_b"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@id/p1"
+        app:layout_constraintEnd_toStartOf="@id/p3"
+        />
+
+
+    <androidx.constraintlayout.helper.widget.MotionPlaceholder
+        android:id="@+id/p3"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="#777"
+        android:visibility="invisible"
+        app:constraint_referenced_ids="view_c"
+
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <androidx.constraintlayout.helper.widget.MotionPlaceholder
+        android:id="@+id/p4"
+        android:layout_width="128dp"
+        android:layout_height="128dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="parent"/>
+
+    <TextView
+        android:id="@+id/info"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="placeholder test 5"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        />
+
+    <TextView
+        android:id="@+id/view_a"
+        android:layout_width="128dp"
+        android:layout_height="128dp"
+        android:background="#F44336"
+        android:gravity="center"
+        android:text="A"
+        android:textSize="42sp"
+        tools:layout_editor_absoluteX="156dp"
+        tools:layout_editor_absoluteY="34dp" />
+
+    <TextView
+        android:id="@+id/view_b"
+        android:layout_width="128dp"
+        android:layout_height="128dp"
+        android:background="#00BCD4"
+        android:gravity="center"
+        android:text="B"
+        android:textSize="42sp"
+        android:visibility="visible"
+        tools:layout_editor_absoluteX="156dp"
+        tools:layout_editor_absoluteY="182dp" />
+
+    <TextView
+        android:id="@+id/view_c"
+        android:layout_width="128dp"
+        android:layout_height="128dp"
+        android:background="#8BC34A"
+        android:gravity="center"
+        android:text="C"
+        android:textSize="42sp"
+        tools:layout_editor_absoluteX="156dp"
+        tools:layout_editor_absoluteY="331dp" />
+</androidx.constraintlayout.motion.widget.MotionLayout >

--- a/projects/MotionLayoutVerification/app/src/main/res/xml/verification_scene_130.xml
+++ b/projects/MotionLayoutVerification/app/src/main/res/xml/verification_scene_130.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MotionScene xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:motion="http://schemas.android.com/apk/res-auto">
+
+
+        <Transition
+            android:id="@+id/previous"
+            motion:constraintSetStart="@id/start"
+            motion:constraintSetEnd="@+id/previous"
+            motion:duration="1000">
+            <OnSwipe motion:dragDirection="dragRight"/>
+        </Transition>
+
+    <Transition
+        android:id="@+id/forward"
+        motion:constraintSetStart="@id/start"
+        motion:constraintSetEnd="@+id/next"
+        motion:duration="1000">
+        <OnSwipe motion:dragDirection="dragLeft"/>
+    </Transition>
+
+
+    <ConstraintSet android:id="@+id/previous" >
+        <ConstraintOverride android:id="@id/p0"  motion:constraint_referenced_ids=""/>
+        <ConstraintOverride android:id="@id/p1"  motion:constraint_referenced_ids=""/>
+        <ConstraintOverride android:id="@id/p2"  motion:constraint_referenced_ids="view_a"/>
+        <ConstraintOverride android:id="@id/p3"  motion:constraint_referenced_ids="view_b" />
+        <ConstraintOverride android:id="@id/p4"  motion:constraint_referenced_ids="view_c" />
+    </ConstraintSet>
+
+        <ConstraintSet android:id="@+id/start">
+            <ConstraintOverride android:id="@id/p0"  motion:constraint_referenced_ids=""/>
+            <ConstraintOverride android:id="@id/p1"  motion:constraint_referenced_ids="view_a"/>
+            <ConstraintOverride android:id="@id/p2"  motion:constraint_referenced_ids="view_b"/>
+            <ConstraintOverride android:id="@id/p3"  motion:constraint_referenced_ids="view_c" />
+            <ConstraintOverride android:id="@id/p4"  motion:constraint_referenced_ids="" />
+        </ConstraintSet>
+
+        <ConstraintSet android:id="@+id/next">
+            <ConstraintOverride android:id="@id/p0"  motion:constraint_referenced_ids="view_a"/>
+            <ConstraintOverride android:id="@id/p1"  motion:constraint_referenced_ids="view_b"/>
+            <ConstraintOverride android:id="@id/p2"  motion:constraint_referenced_ids="view_c"/>
+            <ConstraintOverride android:id="@id/p3"  motion:constraint_referenced_ids="" />
+            <ConstraintOverride android:id="@id/p4"  motion:constraint_referenced_ids="" />
+        </ConstraintSet>
+
+
+</MotionScene>

--- a/projects/MotionLayoutVerification/app/src/main/res/xml/verification_scene_131.xml
+++ b/projects/MotionLayoutVerification/app/src/main/res/xml/verification_scene_131.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MotionScene xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:motion="http://schemas.android.com/apk/res-auto">
+
+
+        <Transition
+            android:id="@+id/previous"
+            motion:constraintSetStart="@id/start"
+            motion:constraintSetEnd="@+id/previous"
+            motion:duration="1000">
+            <OnSwipe motion:dragDirection="dragRight"/>
+        </Transition>
+
+    <Transition
+        android:id="@+id/forward"
+        motion:constraintSetStart="@id/start"
+        motion:constraintSetEnd="@+id/next"
+        motion:duration="1000">
+        <OnSwipe motion:dragDirection="dragLeft"/>
+    </Transition>
+
+
+    <ConstraintSet android:id="@+id/previous" >
+        <ConstraintOverride android:id="@id/p0"  motion:constraint_referenced_ids=""
+            android:layout_width="128dp"
+            android:layout_height="128dp"
+            />
+        <ConstraintOverride android:id="@id/p1"  motion:constraint_referenced_ids=""
+            android:layout_width="128dp"
+            android:layout_height="128dp"
+            />
+        <ConstraintOverride android:id="@id/p2"  motion:constraint_referenced_ids="view_a"/>
+        <ConstraintOverride android:id="@id/p3"  motion:constraint_referenced_ids="view_b" />
+        <ConstraintOverride android:id="@id/p4"  motion:constraint_referenced_ids="view_c" />
+    </ConstraintSet>
+
+        <ConstraintSet android:id="@+id/start">
+            <ConstraintOverride android:id="@id/p0"  motion:constraint_referenced_ids=""
+                android:layout_width="128dp"
+                android:layout_height="128dp"
+                />
+            <ConstraintOverride android:id="@id/p1"  motion:constraint_referenced_ids="view_a"/>
+            <ConstraintOverride android:id="@id/p2"  motion:constraint_referenced_ids="view_b"/>
+            <ConstraintOverride android:id="@id/p3"  motion:constraint_referenced_ids="view_c" />
+            <ConstraintOverride android:id="@id/p4"  motion:constraint_referenced_ids=""
+                android:layout_width="128dp"
+                android:layout_height="128dp"
+                />
+        </ConstraintSet>
+
+        <ConstraintSet android:id="@+id/next">
+            <ConstraintOverride android:id="@id/p0"  motion:constraint_referenced_ids="view_a"/>
+            <ConstraintOverride android:id="@id/p1"  motion:constraint_referenced_ids="view_b"/>
+            <ConstraintOverride android:id="@id/p2"  motion:constraint_referenced_ids="view_c"/>
+            <ConstraintOverride android:id="@id/p3"  motion:constraint_referenced_ids=""
+                android:layout_width="128dp"
+                android:layout_height="128dp"
+                />
+            <ConstraintOverride android:id="@id/p4"  motion:constraint_referenced_ids=""
+                android:layout_width="128dp"
+                android:layout_height="128dp"
+                />
+        </ConstraintSet>
+
+
+</MotionScene>


### PR DESCRIPTION
Add a MotionPlaceholder VirtualLayout, providing placeholder widgets that work in MotionLayout.

The first referenced widget will be centered where the placeholder is positioned. If placeholder is wrap_content itself, the size of the referenced widget will be used.