### PR TITLE
add null checks to Flow

### DIFF
--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/widgets/Flow.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/widgets/Flow.java
@@ -473,7 +473,7 @@ public class Flow extends VirtualLayout {
                     break;
                 }
                 ConstraintWidget widget = mDisplayedWidgets[mStartIndex + index];
-                if (widget.getVisibility() == VISIBLE) {
+                if (widget != null && widget.getVisibility() == VISIBLE) {
                     if (firstVisible == -1) {
                         firstVisible = i;
                     }
@@ -525,6 +525,9 @@ public class Flow extends VirtualLayout {
                         break;
                     }
                     ConstraintWidget widget = mDisplayedWidgets[mStartIndex + index];
+                    if (widget == null) {
+                        continue;
+                    }
                     if (i == 0) {
                         widget.connect(widget.mLeft, mLeft, mPaddingLeft);
                     }
@@ -619,6 +622,9 @@ public class Flow extends VirtualLayout {
                         break;
                     }
                     ConstraintWidget widget = mDisplayedWidgets[mStartIndex + i];
+                    if (widget == null) {
+                        continue;
+                    }
                     if (i == 0) {
                         widget.connect(widget.mTop, mTop, mPaddingTop);
                         int style = mVerticalStyle;


### PR DESCRIPTION
Nicolas Do we need something like this? in  Flow.

There is an issue (in issues)

 System.err: java.lang.NullPointerException: Attempt to invoke virtual method 'int androidx.constraintlayout.core.widgets.ConstraintWidget.getVisibility()' on a null object reference
 System.err: 	at androidx.constraintlayout.core.widgets.Flow$WidgetsList.createConstraints(SourceFile:8)
 System.err: 	at androidx.constraintlayout.core.widgets.Flow.addToSolver(SourceFile:7)
 System.err: 	at androidx.constraintlayout.core.widgets.ConstraintWidgetContainer.addChildrenToSolver(SourceFile:26)
 System.err: 	at androidx.constraintlayout.core.widgets.ConstraintWidgetContainer.layout(SourceFile:48)