### PR TITLE
fix the size of the Timeline graph points

### DIFF
--- a/desktop/ConstraintLayoutInspector/app/src/androidx/constraintLayout/desktop/ui/timeline/GraphRender.java
+++ b/desktop/ConstraintLayoutInspector/app/src/androidx/constraintLayout/desktop/ui/timeline/GraphRender.java
@@ -247,8 +247,8 @@ public class GraphRender {
   static class Attribute {
     String mType;
     MonotoneSpline spline;
-    int[] xPoints = new int[1000];
-    int[] yPoints = new int[1000];
+    int[] xPoints = new int[2000];
+    int[] yPoints = new int[2000];
     double mMin;
     double mMax;
 


### PR DESCRIPTION
Increase the size of xPoints and yPoints to avoid the IndexOutOfBoundsException when the width of the Timeline Panel is too big.