### PR TITLE
make the timeline graph an area graph

### DIFF
--- a/desktop/ConstraintLayoutInspector/app/src/androidx/constraintLayout/desktop/ui/adapters/MEUI.java
+++ b/desktop/ConstraintLayoutInspector/app/src/androidx/constraintLayout/desktop/ui/adapters/MEUI.java
@@ -51,6 +51,10 @@ public class MEUI {
     return !dark ? new Color(rgb) : new Color(darkRGB);
   }
 
+  public static Color makeColorWithAlpha(int rgba, int darkRGBA) {
+    return !dark ? new Color(rgba, true) : new Color(darkRGBA, true);
+  }
+
   private static Color makeColor(String name, int rgb, int darkRGB) {
     return makeColor(rgb, darkRGB);
   }
@@ -110,7 +114,7 @@ public class MEUI {
   public static final Color ourMySelectedLineColor = new Color(0x3879d9);
   public static final Color ourAddConstraintColor = makeColor("UIDesigner.motion.AddConstraintColor", 0xff838383, 0xff666666);
   public static final Color ourAddConstraintPlus = makeColor("UIDesigner.motion.AddConstraintPlus", 0xffc9c9c9, 0xff333333);
-
+  public static final Color ourDashedLineColor = makeColor(0xA0A0A0, 0xBBBBBB);
 
   public static void copy(MTag tag) {
   }
@@ -118,7 +122,24 @@ public class MEUI {
   public static void cut(MTag mSelectedKeyFrame) {
   }
 
-
+  /** List of colors with alpha = 0.7 for graphs. */
+  public static Color[] graphColors = {
+          makeColorWithAlpha(0xa6bcc9b3, 0x8da9bab3),
+          makeColorWithAlpha(0xaee3feb3, 0xaee3feb3),
+          makeColorWithAlpha(0xf8a981b3, 0xf68f5bb3),
+          makeColorWithAlpha(0x89e69ab3, 0x67df7db3),
+          makeColorWithAlpha(0xb39bdeb3, 0x9c7cd4b3),
+          makeColorWithAlpha(0xea85aab3, 0xe46391b3),
+          makeColorWithAlpha(0x6de9d6b3, 0x49e4cdb3),
+          makeColorWithAlpha(0xe3d2abb3, 0xd9c28cb3),
+          makeColorWithAlpha(0x0ab4ffb3, 0x0095d6b3),
+          makeColorWithAlpha(0x1bb6a2b3, 0x138173b3),
+          makeColorWithAlpha(0x9363e3b3, 0x7b40ddb3),
+          makeColorWithAlpha(0xe26b27b3, 0xc1571ab3),
+          makeColorWithAlpha(0x4070bfb3, 0x335a99b3),
+          makeColorWithAlpha(0xc6c54eb3, 0xadac38b3),
+          makeColorWithAlpha(0xcb53a3b3, 0xb8388eb3),
+          makeColorWithAlpha(0x3d8effb3, 0x1477ffb3)};
 
   public static final int DIR_LEFT = 0;
   public static final int DIR_RIGHT = 1;

--- a/desktop/ConstraintLayoutInspector/app/src/androidx/constraintLayout/desktop/ui/timeline/TimeLineRow.java
+++ b/desktop/ConstraintLayoutInspector/app/src/androidx/constraintLayout/desktop/ui/timeline/TimeLineRow.java
@@ -49,6 +49,7 @@ public class TimeLineRow extends JPanel {
   private boolean mHasGraph = true;
   private boolean mGraphOpen = false;
   GraphRender mGraph = new GraphRender();
+  private boolean mShowNewGraph = true;
 
   @Override
   public void updateUI() {
@@ -70,6 +71,7 @@ public class TimeLineRow extends JPanel {
   TimeLineRow(TimelineStructure timelineStructure) {
     setPreferredSize(MEUI.size(100, 20));
     mTimelineStructure = timelineStructure;
+    mGraph.setShowNewGraph(mShowNewGraph);
   }
 
   @Override
@@ -186,8 +188,10 @@ public class TimeLineRow extends JPanel {
       int gy = myRowHeight + ((mShowTitle) ? myTitleHeight : 0);
       mGraph.draw(g, mTimelineStructure, MEUI.ourLeftColumnWidth, gy, w - MEUI.ourLeftColumnWidth, myGraphHeight);
     }
-    g.setColor(MEUI.myGridColor);
-    drawTicks(g, mTimelineStructure, h);
+    if (!mShowNewGraph) {
+      g.setColor(MEUI.myGridColor);
+      TimeLineRow.drawTicks(g, mTimelineStructure, h);
+    }
   }
 
   public void drawArrow(Graphics g, int y) {
@@ -216,9 +220,13 @@ public class TimeLineRow extends JPanel {
   }
 
   public static void drawTicks(Graphics g, TimelineStructure mTimelineStructure, int h) {
+    drawTicks(g, mTimelineStructure, h, 0);
+  }
+
+  public static void drawTicks(Graphics g, TimelineStructure mTimelineStructure, int h, int y) {
     for (int i = 0; i < mTimelineStructure.myXTicksPixels.length; i++) {
       int x = mTimelineStructure.myXTicksPixels[i] + MEUI.ourLeftColumnWidth;
-      g.fillRect(x, 0, 1, h);
+      g.fillRect(x, y, 1, h);
     }
   }
 

--- a/desktop/ConstraintLayoutInspector/app/src/androidx/constraintLayout/desktop/ui/timeline/TimeLineRowData.java
+++ b/desktop/ConstraintLayoutInspector/app/src/androidx/constraintLayout/desktop/ui/timeline/TimeLineRowData.java
@@ -32,6 +32,7 @@ public class TimeLineRowData {
   String mKeyProp;
   String mKeyPropToolTip;
   String mType; // Pos, Trig, Att, TCyc, Cyc
+  int mKeyPropIndex = 0; // used to map a property to a color
 
   private static String[] properties =
     {
@@ -78,6 +79,15 @@ public class TimeLineRowData {
     nameMap.put("KeyAttribute", TYPE_KEY_ATTRIBUTE);
   }
 
+  // map a property to an index that is associated with a specific color
+  private static HashMap<String, Integer> propertyMap = new HashMap<>();
+
+  static {
+    for (int i = 0; i < properties.length; i++) {
+      propertyMap.put(properties[i], i);
+    }
+  }
+
   ArrayList<MTag> mKeyFrames = new ArrayList<>();
   MTag mStartConstraintSet;
   MTag mEndConstraintSet;
@@ -108,12 +118,15 @@ public class TimeLineRowData {
           Debug.log(count + " " + properties[i]);
         }
         mKeyProp = properties[i];
+        mKeyPropIndex = propertyMap.getOrDefault(mKeyProp, properties.length - 1);
       }
     }
     if (count > 1) {
       count = 0;
       mKeyProp = "";
       mKeyPropToolTip = "";
+      // show the a specific color for a composite of propierties
+      mKeyPropIndex = properties.length - 1;
       for (int i = 0; i < properties.length; i++) {
         if ((mask & (1 << i)) != 0) {
           if (count > 0) {


### PR DESCRIPTION
Convert the graph in Timeline panel from a polyline into a  an area graph. We hope this update could make it easier to interpret the graph.

Before:
![image](https://user-images.githubusercontent.com/20599348/140005091-dcf04728-9d40-4391-ba29-090ad9dcbdc8.png)

After: 
![image](https://user-images.githubusercontent.com/20599348/140005113-e0f7e5dd-9c13-4572-9ccd-915d0e36c979.png)
