### PR TITLE
Make ConstraintSet objects extendable

### DIFF
--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintSet.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintSet.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.compose
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.layout.Measurable
+import androidx.constraintlayout.core.state.Transition
+
+/**
+ * Immutable description of the constraints used to layout the children of a [ConstraintLayout].
+ */
+@Immutable
+interface ConstraintSet {
+    /**
+     * Applies the [ConstraintSet] to a state.
+     */
+    fun applyTo(state: State, measurables: List<Measurable>)
+
+    fun override(name: String, value: Float) = this
+    fun applyTo(transition: Transition, type: Int) {
+        // nothing here, used in MotionLayout
+    }
+
+    fun isDirty(measurables: List<Measurable>): Boolean = true
+}
+
+internal interface DerivedConstraintSet: ConstraintSet {
+    /**
+     * [ConstraintSet] that this instance will derive its constraints from.
+     *
+     * This means that the constraints from [extendFrom] will be applied before the constraints of
+     * this [DerivedConstraintSet] instance.
+     */
+    val extendFrom: ConstraintSet?
+
+    override fun applyTo(state: State, measurables: List<Measurable>) {
+        buildMapping(state, measurables)
+        (extendFrom as? DerivedConstraintSet)?.applyToState(state)
+        applyToState(state)
+    }
+
+    /**
+     * Inheritors should implement this function so that derived constraints are applied properly.
+     */
+    fun applyToState(state: State)
+}

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintSetParser.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintSetParser.kt
@@ -905,8 +905,6 @@ fun parseWidget(
 ) {
     val reference = state.constraints(elementName)
     val constraints = element.names() ?: return
-    reference.width = Dimension.Wrap()
-    reference.height = Dimension.Wrap()
     (0 until constraints.size).forEach { i ->
         when (val constraintName = constraints[i]) {
             "width" -> {

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintSetParser.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintSetParser.kt
@@ -904,6 +904,14 @@ fun parseWidget(
     element: CLObject
 ) {
     val reference = state.constraints(elementName)
+    if (reference.width == null) {
+        // Default to Wrap when the Dimension has not been assigned
+        reference.width = Wrap()
+    }
+    if (reference.height == null) {
+        // Default to Wrap when the Dimension has not been assigned
+        reference.height = Wrap()
+    }
     val constraints = element.names() ?: return
     (0 until constraints.size).forEach { i ->
         when (val constraintName = constraints[i]) {

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/DslConstraintSet.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/DslConstraintSet.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.compose
+
+/**
+ * [ConstraintSet] implementation used in the kotlin DSL.
+ */
+internal class DslConstraintSet constructor(
+    val description: ConstraintSetScope.() -> Unit,
+    override val extendFrom: ConstraintSet? = null
+) : DerivedConstraintSet {
+    override fun applyToState(state: State) {
+        val scope = ConstraintSetScope()
+        scope.description()
+        scope.applyTo(state)
+    }
+
+    override fun override(name: String, value: Float): ConstraintSet {
+        // nothing yet
+        return this
+    }
+}

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/JSONConstraintSet.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/JSONConstraintSet.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.compose
+
+import androidx.constraintlayout.core.parser.CLKey
+import androidx.constraintlayout.core.parser.CLParser
+import androidx.constraintlayout.core.parser.CLParsingException
+import androidx.constraintlayout.core.state.Transition
+import org.intellij.lang.annotations.Language
+import java.util.ArrayList
+import java.util.HashMap
+
+internal class JSONConstraintSet(
+    @Language("json5") content: String,
+    @Language("json5") overrideVariables: String? = null,
+    override val extendFrom: ConstraintSet? = null
+) : EditableJSONLayout(content), DerivedConstraintSet {
+    private val overridedVariables = HashMap<String, Float>()
+    private val overrideVariables = overrideVariables
+
+    init {
+        initialization()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other is JSONConstraintSet) {
+            return this.getCurrentContent() == other.getCurrentContent()
+        }
+        return false
+    }
+
+    // Only called by MotionLayout in MotionMeasurer
+    override fun applyTo(transition: Transition, type: Int) {
+        val layoutVariables = LayoutVariables()
+        applyLayoutVariables(layoutVariables)
+        parseJSON(getCurrentContent(), transition, type)
+    }
+
+    fun emitDesignElements(designElements: ArrayList<DesignElement>) {
+        try {
+            designElements.clear()
+            parseDesignElementsJSON(getCurrentContent(), designElements)
+        } catch (e : Exception) {
+            // nothing (content might be invalid, sent by live edit)
+        }
+    }
+
+    // Called by both MotionLayout & ConstraintLayout measurers
+    override fun applyToState(state: State) {
+        val layoutVariables = LayoutVariables()
+        applyLayoutVariables(layoutVariables)
+        // TODO: Need to better handle half parsed JSON and/or incorrect states.
+        try {
+            parseJSON(getCurrentContent(), state, layoutVariables)
+        } catch (e : Exception) {
+            // nothing (content might be invalid, sent by live edit)
+        }
+    }
+
+    override fun override(name: String, value: Float): ConstraintSet {
+        overridedVariables[name] = value
+        return this
+    }
+
+    private fun applyLayoutVariables(layoutVariables: LayoutVariables) {
+        if (overrideVariables != null) {
+            try {
+                val variables = CLParser.parse(overrideVariables)
+                for (i in 0..variables.size() - 1) {
+                    val key = variables[i] as CLKey
+                    val variable = key.value.float
+                    // TODO: allow arbitrary override, not just float values
+                    layoutVariables.putOverride(key.content(), variable)
+                }
+            } catch (e: CLParsingException) {
+                System.err.println("exception: " + e)
+            }
+        }
+        for (name in overridedVariables.keys) {
+            layoutVariables.putOverride(name, overridedVariables[name]!!)
+        }
+    }
+}

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionLayout.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionLayout.kt
@@ -138,9 +138,9 @@ inline fun MotionLayout(
         return
     }
 
-    var start: ConstraintSet by remember(motionScene) { mutableStateOf(JSONConstraintSet(content = startContent)) }
-    var end: ConstraintSet by remember(motionScene) { mutableStateOf(JSONConstraintSet(content = endContent)) }
-    val targetConstraintSet = targetEndContent?.let { JSONConstraintSet(targetEndContent) }
+    var start: ConstraintSet by remember(motionScene) { mutableStateOf(ConstraintSet(jsonContent = startContent)) }
+    var end: ConstraintSet by remember(motionScene) { mutableStateOf(ConstraintSet(jsonContent = endContent)) }
+    val targetConstraintSet = targetEndContent?.let { ConstraintSet(jsonContent = targetEndContent) }
 
     val progress = remember { Animatable(0f) }
 
@@ -379,7 +379,7 @@ interface MotionScene {
     fun getForcedDrawDebug(): MotionLayoutDebugFlags
 }
 
-class JSONMotionScene(@Language("json5") content: String) : EditableJSONLayout(content),
+internal class JSONMotionScene(@Language("json5") content: String) : EditableJSONLayout(content),
     MotionScene {
 
     private val constraintSetsContent = HashMap<String, String>()

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/motion/dsl/ExtendingConstraintSets.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/motion/dsl/ExtendingConstraintSets.kt
@@ -37,13 +37,7 @@ import com.example.constraintlayout.R
 
 @Preview
 @Composable
-private fun DslMotionTransformsExample() {
-    var animateToEnd by remember { mutableStateOf(false) }
-    val progress by animateFloatAsState(
-        targetValue = if (animateToEnd) 1f else 0f,
-        animationSpec = tween(2000)
-    )
-
+private fun DslStartWithJsonEndExample() {
     val start = ConstraintSet {
         val image1 = createRefFor("image1")
         val image2 = createRefFor("image2")
@@ -60,15 +54,66 @@ private fun DslMotionTransformsExample() {
             centerHorizontallyTo(parent)
         }
     }
+    val end = ConstraintSet(start, jsonContent = """
+        {
+          image1: {
+          // Other constraints are derived from the start ConstraintSet in DSL
+            rotationZ: -45
+          }
+        }
+    """.trimIndent())
+
+    CommonMotionLayout(start = start, end = end)
+}
+
+@Preview
+@Composable
+private fun JsonStartWithDslEndExample() {
+    val start = ConstraintSet(jsonContent = """
+        {
+          Helpers: [
+                ['vChain', ['image1','image2'], {
+                  top: ['parent', 'top'],
+                  bottom: ['parent', 'bottom'],
+                  style: 'spread'
+                }]],
+          image1: {
+            width: 200, height: 200,
+            centerHorizontally: 'parent',
+            rotationZ: 90,
+          },
+          image2: {
+            width: 200, height: 200,
+            centerHorizontally: 'parent'
+          }
+        }
+    """.trimIndent())
+
     val end = ConstraintSet(start) {
         constrain(createRefFor("image1")) {
-            rotationZ = -45f
+            rotationZ = -90f
         }
     }
+    CommonMotionLayout(start = start, end = end)
+}
+
+
+@Composable
+private fun CommonMotionLayout(
+    start: ConstraintSet,
+    end: ConstraintSet
+) {
+    var animateToEnd by remember { mutableStateOf(false) }
+    val progress by animateFloatAsState(
+        targetValue = if (animateToEnd) 1f else 0f,
+        animationSpec = tween(2000)
+    )
 
     Column {
         MotionLayout(
-            modifier = Modifier.fillMaxWidth().height(500.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(500.dp),
             start = start,
             end = end,
             progress = progress) {


### PR DESCRIPTION
It is now possible to extend a new ConstraintSet written in DSL using a
ConstraintSet written in Json and vice-versa.

Examples in ExtendingConstraintSets.kt

This is so that ConstraintSet themselves are more interchangeable and
the developer can write their new ConstraintSet in their preferred
syntax.

Modified visibility for related classes that should be internal.

Reorganized some classes in different files (package is unmodified,
should not affect build output).