### PR TITLE
[Compose] Fix ratio and support it in DSL

### DIFF
--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayout.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayout.kt
@@ -1402,6 +1402,20 @@ interface Dimension {
             DimensionDescription { state -> SolverDimension.Fixed(state.convertDimension(dp)) }
 
         /**
+         * Sets the dimensions to be defined as a ratio of the width and height. The assigned
+         * dimension will be considered to also be [fillToConstraints].
+         *
+         * The string to define a ratio is defined by the format: 'W:H'.
+         * Where H is the height as a proportion of W (the width).
+         *
+         * Eg: width = Dimension.ratio('1:2') sets the width to be half as large as the height.
+         *
+         * Note that only one dimension should be defined as a ratio.
+         */
+        fun ratio(ratio: String): Dimension =
+            DimensionDescription { SolverDimension.Ratio(ratio).suggested(SPREAD_DIMENSION) }
+
+        /**
          * A [Dimension] with suggested wrap content behavior. The wrap content size
          * will be respected unless the constraints in the [ConstraintSet] do not allow it.
          * To make the value fixed (respected regardless the [ConstraintSet]), [wrapContent]
@@ -1862,8 +1876,8 @@ internal open class Measurer : BasicMeasure.Measurer, DesignInfoProvider {
         run {
             val measurableLastMeasures = lastMeasures[measurable]
             obtainConstraints(
-                constraintWidget.horizontalDimensionBehaviour,
-                constraintWidget.width,
+                measure.horizontalBehavior,
+                measure.horizontalDimension,
                 constraintWidget.mMatchConstraintDefaultWidth,
                 measure.measureStrategy,
                 (measurableLastMeasures?.get(1) ?: 0) == constraintWidget.height,
@@ -1872,8 +1886,8 @@ internal open class Measurer : BasicMeasure.Measurer, DesignInfoProvider {
                 widthConstraintsHolder
             )
             obtainConstraints(
-                constraintWidget.verticalDimensionBehaviour,
-                constraintWidget.height,
+                measure.verticalBehavior,
+                measure.verticalDimension,
                 constraintWidget.mMatchConstraintDefaultHeight,
                 measure.measureStrategy,
                 (measurableLastMeasures?.get(0) ?: 0) == constraintWidget.width,
@@ -1892,10 +1906,10 @@ internal open class Measurer : BasicMeasure.Measurer, DesignInfoProvider {
 
         if ((measure.measureStrategy == TRY_GIVEN_DIMENSIONS ||
                 measure.measureStrategy == USE_GIVEN_DIMENSIONS) ||
-            constraintWidget.horizontalDimensionBehaviour != MATCH_CONSTRAINT ||
-            constraintWidget.mMatchConstraintDefaultWidth != MATCH_CONSTRAINT_SPREAD ||
-            constraintWidget.verticalDimensionBehaviour != MATCH_CONSTRAINT ||
-            constraintWidget.mMatchConstraintDefaultHeight != MATCH_CONSTRAINT_SPREAD
+            !(measure.horizontalBehavior == MATCH_CONSTRAINT &&
+            constraintWidget.mMatchConstraintDefaultWidth == MATCH_CONSTRAINT_SPREAD &&
+            measure.verticalBehavior == MATCH_CONSTRAINT &&
+            constraintWidget.mMatchConstraintDefaultHeight == MATCH_CONSTRAINT_SPREAD)
         ) {
             if (DEBUG) {
                 Log.d("CCL", "Measuring ${measurable.layoutId} with $constraints")

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintSetParser.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintSetParser.kt
@@ -1144,7 +1144,7 @@ private fun parseDimensionMode(dimensionString: String): Dimension {
                 val percentValue = percentString.toFloat() / 100f
                 dimension = Dimension.Percent(0, percentValue).suggested(0)
             } else if (dimensionString.contains(':')) {
-                dimension = Dimension.Ratio(dimensionString).suggested(0)
+                dimension = Dimension.Ratio(dimensionString).suggested(SPREAD_DIMENSION)
             }
         }
     }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/widgets/analyzer/Direct.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/widgets/analyzer/Direct.java
@@ -784,7 +784,7 @@ public class Direct {
                         && layout.mMatchConstraintDefaultHeight == ConstraintWidget.MATCH_CONSTRAINT_SPREAD
                         && layout.mDimensionRatio == 0
                         && layout.hasDanglingDimension(ConstraintWidget.VERTICAL))
-                || (horizontalBehaviour == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
+                || (verticalBehaviour == ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
                         && layout.mMatchConstraintDefaultHeight == MATCH_CONSTRAINT_WRAP
                         && layout.hasResolvedTargets(VERTICAL, layout.getHeight()));
         if (layout.mDimensionRatio > 0 && (isHorizontalFixed || isVerticalFixed)) {

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/constraint/dsl/Ratio.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/constraint/dsl/Ratio.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.constraintlayout.constraint.dsl
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.ConstraintSet
+import androidx.constraintlayout.compose.Dimension
+
+@Preview
+@Composable
+private fun RatioExamplesInDsl() {
+    val constraintSet = ConstraintSet {
+        constrain(createRefFor("box1")) {
+            centerTo(parent)
+            width = Dimension.value(100.dp)
+            height = Dimension.ratio("4:2")
+        }
+    }
+    ConstraintLayout(
+        modifier = Modifier
+            .background(Color.Blue)
+            .fillMaxSize(),
+        constraintSet = constraintSet
+    ) {
+        Spacer(
+            modifier = Modifier
+                .background(Color.Red)
+                .layoutId("box1"),
+        )
+    }
+}


### PR DESCRIPTION
Ratio didn't work properly since the Optimizer measurements were being
ignored.

width/height can now be assigned a ratio when using the DSL