### PR TITLE
[Compose] Support bias and clearing inherited constraints

### DIFF
--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayoutBaseScope.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayoutBaseScope.kt
@@ -802,7 +802,7 @@ class ConstrainScope internal constructor(internal val id: Any) {
     }
 
     /**
-     * Adds both start and end links towards other [ConstraintLayoutBaseScope.HorizontalAnchor]s.
+     * Adds both start and end links towards other [ConstraintLayoutBaseScope.VerticalAnchor]s.
      */
     // TODO(popam, b/158069248): add parameter for gone margin
     fun linkTo(
@@ -815,7 +815,8 @@ class ConstrainScope internal constructor(internal val id: Any) {
         this@ConstrainScope.start.linkTo(start, startMargin)
         this@ConstrainScope.end.linkTo(end, endMargin)
         tasks.add { state ->
-            state.constraints(id).horizontalBias(bias)
+            val resolvedBias = if (state.layoutDirection == LayoutDirection.Rtl) 1 - bias else bias
+            state.constraints(id).horizontalBias(resolvedBias)
         }
     }
 
@@ -871,8 +872,11 @@ class ConstrainScope internal constructor(internal val id: Any) {
      * This will center horizontally the current layout inside or around (depending on size)
      * [other].
      */
-    fun centerHorizontallyTo(other: ConstrainedLayoutReference) {
-        linkTo(other.start, other.end)
+    fun centerHorizontallyTo(
+        other: ConstrainedLayoutReference,
+        @FloatRange(from = 0.0f.toDouble(), to = 1.0f.toDouble()) bias: Float = 0.5f
+    ) {
+        linkTo(other.start, other.end, bias = bias)
     }
 
     /**
@@ -880,8 +884,11 @@ class ConstrainScope internal constructor(internal val id: Any) {
      * This will center vertically the current layout inside or around (depending on size)
      * [other].
      */
-    fun centerVerticallyTo(other: ConstrainedLayoutReference) {
-        linkTo(other.top, other.bottom)
+    fun centerVerticallyTo(
+        other: ConstrainedLayoutReference,
+        @FloatRange(from = 0.0f.toDouble(), to = 1.0f.toDouble()) bias: Float = 0.5f
+    ) {
+        linkTo(other.top, other.bottom, bias = bias)
     }
 
     /**
@@ -906,7 +913,35 @@ class ConstrainScope internal constructor(internal val id: Any) {
      */
     fun circular(other: ConstrainedLayoutReference, angle: Float, distance: Dp) {
         tasks.add { state ->
-            state.constraints(id).circularConstraint(other.id, angle, state.convertDimension(distance).toFloat())
+            state.constraints(id)
+                .circularConstraint(other.id, angle, state.convertDimension(distance).toFloat())
+        }
+    }
+
+    /**
+     * Clear the constraints on the horizontal axis (left, right, start, end).
+     */
+    fun clearHorizontal() {
+        tasks.add { state ->
+            state.constraints(id).clearHorizontal()
+        }
+    }
+
+    /**
+     * Clear the constraints on the vertical axis (top, bottom, baseline).
+     */
+    fun clearVertical() {
+        tasks.add { state ->
+            state.constraints(id).clearVertical()
+        }
+    }
+
+    /**
+     * Clear all constraints (vertical, horizontal, circular).
+     */
+    fun clearConstraints() {
+        tasks.add { state ->
+            state.constraints(id).clear()
         }
     }
 

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/widgets/analyzer/Direct.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/widgets/analyzer/Direct.java
@@ -339,6 +339,8 @@ public class Direct {
                     ConstraintWidgetContainer.measure(level + 1, widget, measurer, measure, BasicMeasure.Measure.SELF_DIMENSIONS);
                 }
 
+                boolean bothConnected = (first == widget.mLeft && widget.mRight.mTarget != null && widget.mRight.mTarget.hasFinalValue())
+                        || (first == widget.mRight && widget.mLeft.mTarget != null && widget.mLeft.mTarget.hasFinalValue());
                 if (widget.getHorizontalDimensionBehaviour() != ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
                         || canMeasure) {
                     if (widget.isMeasureRequested()) {
@@ -358,8 +360,7 @@ public class Direct {
                         x1 = x2 - widget.getWidth();
                         widget.setFinalHorizontal(x1, x2);
                         horizontalSolvingPass(level + 1, widget, measurer, isRtl);
-                    } else if (first == widget.mLeft && widget.mRight.mTarget != null
-                            && widget.mRight.mTarget.hasFinalValue() && !widget.isInHorizontalChain()) {
+                    } else if (bothConnected && !widget.isInHorizontalChain()) {
                         solveHorizontalCenterConstraints(level + 1, measurer, widget, isRtl);
                     } else if (APPLY_MATCH_PARENT && widget.getHorizontalDimensionBehaviour() == ConstraintWidget.DimensionBehaviour.MATCH_PARENT) {
                         widget.setFinalHorizontal(0, widget.getWidth());
@@ -369,8 +370,6 @@ public class Direct {
                         && widget.mMatchConstraintMaxWidth >= 0 && widget.mMatchConstraintMinWidth >= 0
                         && (widget.getVisibility() == ConstraintWidget.GONE || ((widget.mMatchConstraintDefaultWidth == ConstraintWidget.MATCH_CONSTRAINT_SPREAD) && widget.getDimensionRatio() == 0))
                         && !widget.isInHorizontalChain() && !widget.isInVirtualLayout()) {
-                    boolean bothConnected = (first == widget.mLeft && widget.mRight.mTarget != null && widget.mRight.mTarget.hasFinalValue())
-                            || (first == widget.mRight && widget.mLeft.mTarget != null && widget.mLeft.mTarget.hasFinalValue());
                     if (bothConnected && !widget.isInHorizontalChain()) {
                         solveHorizontalMatchConstraint(level + 1, layout, measurer, widget, isRtl);
                     }
@@ -469,6 +468,8 @@ public class Direct {
                     ConstraintWidgetContainer.measure(level + 1, widget, measurer, measure, BasicMeasure.Measure.SELF_DIMENSIONS);
                 }
 
+                boolean bothConnected = (first == widget.mTop && widget.mBottom.mTarget != null && widget.mBottom.mTarget.hasFinalValue())
+                        || (first == widget.mBottom && widget.mTop.mTarget != null && widget.mTop.mTarget.hasFinalValue());
                 if (widget.getVerticalDimensionBehaviour() != ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT
                         || canMeasure) {
                     if (widget.isMeasureRequested()) {
@@ -483,13 +484,12 @@ public class Direct {
                         y2 = y1 + widget.getHeight();
                         widget.setFinalVertical(y1, y2);
                         verticalSolvingPass(level + 1, widget, measurer);
-                    } else if (first == widget.mBottom && widget.mBottom.mTarget == null) {
+                    } else if (first == widget.mBottom && widget.mTop.mTarget == null) {
                         y2 = t - widget.mBottom.getMargin();
                         y1 = y2 - widget.getHeight();
                         widget.setFinalVertical(y1, y2);
                         verticalSolvingPass(level + 1, widget, measurer);
-                    } else if (first == widget.mTop && widget.mBottom.mTarget != null
-                            && widget.mBottom.mTarget.hasFinalValue()) {
+                    } else if (bothConnected && !widget.isInVerticalChain()) {
                         solveVerticalCenterConstraints(level + 1, measurer, widget);
                     } else if (APPLY_MATCH_PARENT && widget.getVerticalDimensionBehaviour() == ConstraintWidget.DimensionBehaviour.MATCH_PARENT) {
                         widget.setFinalVertical(0, widget.getHeight());
@@ -499,8 +499,6 @@ public class Direct {
                         && widget.mMatchConstraintMaxHeight >= 0 && widget.mMatchConstraintMinHeight >= 0
                         && (widget.getVisibility() == ConstraintWidget.GONE || ((widget.mMatchConstraintDefaultHeight == ConstraintWidget.MATCH_CONSTRAINT_SPREAD) && widget.getDimensionRatio() == 0))
                         && !widget.isInVerticalChain() && !widget.isInVirtualLayout()) {
-                    boolean bothConnected = (first == widget.mTop && widget.mBottom.mTarget != null && widget.mBottom.mTarget.hasFinalValue())
-                            || (first == widget.mBottom && widget.mTop.mTarget != null && widget.mTop.mTarget.hasFinalValue());
                     if (bothConnected && !widget.isInVerticalChain()) {
                         solveVerticalMatchConstraint(level + 1, layout, measurer, widget);
                     }
@@ -594,6 +592,7 @@ public class Direct {
      * @param isRtl
      */
     private static void solveHorizontalCenterConstraints(int level, BasicMeasure.Measurer measurer, ConstraintWidget widget, boolean isRtl) {
+        // TODO: Handle match constraints here or before calling this
         int x1;
         int x2;
         float bias = widget.getHorizontalBiasPercent();
@@ -635,6 +634,7 @@ public class Direct {
      * @param widget
      */
     private static void solveVerticalCenterConstraints(int level, BasicMeasure.Measurer measurer, ConstraintWidget widget) {
+        // TODO: Handle match constraints here or before calling this
         int y1;
         int y2;
         float bias = widget.getVerticalBiasPercent();

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/ComposableInvocator.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/ComposableInvocator.kt
@@ -22,8 +22,7 @@ import java.util.*
 
 class ComposableInvocator {
     private val supportedPackages = listOf<String>(
-        "com.example.constraintlayout",
-        "com.example.constraintlayout.verification"
+        "com.example.constraintlayout.verification.dsl"
     )
 
     /**
@@ -31,8 +30,7 @@ class ComposableInvocator {
      * Eg: for "test" it will automatically look for "test1", "test2", ...
      */
     private val supportedFileNames = listOf<String>(
-        "test",
-        "VTest"
+        "DslVerification"
     )
 
     /**
@@ -42,10 +40,7 @@ class ComposableInvocator {
      * Eg: for "Example" it will also look for "Example1", "Example2", ...
      */
     private val baseComposableNames = listOf<String>(
-        "ScreenExample",
-        "Screen",
-        "ExampleLayout",
-        "VTest"
+        "Test"
     )
 
     private val composablesIndex = mutableListOf<ComposableData>()

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/dsl/AspectRatio.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/dsl/AspectRatio.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:JvmName("DslVerificationKt")
+@file:JvmMultifileClass
+
+package com.example.constraintlayout.verification.dsl
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.ConstraintSet
+import androidx.constraintlayout.compose.Dimension
+
+@Preview
+@Composable
+fun Test5() {
+    val constraintSet = ConstraintSet {
+        val box1 = createRefFor("box1")
+        constrain(box1) {
+            width = Dimension.fillToConstraints
+            height = Dimension.ratio("1:1.2")
+            centerTo(parent)
+        }
+    }
+    Column {
+        ConstraintLayout(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f, fill = true), constraintSet = constraintSet
+        ) {
+            Box(
+                modifier = Modifier
+                    .background(Color.Red)
+                    .layoutId("box1")
+            )
+        }
+        Button(onClick = { }) {
+            Text(text = "Run")
+        }
+    }
+}
+
+@Preview
+@Composable
+fun Test6() {
+    val constraintSet = ConstraintSet {
+        val text1 = createRefFor("text1")
+        val box1 = createRefFor("box1")
+
+        constrain(text1) {
+            width = Dimension.wrapContent
+            height = Dimension.ratio("1:2")
+            centerVerticallyTo(parent)
+            start.linkTo(parent.start)
+            end.linkTo(box1.start)
+        }
+        constrain(box1) {
+            width = Dimension.value(50.dp)
+            height = Dimension.value(50.dp)
+            centerVerticallyTo(parent)
+            end.linkTo(parent.end, 8.dp)
+        }
+    }
+    Column {
+        ConstraintLayout(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f, fill = true), constraintSet = constraintSet
+        ) {
+            Text(
+                modifier = Modifier
+                    .layoutId("text1")
+                    .background(Color.Red),
+                text = "Hello, World!"
+            )
+            Box(
+                modifier = Modifier
+                    .layoutId("box1")
+                    .background(Color.Blue)
+            )
+        }
+        Button(onClick = { }) {
+            Text(text = "Run")
+        }
+    }
+}

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/dsl/Barriers.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/dsl/Barriers.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:JvmName("DslVerificationKt")
+@file:JvmMultifileClass
+
+package com.example.constraintlayout.verification.dsl
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.ConstraintSet
+import androidx.constraintlayout.compose.Dimension
+
+@Preview
+@Composable
+fun Test2() { // Vertical barrier
+    val constraintSet = ConstraintSet(TwoBoxConstraintSet) {
+        val box1 = createRefFor("box1")
+        val box2 = createRefFor("box2")
+        val box3 = createRefFor("box3")
+
+        val barr = createBottomBarrier(box1, box2)
+
+        constrain(box3) {
+            width = Dimension.value(50.dp)
+            height = Dimension.value(50.dp)
+            centerHorizontallyTo(parent)
+            top.linkTo(barr, 8.dp)
+        }
+    }
+
+    Column {
+        ConstraintLayout(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f, fill = true), constraintSet = constraintSet
+        ) {
+            Box(
+                modifier = Modifier
+                    .background(Color.Red)
+                    .layoutId("box1")
+            )
+            Box(
+                modifier = Modifier
+                    .background(Color.Blue)
+                    .layoutId("box2")
+            )
+            Box(
+                modifier = Modifier
+                    .background(Color.Yellow)
+                    .layoutId("box3")
+            )
+        }
+        Button(onClick = { }) {
+            Text(text = "Run")
+        }
+    }
+}
+
+@Preview
+@Composable
+fun Test3() { // Right barrier
+    val constraintSet = ConstraintSet(TwoBoxConstraintSet) {
+        val box1 = createRefFor("box1")
+        val box2 = createRefFor("box2")
+        val box3 = createRefFor("box3")
+        val barr = createAbsoluteRightBarrier(box1, box2)
+
+        constrain(box2) {
+            centerHorizontallyTo(parent, bias = 0.2f)
+        }
+
+        constrain(box3) {
+            width = Dimension.value(30.dp)
+            height = Dimension.value(30.dp)
+            top.linkTo(box1.top)
+            start.linkTo(barr) // On RTL this will be the right
+        }
+    }
+
+    CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+        Column {
+            ConstraintLayout(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f, fill = true), constraintSet = constraintSet
+            ) {
+                Box(
+                    modifier = Modifier
+                        .background(Color.Red)
+                        .layoutId("box1")
+                )
+                Box(
+                    modifier = Modifier
+                        .background(Color.Blue)
+                        .layoutId("box2")
+                )
+                Box(
+                    modifier = Modifier
+                        .background(Color.Yellow)
+                        .layoutId("box3")
+                )
+            }
+            Button(onClick = { }) {
+                Text(text = "Run")
+            }
+        }
+    }
+}

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/dsl/CommonConstraintSets.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/dsl/CommonConstraintSets.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.constraintlayout.verification.dsl
+
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintSet
+import androidx.constraintlayout.compose.Dimension
+
+val TwoBoxConstraintSet = ConstraintSet {
+    val box1 = createRefFor("box1")
+    val box2 = createRefFor("box2")
+    constrain(box1) {
+        centerTo(parent)
+        width = Dimension.value(30.dp)
+        height = Dimension.value(100.dp)
+    }
+    constrain(box2) {
+        width = Dimension.value(50.dp)
+        height = Dimension.value(50.dp)
+        centerHorizontallyTo(parent)
+        top.linkTo(box1.bottom, 8.dp)
+    }
+}

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/dsl/Guidelines.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/dsl/Guidelines.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:JvmName("DslVerificationKt")
+@file:JvmMultifileClass
+
+package com.example.constraintlayout.verification.dsl
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.ConstraintSet
+
+@Preview
+@Composable
+fun Test4() {
+    val constraintSet = ConstraintSet(TwoBoxConstraintSet) {
+        val box1 = createRefFor("box1")
+
+        val guideBott = createGuidelineFromBottom(10.dp)
+        val guideTop = createGuidelineFromTop(0.5f)
+        val guideLeft = createGuidelineFromAbsoluteLeft(10.dp)
+        val guideEnd = createGuidelineFromEnd(0.5f)
+
+        constrain(box1) {
+            linkTo(guideLeft, guideEnd)
+            linkTo(guideTop, guideBott)
+        }
+    }
+
+    Column {
+        ConstraintLayout(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f, fill = true), constraintSet = constraintSet
+        ) {
+            Box(
+                modifier = Modifier
+                    .background(Color.Red)
+                    .layoutId("box1")
+            )
+            Box(
+                modifier = Modifier
+                    .background(Color.Blue)
+                    .layoutId("box2")
+            )
+        }
+        Button(onClick = { }) {
+            Text(text = "Run")
+        }
+    }
+}

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/dsl/Rtl.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/dsl/Rtl.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:JvmName("DslVerificationKt")
+@file:JvmMultifileClass
+
+package com.example.constraintlayout.verification.dsl
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.ConstraintSet
+
+@Preview
+@Composable
+fun Test1() {
+    val constraintSet = ConstraintSet(TwoBoxConstraintSet) {
+        val box1 = createRefFor("box1")
+        val box2 = createRefFor("box2")
+        constrain(box1) {
+            // TODO: Add a way to specify if this is LTR only
+            centerHorizontallyTo(parent, 0.2f)
+        }
+        constrain(box2) {
+            clearHorizontal()
+            absoluteLeft.linkTo(box1.start, 8.dp)
+        }
+    }
+    CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+        Column {
+            ConstraintLayout(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f, fill = true), constraintSet = constraintSet
+            ) {
+                Box(
+                    modifier = Modifier
+                        .background(Color.Red)
+                        .layoutId("box1")
+                )
+                Box(
+                    modifier = Modifier
+                        .background(Color.Blue)
+                        .layoutId("box2")
+                )
+            }
+            Button(onClick = { }) {
+                Text(text = "Run")
+            }
+        }
+    }
+}

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/dsl/Visibility.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/dsl/Visibility.kt
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package com.example.constraintlayout.verification
+@file:JvmName("DslVerificationKt")
+@file:JvmMultifileClass
+package com.example.constraintlayout.verification.dsl
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.Button
 import androidx.compose.material.Text
@@ -28,35 +29,25 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.ConstraintSet
-import androidx.constraintlayout.compose.Dimension
 import androidx.constraintlayout.compose.Visibility
 
 @Preview
 @Composable
-fun DslTest() {
+fun Test() {
     var hide by remember { mutableStateOf(true) }
-    val constraintSet = ConstraintSet {
+    val constraintSet = ConstraintSet(TwoBoxConstraintSet) {
         val box1 = createRefFor("box1")
-        val box2 = createRefFor("box2")
         constrain(box1) {
-            centerTo(parent)
             alpha = 0.5f
             visibility = if (hide) Visibility.Gone else Visibility.Visible
-            width = Dimension.value(30.dp)
-            height = Dimension.value(100.dp)
-        }
-        constrain(box2) {
-            width = Dimension.value(50.dp)
-            height = Dimension.value(50.dp)
-            centerHorizontallyTo(parent)
-            top.linkTo(box1.bottom, 8.dp)
         }
     }
     Column {
-        ConstraintLayout(modifier = Modifier.fillMaxWidth().weight(1f, fill = true), constraintSet = constraintSet) {
+        ConstraintLayout(modifier = Modifier
+            .fillMaxWidth()
+            .weight(1f, fill = true), constraintSet = constraintSet) {
             Box(modifier = Modifier
                 .background(Color.Red)
                 .layoutId("box1"))


### PR DESCRIPTION
Can now set bias in dsl when using centerHorizontallyTo and
centerVerticallyTo.

Can clear constraints extended from another ConstraintSet.

Added some test examples using the DSL.

Fixed a small issue in the optimizer where it wouldn't apply the
contraints if both anchors were connected.