### PR TITLE
Friendlier layoutId Api and clean MotionLayout redundant code

### DIFF
--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayoutTag.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayoutTag.kt
@@ -26,16 +26,29 @@ import androidx.compose.ui.platform.InspectorValueInfo
 import androidx.compose.ui.platform.debugInspectorInfo
 import androidx.compose.ui.unit.Density
 
-fun Modifier.layoutId(layoutId: String, tag: String) = this.then(
-    ConstraintLayoutTag(
-        constraintLayoutId = layoutId,
-        constraintLayoutTag = tag,
-        inspectorInfo = debugInspectorInfo {
-            name = "constraintLayoutId"
-            value = layoutId
-        }
-    )
-)
+/**
+ * Alternative to [androidx.compose.ui.layout.layoutId] that enables the use of [tag].
+ *
+ * @param layoutId The unique Id string assigned to the Composable
+ * @param tag A string to represent a group of Composables that may be affected by a
+ * ConstraintLayout function. Eg: The `Variables` block in a JSON5 based [ConstraintSet]
+ */
+fun Modifier.layoutId(layoutId: String, tag: String? = null) = this.run {
+    if (tag == null) {
+        this.layoutId(layoutId)
+    } else {
+        then(
+            ConstraintLayoutTag(
+                constraintLayoutId = layoutId,
+                constraintLayoutTag = tag,
+                inspectorInfo = debugInspectorInfo {
+                    name = "constraintLayoutId"
+                    value = layoutId
+                }
+            )
+        )
+    }
+}
 
 @Immutable
 private class ConstraintLayoutTag(

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayoutTag.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayoutTag.kt
@@ -33,11 +33,12 @@ import androidx.compose.ui.unit.Density
  * @param tag A string to represent a group of Composables that may be affected by a
  * ConstraintLayout function. Eg: The `Variables` block in a JSON5 based [ConstraintSet]
  */
-fun Modifier.layoutId(layoutId: String, tag: String? = null) = this.run {
+fun Modifier.layoutId(layoutId: String, tag: String? = null): Modifier {
     if (tag == null) {
-        this.layoutId(layoutId)
+        // Fallback to androidx.compose.ui.layout.layoutId
+        return this.layoutId(layoutId)
     } else {
-        then(
+        return this.then(
             ConstraintLayoutTag(
                 constraintLayoutId = layoutId,
                 constraintLayoutTag = tag,

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/dsl/Guidelines.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/dsl/Guidelines.kt
@@ -28,11 +28,11 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.ConstraintSet
+import androidx.constraintlayout.compose.layoutId
 import com.example.constraintlayout.verification.dsl.DslVerification.TwoBoxConstraintSet
 
 @Preview

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/dsl/LoginUi.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/dsl/LoginUi.kt
@@ -24,12 +24,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
-import androidx.constraintlayout.compose.ConstraintSet
 import androidx.constraintlayout.compose.Dimension
 import com.example.constraintlayout.R
 


### PR DESCRIPTION
- removed some redundant MotionLayout code
- modified and documented Modifier.layoutId Api so that it stops
conflicting with compose.ui.layout.layoutId Api in autocomplete