### PR TITLE
[Compose] Remeasure MotionLayout on child size change

### DIFF
--- a/projects/ComposeConstraintLayout/app/src/androidTest/java/com/example/constraintlayout/VerificationUtils.kt
+++ b/projects/ComposeConstraintLayout/app/src/androidTest/java/com/example/constraintlayout/VerificationUtils.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.constraintlayout
+
+import junit.framework.TestCase
+
+internal fun parseBaselineResults(rawString: String): MutableMap<String, String> {
+    return rawString.split(";").mapNotNull {
+        val nameValue = it.takeIf { it.isNotBlank() }?.trimIndent()?.split("=")
+        if (nameValue?.size == 2) {
+            Pair(nameValue[0], nameValue[1])
+        } else {
+            null
+        }
+    }.toMap(mutableMapOf())
+}
+
+internal fun checkTest(
+    baselineResults: MutableMap<String, String>,
+    results: Map<String, String>
+) {
+    var failed = false
+    var failedCount = 0
+    for (result in results) {
+        if (baselineResults.contains(result.key)) {
+            if (baselineResults[result.key] != result.value) {
+                println("----------")
+                println("Error in Composable: ${result.key}")
+                println("Expected: ${baselineResults[result.key]}")
+                println("Was: ${result.value}")
+                println("----------")
+                failed = true
+                failedCount++
+            }
+            baselineResults.remove(result.key)
+        } else {
+            println("----------")
+            println("New Composable Result: ${result.key}")
+            println("----------")
+            failed = true
+            failedCount++
+        }
+    }
+    for (baseline in baselineResults) {
+        println("----------")
+        println("Missing result for: ${baseline.key}")
+        println("----------")
+        failed = true
+        failedCount++
+    }
+    if (failed) {
+        println("----------")
+        println("$failedCount Composables failed")
+        println("New Baseline:")
+        val base = results.map { "${it.key}=${it.value}" }.joinToString(";\n")
+        // TODO: Find a better way to output the result, so that it's easy to update the
+        //  baseline (results.txt), alternatively, reduce the amount of text in the file
+
+        // You can update results.txt by placing a breakpoint here in debugging mode and copying
+        // the contents of 'base' into the file.
+        TestCase.assertEquals("", base)
+        println("----------")
+    }
+}

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/ComposableInvocator.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/ComposableInvocator.kt
@@ -20,9 +20,9 @@ import androidx.compose.runtime.Composer
 import com.example.constraintlayout.verification.CommonPreviewUtilsCopy.findComposableMethod
 import java.util.*
 
-class ComposableInvocator {
+class ComposableInvocator(packageString: String, fileName: String) {
     private val supportedPackages = listOf<String>(
-        "com.example.constraintlayout.verification.dsl"
+        packageString
     )
 
     /**
@@ -30,7 +30,7 @@ class ComposableInvocator {
      * Eg: for "test" it will automatically look for "test1", "test2", ...
      */
     private val supportedFileNames = listOf<String>(
-        "DslVerification"
+        fileName
     )
 
     /**

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/motiondsl/TestUtil.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/motiondsl/TestUtil.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.constraintlayout.verification.motiondsl
+
+import androidx.annotation.FloatRange
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+import androidx.compose.ui.semantics.semantics
+import androidx.constraintlayout.compose.ConstraintSet
+import androidx.constraintlayout.compose.MotionLayout
+import androidx.constraintlayout.compose.MotionLayoutScope
+import kotlinx.coroutines.launch
+
+interface MotionTestInfo {
+    fun setProgress(
+        @FloatRange(from = 0.0, to = 1.0, fromInclusive = true, toInclusive = true)progress: Float
+    )
+
+    fun recompose()
+}
+
+internal val MotionTestInfoProviderKey = SemanticsPropertyKey<MotionTestInfo>("MotionTestInfo")
+
+internal var SemanticsPropertyReceiver.motionTestProvider by MotionTestInfoProviderKey
+
+
+@Suppress("NOTHING_TO_INLINE")
+@Composable
+internal inline fun MotionTestWrapper(
+    modifier: Modifier,
+    start: ConstraintSet,
+    end: ConstraintSet,
+    progress: Float,
+    crossinline onRecompose: @DisallowComposableCalls () -> Unit,
+    crossinline content: @Composable MotionLayoutScope.() -> Unit
+) {
+    val internalProgress = remember { mutableStateOf(0f) }
+    val lastParameterProgress = remember { mutableStateOf(progress) }
+
+    val testProgress = remember { Animatable(initialValue = 0.0f) }
+    val animateScope = rememberCoroutineScope()
+
+    if (progress != lastParameterProgress.value) {
+        internalProgress.value = progress
+        lastParameterProgress.value = progress
+    }
+    else {
+        internalProgress.value = testProgress.value
+    }
+
+    val testProvider = remember {
+        object : MotionTestInfo {
+            override fun setProgress(progress: Float) {
+                animateScope.launch {
+                    testProgress.animateTo(
+                        progress,
+                        tween(3000)
+                    )
+                }
+            }
+
+            override fun recompose() {
+                onRecompose()
+            }
+        }
+    }
+
+    MotionLayout(
+        modifier = modifier.semantics { motionTestProvider = testProvider },
+        start = start,
+        end = end,
+        progress = internalProgress.value,
+        content = content
+    )
+}

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/motiondsl/TextResize.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/verification/motiondsl/TextResize.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:JvmName("MotionDslVerificationKt")
+@file:JvmMultifileClass
+
+package com.example.constraintlayout.verification.motiondsl
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Button
+import androidx.compose.material.Divider
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintSet
+
+/**
+ * Text that resizes itself should have correct dimensions during animation
+ */
+@Preview
+@Composable
+fun Test1() {
+    var animateToEnd by remember { mutableStateOf(false) }
+    var textValue by remember { mutableStateOf("My Text") }
+
+    val progress by animateFloatAsState(targetValue = if (animateToEnd) 1.0f else 0.0f, tween(3000))
+
+    val start = remember {
+        ConstraintSet {
+            val text = createRefFor("text")
+            constrain(text) {
+                start.linkTo(parent.start, 10.dp)
+                bottom.linkTo(parent.bottom, 10.dp)
+            }
+        }
+    }
+    val end = remember {
+        ConstraintSet {
+            val text = createRefFor("text")
+            constrain(text) {
+                end.linkTo(parent.end, 10.dp)
+                top.linkTo(parent.top, 10.dp)
+            }
+        }
+    }
+    val onClick = { textValue += " appended" }
+
+    Column {
+        Row {
+            Button(onClick = { animateToEnd = !animateToEnd }) {
+                Text(text = "Run")
+            }
+            Divider(Modifier.width(10.dp))
+            Button(onClick = onClick) {
+                Text(text = "Recompose Text")
+            }
+        }
+        MotionTestWrapper(
+            modifier = Modifier.fillMaxSize(),
+            start = start,
+            end = end,
+            progress = progress,
+            onRecompose = onClick
+        ) {
+            Text(text = textValue, Modifier.layoutId("text"))
+        }
+    }
+}

--- a/projects/ComposeConstraintLayout/app/src/main/res/raw/motion_results.txt
+++ b/projects/ComposeConstraintLayout/app/src/main/res/raw/motion_results.txt
@@ -1,0 +1,1 @@
+com.example.constraintlayout.verification.motiondsl.MotionDslVerificationKt#Test1=Rect.fromLTRB(28.0, 2080.0, 161.0, 2132.0):Rect.fromLTRB(386.0, 1104.0, 694.0, 1156.0):Rect.fromLTRB(744.0, 127.0, 1052.0, 179.0)


### PR DESCRIPTION
- Code cleanup/refactor for clarity and early return conditions

- Need to remeasure the layout if the size of any child Composable
  changed externally

- Added MotionVerificationTest that tests the bounds of a MotionLayout
  composable child at three points during animation (start, half-way,
  end). It also offers a chance to recompose at the midpoint.