### PR TITLE
[Compose] Support multiple Transitions in 'constraintSetName' API

### DIFF
--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/MotionParserTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/MotionParserTest.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.core.parser.CLParser
 import androidx.constraintlayout.core.parser.CLParsingException
+import androidx.constraintlayout.core.state.TransitionParser
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
@@ -82,7 +83,7 @@ internal class MotionParserTest {
         """.trimIndent()
         // Parsing transition throws an exception but the Composable should not crash the app
         assertFailsWith<CLParsingException> {
-            parseTransition(CLParser.parse(transitionContent), coreTransition)
+            TransitionParser.parse(CLParser.parse(transitionContent), coreTransition)
         }
         coreTransition = androidx.constraintlayout.core.state.Transition()
         rule.setContent {

--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/motion/statemanager/StateToStateMotionManagerTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/motion/statemanager/StateToStateMotionManagerTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.compose.motion.statemanager
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.ui.test.TestMonotonicFrameClock
+import androidx.constraintlayout.compose.JSONMotionScene
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.withContext
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+
+internal class StateToStateMotionManagerTest {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testCorrectStartAndEnd() = runBlockingTest {
+        @Language("JSON5")
+        val content = """
+            {
+              ConstraintSets: {
+                a: {
+                  box: {
+                    width: 50, height: 50,
+                  }
+                },
+                b: {
+                  Extends: 'a',
+                },
+                c: {
+                  Extends: 'a',
+                },
+              },
+              Transitions: {
+                default: {
+                  from: 'b',
+                  to: 'c'
+                },
+                ab: {
+                  from: 'a',
+                  to: 'b'
+                }
+              }
+            }
+        """.trimIndent()
+        val motionScene = JSONMotionScene(content)
+        val progress = Animatable(0f)
+
+        val stateManager = StateToStateMotionManager(
+            scene = motionScene,
+            animatableProgress = progress,
+            animationSpec = tween(100)
+        )
+
+        var start = stateManager.startConstraintSet
+        var end = stateManager.endConstraintSet
+        var transition = stateManager.transition
+        withContext(TestMonotonicFrameClock(this, 1_000_000L)) {
+            launch {
+                stateManager.setTo("c")
+                // b -> c, default Transition
+                assertSame(start, stateManager.startConstraintSet)
+                assertSame(end, stateManager.endConstraintSet)
+                assertSame(transition, stateManager.transition)
+                assertEquals(1.0f, progress.value)
+            }.join()
+
+            launch {
+                stateManager.setTo("a")
+                // c -> a, default Transition
+                assertSame(end, stateManager.startConstraintSet)
+                assertNotSame(start, stateManager.endConstraintSet)
+                assertSame(transition, stateManager.transition)
+                assertEquals(1.0f, progress.value)
+                start = stateManager.startConstraintSet
+                end = stateManager.endConstraintSet
+            }.join()
+
+            launch {
+                stateManager.setTo("b")
+                // a -> b, Ab Transition
+                assertSame(end, stateManager.startConstraintSet)
+                assertNotSame(start, stateManager.endConstraintSet)
+                assertNotSame(transition, stateManager.transition)
+                assertEquals(1.0f, progress.value)
+                start = stateManager.startConstraintSet
+                end = stateManager.endConstraintSet
+                transition = stateManager.transition
+            }.join()
+
+            launch {
+                stateManager.setTo("a")
+                // a -> b, Ab Transition, reverse
+                assertSame(start, stateManager.startConstraintSet)
+                assertSame(end, stateManager.endConstraintSet)
+                assertSame(transition, stateManager.transition)
+                assertEquals(0.0f, progress.value)
+            }.join()
+        }
+    }
+}

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintSetParser.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintSetParser.kt
@@ -161,8 +161,6 @@ internal class OverrideValue(private var value: Float) : GeneratedValue {
     }
 }
 
-
-
 internal fun parseJSON(content: String, transition: Transition, state: Int) {
     try {
         val json = CLParser.parse(content)
@@ -312,7 +310,7 @@ internal fun parseTransitions(scene: MotionScene, json: Any) {
     (0 until elements.size).forEach { i ->
         val elementName = elements[i]
         val element = json.getObject(elementName)
-        scene.setTransitionContent(elementName, element.toJSON())
+        scene.setTransitionContentObject(elementName, element)
     }
 }
 

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/JSONMotionScene.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/JSONMotionScene.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.compose
+
+import androidx.constraintlayout.core.parser.CLObject
+import androidx.constraintlayout.core.parser.CLParser
+import androidx.constraintlayout.core.parser.CLParsingException
+import org.intellij.lang.annotations.Language
+
+internal class JSONMotionScene(@Language("json5") content: String) : EditableJSONLayout(content),
+    MotionScene {
+
+    private val constraintSetsContent = HashMap<String, String>()
+    private val transitionsContent = HashMap<String, CLObject>()
+    private var forcedProgress: Float = Float.NaN
+
+    init {
+        // call parent init here so that hashmaps are created
+        initialization()
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Accessors
+    ///////////////////////////////////////////////////////////////////////////
+
+    override fun setConstraintSetContent(name: String, content: String) {
+        constraintSetsContent[name] = content
+    }
+
+    override fun setTransitionContent(name: String, content: String) {
+        parseOrNull(content)?.let {
+            if (!transitionsContent.containsKey(name)) {
+                transitionsContent[name] = it
+            }
+        }
+    }
+
+    override fun setTransitionContentObject(name: String, parsedContent: CLObject) {
+        transitionsContent[name] = parsedContent
+    }
+
+    override fun getConstraintSet(name: String): String? {
+        return constraintSetsContent[name]
+    }
+
+    override fun getConstraintSet(index: Int): String? {
+        return constraintSetsContent.values.elementAtOrNull(index)
+    }
+
+    override fun getTransition(name: String): String? {
+        return transitionsContent[name]?.toJSON()
+    }
+
+    override fun getTransitionContentObject(name: String): CLObject? {
+        return transitionsContent[name]
+    }
+
+    override fun getTransitionsNameSet(): Set<String> {
+        return transitionsContent.keys.toSet() // return a copy
+    }
+
+    override fun getForcedProgress(): Float {
+        return forcedProgress;
+    }
+
+    override fun resetForcedProgress() {
+        forcedProgress = Float.NaN
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // on update methods
+    ///////////////////////////////////////////////////////////////////////////
+
+    override fun onNewContent(content: String) {
+        super.onNewContent(content)
+        try {
+            parseMotionSceneJSON(this, content);
+        } catch (e: Exception) {
+            // nothing (content might be invalid, sent by live edit)
+        }
+    }
+
+    override fun onNewProgress(progress: Float) {
+        forcedProgress = progress
+        signalUpdate()
+    }
+
+}

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/JSONTransition.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/JSONTransition.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.compose
+
+import androidx.constraintlayout.core.parser.CLObject
+import androidx.constraintlayout.core.parser.CLParsingException
+import androidx.constraintlayout.core.state.TransitionParser
+
+internal class JSONTransition(private val parsedContent: CLObject) : Transition {
+    override fun applyTo(transition: androidx.constraintlayout.core.state.Transition, type: Int) {
+        try {
+            TransitionParser.parse(parsedContent, transition)
+        } catch (e: CLParsingException) {
+            System.err.println("Error parsing JSON $e")
+        }
+    }
+
+    override fun getStartConstraintSetId(): String {
+        return parsedContent.getStringOrNull("from") ?: "start"
+    }
+
+    override fun getEndConstraintSetId(): String {
+        return parsedContent.getStringOrNull("to") ?: "end"
+    }
+}

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/motion/statemanager/StateToStateMotionManager.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/motion/statemanager/StateToStateMotionManager.kt
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.compose.motion.statemanager
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.AnimationVector1D
+import androidx.constraintlayout.compose.ConstraintSet
+import androidx.constraintlayout.compose.JSONConstraintSet
+import androidx.constraintlayout.compose.JSONTransition
+import androidx.constraintlayout.compose.MotionScene
+
+/**
+ * Manages the layout and animation state of MotionLayout across recompositions.
+ *
+ * @param scene Defines the possible layouts and animation parameters
+ * @param animatableProgress Effectively a callback to drive the animations
+ * @param animationSpec Defines the behavior of the progress curve over time
+ */
+@PublishedApi
+internal class StateToStateMotionManager(
+    private val scene: MotionScene,
+    private val animatableProgress: Animatable<Float, AnimationVector1D>,
+    private val animationSpec: AnimationSpec<Float>
+) {
+    // TODO: Make the Animatable progress a property of this class, expose the value with a Compose
+    //  observable delegate
+
+    /**
+     * [ConstraintSet] object to name mapping.
+     *
+     * Meant to be used so that the objects are instantiated once and if/when they are needed.
+     */
+    // TODO: Change to a more appropriate caching (cheaper, lighter, etc)
+    private val lazyConstraintSetsByName = HashMap<String, ConstraintSet>()
+
+    /**
+     * Transition object to name mapping.
+     *
+     * Meant to be used so that the objects are instantiated once and if/when they are needed.
+     */
+    // TODO: Change to a more appropriate caching (cheaper, lighter, etc)
+    private val lazyTransitionsByName =
+        HashMap<String, androidx.constraintlayout.compose.Transition>()
+
+    /**
+     * Mapping for `from` `to` declarations to their corresponding Transition name.
+     *
+     * This mapping exists to avoid
+     */
+    private val targetsToTransitionName =
+        HashMap<Pair<String, String>, String>()
+
+    /**
+     * True if the current state of the Layout is on the End [ConstraintSet].
+     */
+    private var atEnd: Boolean = false
+
+    private var transitionsNames: Set<String> = scene.getTransitionsNameSet()
+    private val defaultTransition = getTransitionInstance("default")
+
+    private var from: Pair<String, ConstraintSet>
+    private var to: Pair<String, ConstraintSet>
+
+    /**
+     * Start [ConstraintSet] to be used in MotionLayout
+     */
+    val startConstraintSet
+        get() = from.second
+
+    /**
+     * End [ConstraintSet] to be used in MotionLayout.
+     */
+    val endConstraintSet
+        get() = to.second
+
+    /**
+     * Transition to be used in MotionLayout.
+     */
+    var transition: androidx.constraintlayout.compose.Transition
+
+    init {
+        transitionsNames.mapNotNull { transitionName ->
+            // Map Transition names with their 'from' and 'to' definitions
+            val parsedObject =
+                scene.getTransitionContentObject(transitionName) ?: return@mapNotNull null
+            if (parsedObject.has("from") && parsedObject.has("to")) {
+                val fromId = parsedObject.getStringOrNull("from") ?: return@mapNotNull null
+                val toId = parsedObject.getStringOrNull("to") ?: return@mapNotNull null
+                return@mapNotNull Pair(Pair(fromId, toId), transitionName)
+            } else {
+                return@mapNotNull null
+            }
+        }.toMap(targetsToTransitionName)
+
+        // Define the initial state of the Layout
+        val fromId = defaultTransition.getStartConstraintSetId()
+        val toId = defaultTransition.getEndConstraintSetId()
+        from = fromId to getConstraintSetInstance(fromId)
+        to = toId to getConstraintSetInstance(toId)
+        transition = defaultTransition
+    }
+
+    /**
+     * Animate to the ConstraintSet defined by [targetStateName].
+     *
+     * The Transition applied to the animation depends on the from/to definitions of each
+     * Transition. The following rules apply on this order:
+     * - Transition that exactly matches the current (from) and [targetStateName] (to) ConstraintSet
+     * - Transition that matches the current state as the end (to) and the [targetStateName] as the
+     * start (from). In this case, the animation is played in reverse (1 -> 0).
+     * - Default Transition is used, regardless of from/to values. Animated forwards (0 -> 1).
+     */
+    suspend fun setTo(targetStateName: String?) {
+        if (targetStateName == null) {
+            return
+        }
+        if (atEnd && targetStateName == to.first) {
+            return
+        } else if (!atEnd && targetStateName == from.first) {
+            return
+        }
+
+        val targetInstance: ConstraintSet = try {
+            getConstraintSetInstance(targetStateName)
+        } catch (e: IllegalStateException) {
+            System.err.println(e.message) // Fail safely
+            return
+        }
+
+        val lastFrom = from.first
+        val lastTo = to.first
+
+        if (atEnd) {
+            from = to
+        }
+        to = targetStateName to targetInstance
+
+        val mayReverse = lastFrom == to.first && lastTo == from.first
+
+        // If we are at the end, we may potentially animate in reverse, but we need to check
+        // that there are no matching Transitions for the next state
+        val doReverse =
+            atEnd && mayReverse && !targetsToTransitionName.containsKey(Pair(from.first, to.first))
+
+        var progressInitialValue = 0.0f
+        var progressTargetValue = 1.0f
+
+        if (doReverse) {
+            // Setup to animate on reverse
+            val aux = to
+            to = from
+            from = aux
+            progressInitialValue = 1.0f
+            progressTargetValue = 0.0f
+        }
+
+        // Update transition
+        transition =
+            getTransitionInstance(targetsToTransitionName[Pair(from.first, to.first)] ?: "default")
+
+
+        if (animatableProgress.value != progressInitialValue) {
+            animatableProgress.snapTo(progressInitialValue)
+        }
+        animatableProgress.animateTo(
+            targetValue = progressTargetValue,
+            animationSpec = animationSpec
+        )
+
+        // Update indicator after finishing the animation
+        atEnd = !doReverse
+    }
+
+    private fun getTransitionInstance(transitionName: String): androidx.constraintlayout.compose.Transition {
+        return lazyTransitionsByName.getOrPut(transitionName) {
+            val parsedContent = scene.getTransitionContentObject(transitionName)
+            checkNotNull(parsedContent) { "Issue with content of Transition: $transitionName" }
+            JSONTransition(parsedContent)
+        }
+    }
+
+    private fun getConstraintSetInstance(constraintSetName: String): ConstraintSet {
+        return lazyConstraintSetsByName.getOrPut(constraintSetName) {
+            val content = scene.getConstraintSet(constraintSetName)
+            check(content != null) { "Content missing for ConstraintSet: $constraintSetName" }
+            JSONConstraintSet(content)
+        }
+    }
+}


### PR DESCRIPTION
Animations will appply the corresponding Transition based on the state
of the Layout, depending on which ConstraintSet are at the start/end.

See StateToStateMotionManager.kt

- Moved JSONMotionScene to a separate file
- Refactored Transition anonymous implementation into JSONTransition
- Fixed MotionParserTest.kt
