### PR TITLE
fix common typos

### DIFF
--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/utils/StopLogic.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/motion/utils/StopLogic.java
@@ -56,7 +56,7 @@ public class StopLogic extends MotionInterpolator {
     }
 
     /**
-     * Configure the stop logic base on the paramenters
+     * Configure the stop logic base on the parameters
      * @param currentPos   start position
      * @param destination  the ending position
      * @param currentVelocity  the starting velocity

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/ArrayLinkedVariables.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/ArrayLinkedVariables.java
@@ -539,7 +539,7 @@ public class ArrayLinkedVariables implements ArrayRow.ArrayRowVariables {
     }
 
     /**
-     * Get the next index in in mArrayIndices given the current one
+     * Get the next index in mArrayIndices given the current one
      * @param index
      * @return
      */


### PR DESCRIPTION
Fix two api errors that was complained by ASOP Lint check.

1. Common typo found: "index in in mArrayIndices" -- should it be "index in mArrayIndices"?  in /src/main/java/androidx/constraintlayout/core/ArrayLinkedVariables.java#542
2. Common typo found: "paramenters" -- should it be "parameters"? in /src/main/java/androidx/constraintlayout/motion/utils/StopLogic.java#59