### PR TITLE
Fix for gradlew build

### DIFF
--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/motion/utils/Schlick.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/motion/utils/Schlick.java
@@ -17,7 +17,7 @@
 package androidx.constraintlayout.core.motion.utils;
 
 /**
- * Schlick’s bias and gain functions
+ * Schlick's bias and gain functions
  * curve for use in an easing function including quantize functions
  */
 public class Schlick extends Easing {

--- a/constraintlayout/gradle.properties
+++ b/constraintlayout/gradle.properties
@@ -10,3 +10,4 @@ core.version=1.1.0-alpha01
 compose.version=1.1.0-alpha01
 tools.version=1.0.0-alpha05
 swing.version=1.0.0-alpha05
+org.gradle.java.home=/Applications/Android Studio.app/Contents/jre/Contents/Home


### PR DESCRIPTION
Fix for issues faced while setting up the project.
* Using android studio's default JAVA_HOME for ./gradlew build
* There was one typo in documentation which was causing build fail.