### PR TITLE
[Compose] Unify internal MotionLayout calls

### DIFF
--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayout.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayout.kt
@@ -658,7 +658,7 @@ fun Dimension.MaxCoercible.atMost(dp: Dp): Dimension =
     (this as DimensionDescription).also { it.max = dp }
 
 /**
- * Sets the upper bound of the current [Dimension] to be the [Wrap] size of the child.
+ * Sets the upper bound of the current [Dimension] to be the [WRAP_DIMENSION] size of the child.
  */
 val Dimension.MaxCoercible.atMostWrapContent: Dimension
     get() = (this as DimensionDescription).also { it.maxSymbol = WRAP_DIMENSION }
@@ -779,7 +779,7 @@ internal abstract class EditableJSONLayout(@Language("json5") content: String) :
     }
 
     // region Accessors
-    fun setUpdateFlag(needsUpdate: MutableState<Long>) {
+    override fun setUpdateFlag(needsUpdate: MutableState<Long>) {
         updateFlag = needsUpdate
     }
 
@@ -805,7 +805,7 @@ internal abstract class EditableJSONLayout(@Language("json5") content: String) :
         return debugName
     }
 
-    fun getForcedDrawDebug(): MotionLayoutDebugFlags {
+    override fun getForcedDrawDebug(): MotionLayoutDebugFlags {
         return forcedDrawDebug
     }
 
@@ -854,10 +854,6 @@ internal abstract class EditableJSONLayout(@Language("json5") content: String) :
         } catch (e: Exception) {
             // nothing (content might be invalid, sent by live edit)
         }
-    }
-
-    protected open fun onNewProgress(progress: Float) {
-        // nothing for ConstraintSet
     }
 
     fun onNewDimensions(width: Int, height: Int) {
@@ -959,6 +955,20 @@ interface LayoutInformationReceiver {
     fun getLayoutInformationMode(): LayoutInfoFlags
     fun getForcedWidth(): Int
     fun getForcedHeight(): Int
+    fun setUpdateFlag(needsUpdate: MutableState<Long>)
+    fun getForcedDrawDebug(): MotionLayoutDebugFlags
+
+    /**
+     * reset the force progress flag
+     */
+    fun resetForcedProgress()
+
+    /**
+     * Get the progress of the force progress
+     */
+    fun getForcedProgress(): Float
+
+    fun onNewProgress(progress: Float)
 }
 
 @PublishedApi

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintSet.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintSet.kt
@@ -38,6 +38,7 @@ interface ConstraintSet {
     fun isDirty(measurables: List<Measurable>): Boolean = true
 }
 
+@Immutable
 internal interface DerivedConstraintSet : ConstraintSet {
     /**
      * [ConstraintSet] that this instance will derive its constraints from.

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/DslConstraintSet.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/DslConstraintSet.kt
@@ -16,9 +16,12 @@
 
 package androidx.constraintlayout.compose
 
+import androidx.compose.runtime.Immutable
+
 /**
  * [ConstraintSet] implementation used in the kotlin DSL.
  */
+@Immutable
 internal class DslConstraintSet constructor(
     val description: ConstraintSetScope.() -> Unit,
     override val extendFrom: ConstraintSet? = null

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/JSONConstraintSet.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/JSONConstraintSet.kt
@@ -16,6 +16,7 @@
 
 package androidx.constraintlayout.compose
 
+import androidx.compose.runtime.Immutable
 import androidx.compose.ui.layout.Measurable
 import androidx.constraintlayout.core.parser.CLKey
 import androidx.constraintlayout.core.parser.CLParser
@@ -24,6 +25,7 @@ import androidx.constraintlayout.core.state.ConstraintSetParser
 import androidx.constraintlayout.core.state.Transition
 import org.intellij.lang.annotations.Language
 
+@Immutable
 internal class JSONConstraintSet(
     @Language("json5") content: String,
     @Language("json5") overrideVariables: String? = null,
@@ -71,7 +73,6 @@ internal class JSONConstraintSet(
         // TODO: Need to better handle half parsed JSON and/or incorrect states.
         try {
             ConstraintSetParser.parseJSON(getCurrentContent(), state, layoutVariables)
-
             _isDirty = false
         } catch (e: Exception) {
             // nothing (content might be invalid, sent by live edit)
@@ -106,5 +107,18 @@ internal class JSONConstraintSet(
         for (name in overridedVariables.keys) {
             layoutVariables.putOverride(name, overridedVariables[name]!!)
         }
+    }
+
+    override fun resetForcedProgress() {
+        // Nothing for ConstraintSet
+    }
+
+    override fun getForcedProgress(): Float {
+        // Nothing for ConstraintSet
+        return 0f
+    }
+
+    override fun onNewProgress(progress: Float) {
+        // Nothing for ConstraintSet
     }
 }

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionDragHandler.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionDragHandler.kt
@@ -19,7 +19,6 @@ package androidx.constraintlayout.compose
 import android.annotation.SuppressLint
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
@@ -31,32 +30,6 @@ import androidx.compose.ui.unit.Velocity
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.isActive
-
-/**
- * Helper modifier for MotionLayout to support OnSwipe in Transitions.
- *
- * @see Modifier.pointerInput
- * @see TransitionHandler
- */
-@SuppressLint("UnnecessaryComposedModifier")
-@Suppress("NOTHING_TO_INLINE")
-@PublishedApi
-internal inline fun Modifier.motionPointerInput(
-    key: Any = Unit,
-    progressState: MutableState<Float>,
-    measurer: MotionMeasurer
-): Modifier {
-    val motionProgress: MotionProgress =
-        object : MotionProgress {
-            override val progress: Float
-                get() = progressState.value
-
-            override suspend fun updateProgress(newProgress: Float) {
-                progressState.value = newProgress
-            }
-        }
-    return this.motionPointerInput(key, motionProgress, measurer)
-}
 
 /**
  * Helper modifier for MotionLayout to support OnSwipe in Transitions.

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionLayout.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionLayout.kt
@@ -56,10 +56,10 @@ import kotlinx.coroutines.launch
 inline fun MotionLayout(
     start: ConstraintSet,
     end: ConstraintSet,
+    modifier: Modifier = Modifier,
     transition: Transition? = null,
     progress: Float,
     debug: EnumSet<MotionLayoutDebugFlags> = EnumSet.of(MotionLayoutDebugFlags.NONE),
-    modifier: Modifier = Modifier,
     optimizationLevel: Int = Optimizer.OPTIMIZATION_STANDARD,
     crossinline content: @Composable MotionLayoutScope.() -> Unit
 ) {
@@ -87,8 +87,8 @@ inline fun MotionLayout(
 inline fun MotionLayout(
     motionScene: MotionScene,
     progress: Float,
-    debug: EnumSet<MotionLayoutDebugFlags> = EnumSet.of(MotionLayoutDebugFlags.NONE),
     modifier: Modifier = Modifier,
+    debug: EnumSet<MotionLayoutDebugFlags> = EnumSet.of(MotionLayoutDebugFlags.NONE),
     optimizationLevel: Int = Optimizer.OPTIMIZATION_STANDARD,
     crossinline content: @Composable (MotionLayoutScope.() -> Unit),
 ) {
@@ -118,10 +118,10 @@ inline fun MotionLayout(
 @Composable
 inline fun MotionLayout(
     motionScene: MotionScene,
-    constraintSetName: String? = null,
-    animationSpec: AnimationSpec<Float> = tween<Float>(),
-    debug: EnumSet<MotionLayoutDebugFlags> = EnumSet.of(MotionLayoutDebugFlags.NONE),
     modifier: Modifier = Modifier,
+    constraintSetName: String? = null,
+    animationSpec: AnimationSpec<Float> = tween(),
+    debug: EnumSet<MotionLayoutDebugFlags> = EnumSet.of(MotionLayoutDebugFlags.NONE),
     optimizationLevel: Int = Optimizer.OPTIMIZATION_STANDARD,
     noinline finishedAnimationListener: (() -> Unit)? = null,
     crossinline content: @Composable (MotionLayoutScope.() -> Unit)
@@ -144,11 +144,11 @@ inline fun MotionLayout(
 inline fun MotionLayout(
     start: ConstraintSet,
     end: ConstraintSet,
+    modifier: Modifier = Modifier,
     transition: Transition? = null,
     progress: Float,
     debug: EnumSet<MotionLayoutDebugFlags> = EnumSet.of(MotionLayoutDebugFlags.NONE),
     informationReceiver: LayoutInformationReceiver? = null,
-    modifier: Modifier = Modifier,
     optimizationLevel: Int = Optimizer.OPTIMIZATION_STANDARD,
     crossinline content: @Composable (MotionLayoutScope.() -> Unit)
 ) {
@@ -166,15 +166,15 @@ inline fun MotionLayout(
     )
 }
 
-@OptIn(ExperimentalMotionApi::class)
+@ExperimentalMotionApi
 @PublishedApi
 @Composable
 internal inline fun MotionLayoutCore(
     motionScene: MotionScene,
-    constraintSetName: String? = null,
-    animationSpec: AnimationSpec<Float> = tween<Float>(),
-    debugFlag: MotionLayoutDebugFlags = MotionLayoutDebugFlags.NONE,
     modifier: Modifier = Modifier,
+    constraintSetName: String? = null,
+    animationSpec: AnimationSpec<Float> = tween(),
+    debugFlag: MotionLayoutDebugFlags = MotionLayoutDebugFlags.NONE,
     optimizationLevel: Int = Optimizer.OPTIMIZATION_STANDARD,
     noinline finishedAnimationListener: (() -> Unit)? = null,
     crossinline content: @Composable (MotionLayoutScope.() -> Unit)
@@ -211,7 +211,8 @@ internal inline fun MotionLayoutCore(
     }
 
     val targetConstraintSet = remember(motionScene, constraintSetName) {
-        val targetEndContent = constraintSetName?.let { motionScene.getConstraintSet(constraintSetName) }
+        val targetEndContent =
+            constraintSetName?.let { motionScene.getConstraintSet(constraintSetName) }
         targetEndContent?.let { ConstraintSet(targetEndContent) }
     }
 
@@ -270,8 +271,8 @@ internal inline fun MotionLayoutCore(
 internal inline fun MotionLayoutCore(
     motionScene: MotionScene,
     progress: Float,
-    debug: EnumSet<MotionLayoutDebugFlags> = EnumSet.of(MotionLayoutDebugFlags.NONE),
     modifier: Modifier = Modifier,
+    debug: EnumSet<MotionLayoutDebugFlags> = EnumSet.of(MotionLayoutDebugFlags.NONE),
     optimizationLevel: Int = Optimizer.OPTIMIZATION_STANDARD,
     crossinline content: @Composable (MotionLayoutScope.() -> Unit),
 ) {
@@ -316,11 +317,11 @@ internal inline fun MotionLayoutCore(
 internal inline fun MotionLayoutCore(
     start: ConstraintSet,
     end: ConstraintSet,
+    modifier: Modifier = Modifier,
     transition: TransitionImpl? = null,
     motionProgress: MotionProgress,
     debugFlag: MotionLayoutDebugFlags = MotionLayoutDebugFlags.NONE,
     informationReceiver: LayoutInformationReceiver? = null,
-    modifier: Modifier = Modifier,
     optimizationLevel: Int = Optimizer.OPTIMIZATION_STANDARD,
     crossinline content: @Composable MotionLayoutScope.() -> Unit
 ) {
@@ -448,6 +449,7 @@ internal inline fun MotionLayoutCore(
     )
 }
 
+@Suppress("unused")
 @LayoutScopeMarker
 class MotionLayoutScope @PublishedApi internal constructor(
     measurer: MotionMeasurer,
@@ -611,7 +613,7 @@ internal fun UpdateWithForcedIfNoUserChange(
     val forcedProgress = informationReceiver.getForcedProgress()
 
     // Save the initial progress
-    val lastUserProgress = remember { Ref<Float>().apply { value = currentUserProgress} }
+    val lastUserProgress = remember { Ref<Float>().apply { value = currentUserProgress } }
 
     if (!forcedProgress.isNaN() && lastUserProgress.value == currentUserProgress) {
         // Use the forced progress if the user progress hasn't changed

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionScene.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionScene.kt
@@ -19,7 +19,6 @@ package androidx.constraintlayout.compose
 import android.annotation.SuppressLint
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.remember
 import androidx.constraintlayout.core.state.ConstraintSetParser
 import androidx.constraintlayout.core.state.CoreMotionScene
@@ -30,10 +29,7 @@ import org.intellij.lang.annotations.Language
  * Information for MotionLayout to animate between multiple [ConstraintSet]s.
  */
 @Immutable
-interface MotionScene : CoreMotionScene {
-    fun setUpdateFlag(needsUpdate: MutableState<Long>)
-    fun getForcedDrawDebug(): MotionLayoutDebugFlags
-}
+interface MotionScene : CoreMotionScene
 
 /**
  * Parses the given JSON5 into a [MotionScene].

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/Transition.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/Transition.kt
@@ -20,7 +20,6 @@ import android.annotation.SuppressLint
 import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
@@ -56,16 +55,14 @@ fun Transition(@Language("json5") content: String): Transition? {
             Log.e("CML", "Error parsing JSON $e")
             null
         }
-        mutableStateOf(
-            if (parsed != null) {
-                val pixelDp = CorePixelDp { dpValue -> dpValue * dpToPixel }
-                TransitionImpl(parsed, pixelDp)
-            } else {
-                null
-            }
-        )
+        if (parsed != null) {
+            val pixelDp = CorePixelDp { dpValue -> dpValue * dpToPixel }
+            TransitionImpl(parsed, pixelDp)
+        } else {
+            null
+        }
     }
-    return transition.value
+    return transition
 }
 
 /**

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/TransitionHandler.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/TransitionHandler.kt
@@ -38,15 +38,15 @@ internal class TransitionHandler(
     /**
      * The [motionProgress] is updated based on the [Offset] from a single drag event.
      */
-    suspend fun updateProgressOnDrag(dragAmount: Offset) {
+    fun updateProgressOnDrag(dragAmount: Offset) {
         val progressDelta = transition.dragToProgress(
-            motionProgress.progress,
+            motionProgress.currentProgress,
             motionMeasurer.layoutCurrentWidth,
             motionMeasurer.layoutCurrentHeight,
             dragAmount.x,
             dragAmount.y
         )
-        var newProgress = motionProgress.progress + progressDelta
+        var newProgress = motionProgress.currentProgress + progressDelta
         newProgress = newProgress.coerceIn(0f, 1f)
         motionProgress.updateProgress(newProgress)
     }
@@ -57,7 +57,7 @@ internal class TransitionHandler(
      */
     suspend fun onTouchUp(velocity: Velocity) {
         coroutineContext.monotonicFrameClock.withFrameNanos { timeNanos ->
-            transition.setTouchUp(motionProgress.progress, timeNanos, velocity.x, velocity.y)
+            transition.setTouchUp(motionProgress.currentProgress, timeNanos, velocity.x, velocity.y)
         }
     }
 
@@ -76,6 +76,6 @@ internal class TransitionHandler(
      * Returns true if the progress is still expected to be updated by [updateProgressWhileTouchUp].
      */
     fun pendingProgressWhileTouchUp(): Boolean {
-        return transition.isTouchNotDone(motionProgress.progress)
+        return transition.isTouchNotDone(motionProgress.currentProgress)
     }
 }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/CoreMotionScene.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/CoreMotionScene.java
@@ -49,16 +49,6 @@ public interface CoreMotionScene {
     void setDebugName(String name);
 
     /**
-     * reset the force progress flag
-     */
-    void resetForcedProgress();
-
-    /**
-     * Get the progress of the force progress
-     */
-    float getForcedProgress();
-
-    /**
      * get a transition give the name
      *
      * @param str the name of the transition

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/MainActivity.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/MainActivity.kt
@@ -140,7 +140,7 @@ class MainActivity : AppCompatActivity() {
 
         demos.add(object : CompFunc { @Composable override fun Run() { MotionExample7() } })
         demos.add(object : CompFunc { @Composable override fun Run() { ScreenExample21() } })
-        demos.add(object : CompFunc { @Composable override fun Run() { ScreenExample22() } })
+        demos.add(object : CompFunc { @Composable override fun Run() { Playground() } })
         demos.add(object : CompFunc { @Composable override fun Run() { ResizeExample1() } })
 
         demos.add(object : CompFunc { @Composable override fun Run() { ExampleLayout() } })

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/OnSwipeExperiment.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/OnSwipeExperiment.kt
@@ -58,6 +58,7 @@ fun OnSwipeExperiment() {
         // language=json5
         """
        {
+         Header: { exportAs: 'swipeExpr' },
          ConstraintSets: {
            start: {
              box: {

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/test.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/test.kt
@@ -1649,7 +1649,7 @@ public fun ScreenExample20() {
 
 @Preview(group = "guidelines")
 @Composable
-public fun ScreenExample22() {
+fun Playground() {
     ConstraintLayout(
         ConstraintSet("""
         {


### PR DESCRIPTION
There's now only one call to MultiMeasureLayout, so all public MotionLayout methods eventually call that method as well.

Fixed Modifier order warning: should be first optional parameter. Note that this may cause some breakages.