### PR TITLE
[Compose] Fix chains for JSON and DSL

### DIFF
--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintSetParser.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintSetParser.java
@@ -780,7 +780,6 @@ public class ConstraintSetParser {
                             CLArray array = (CLArray) chainElement;
                             if (array.size() > 0) {
                                 String id = array.get(0).content();
-                                chain.add(id);
                                 float weight = Float.NaN;
                                 float preMargin = Float.NaN;
                                 float postMargin = Float.NaN;

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/ChainReference.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/ChainReference.java
@@ -16,6 +16,8 @@
 
 package androidx.constraintlayout.core.state.helpers;
 
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.UNKNOWN;
+
 import androidx.constraintlayout.core.state.HelperReference;
 import androidx.constraintlayout.core.state.State;
 
@@ -70,12 +72,12 @@ public class ChainReference extends HelperReference {
 
   protected float getWeight(String id) {
        if (mMapWeights == null) {
-           return -1;
+           return UNKNOWN;
        }
        if (mMapWeights.containsKey(id)) {
            return mMapWeights.get(id);
        }
-       return 1;
+       return UNKNOWN;
     }
 
     protected float getPostMargin(String id) {

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/HorizontalChainReference.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/HorizontalChainReference.java
@@ -16,6 +16,8 @@
 
 package androidx.constraintlayout.core.state.helpers;
 
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.UNKNOWN;
+
 import androidx.constraintlayout.core.state.ConstraintReference;
 import androidx.constraintlayout.core.state.State;
 import androidx.constraintlayout.core.widgets.ConstraintWidget;
@@ -66,7 +68,10 @@ public class HorizontalChainReference extends ChainReference {
                 previous.endToStart(reference.getKey()).margin(getPostMargin(preKey));
                 reference.startToEnd(previous.getKey()).margin(getPreMargin(refKey));
             }
-            reference.setHorizontalChainWeight(getWeight(key.toString()));
+            float weight = getWeight(key.toString());
+            if (weight != UNKNOWN) {
+                reference.setHorizontalChainWeight(weight);
+            }
             previous = reference;
         }
 

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/VerticalChainReference.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/VerticalChainReference.java
@@ -16,6 +16,8 @@
 
 package androidx.constraintlayout.core.state.helpers;
 
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.UNKNOWN;
+
 import androidx.constraintlayout.core.state.ConstraintReference;
 import androidx.constraintlayout.core.state.State;
 import androidx.constraintlayout.core.widgets.ConstraintWidget;
@@ -57,7 +59,10 @@ public class VerticalChainReference extends ChainReference {
                 previous.bottomToTop(reference.getKey()).margin(getPostMargin(preKey));
                 reference.topToBottom(previous.getKey()).margin(getPreMargin(refKey));
             }
-            reference.setVerticalChainWeight(getWeight(key.toString()));
+            float weight = getWeight(key.toString());
+            if (weight != UNKNOWN) {
+                reference.setVerticalChainWeight(weight);
+            }
             previous = reference;
         }
 


### PR DESCRIPTION
The weight for JSON and DSL would get ignored.

For the DSL, the weight value would get overriden by ChainReference.

In JSON, the reference was being added twice per element when using
weight, ultimately, only the first addition was being used, which didn't
include values for weight and margins.