### PR TITLE
[Grid] add examples for the medium article

### DIFF
--- a/projects/GridExperiments/app/src/main/java/android/support/constraint/app/MainActivity.java
+++ b/projects/GridExperiments/app/src/main/java/android/support/constraint/app/MainActivity.java
@@ -32,6 +32,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * MainActivity for Grid helper
@@ -148,13 +150,15 @@ public class MainActivity extends AppCompatActivity {
     private static int[] getLayouts( ) {
         ArrayList<String> list = new ArrayList<>();
         Field[] f = R.layout.class.getDeclaredFields();
+        Set<String> layouts = new HashSet<>(Arrays.asList("activity_main",
+                "column_in_row", "row_in_column"));
 
         int []ret = new int[f.length];
          int count = 0;
         for (int i = 0; i < f.length; i++) {
             try {
                 String name = f[i].getName();
-                if (!name.contains("_") || name.equals("activity_main")) {
+                if (!name.contains("_") || layouts.contains(name)) {
                     ret[count++] = f[i].getInt(null);
                 }
             } catch (IllegalAccessException e) {

--- a/projects/GridExperiments/app/src/main/res/layout/column.xml
+++ b/projects/GridExperiments/app/src/main/res/layout/column.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.helper.widget.Grid
+        android:id="@+id/grid"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="5dp"
+        app:constraint_referenced_ids="btn0,btn1,btn2,btn3,btn4"
+        app:grid_columns="1"
+        app:grid_rows="0" />
+
+    <Button
+        android:id="@+id/btn0"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="0"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="57dp" />
+
+    <Button
+        android:id="@+id/btn1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="1"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="4dp"
+        tools:layout_editor_absoluteY="301dp" />
+
+    <Button
+        android:id="@+id/btn2"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="2"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="301dp" />
+
+    <Button
+        android:id="@+id/btn3"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="3"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="141dp"
+        tools:layout_editor_absoluteY="545dp" />
+
+    <Button
+        android:id="@+id/btn4"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="4"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="57dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/projects/GridExperiments/app/src/main/res/layout/column_in_row.xml
+++ b/projects/GridExperiments/app/src/main/res/layout/column_in_row.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.helper.widget.Grid
+        android:id="@+id/row"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="5dp"
+        app:constraint_referenced_ids="btn0,column,btn1,btn2,btn3"
+        app:grid_horizontalGaps="10dp"
+        app:grid_columns="0"
+        app:grid_rows="1" />
+
+    <androidx.constraintlayout.helper.widget.Grid
+        android:id="@+id/column"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_margin="5dp"
+        app:constraint_referenced_ids="btn4,btn5,btn6"
+        app:grid_horizontalGaps="10dp"
+        app:grid_columns="1"
+        app:grid_rows="0" />
+
+    <Button
+        android:id="@+id/btn0"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="0"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="57dp" />
+
+    <Button
+        android:id="@+id/btn1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="1"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="4dp"
+        tools:layout_editor_absoluteY="301dp" />
+
+    <Button
+        android:id="@+id/btn2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="2"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="301dp" />
+
+    <Button
+        android:id="@+id/btn3"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="3"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="141dp"
+        tools:layout_editor_absoluteY="545dp" />
+
+    <Button
+        android:id="@+id/btn4"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="4"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="57dp" />
+
+    <Button
+        android:id="@+id/btn5"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="5"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="141dp"
+        tools:layout_editor_absoluteY="545dp" />
+
+    <Button
+        android:id="@+id/btn6"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="6"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="57dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/projects/GridExperiments/app/src/main/res/layout/dialer.xml
+++ b/projects/GridExperiments/app/src/main/res/layout/dialer.xml
@@ -9,7 +9,7 @@
         android:id="@+id/grid"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:constraint_referenced_ids="calculatorText,btn1,btn2,btn3,btn4,btn5,btn6,btn7,btn8,btn9,star,btn0,pound,call"
+        app:constraint_referenced_ids="dialerText,btn1,btn2,btn3,btn4,btn5,btn6,btn7,btn8,btn9,star,btn0,pound,call"
         app:grid_columns="3"
         app:grid_rows="6"
         app:grid_horizontalGaps="5dp"
@@ -17,14 +17,6 @@
         app:grid_orientation="horizontal"
         app:grid_spans="0:1x3"
         app:grid_skips="15:1x1"/>
-
-
-    <TextView
-        android:id="@+id/dialerText"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:background="@color/cardview_shadow_start_color"
-        android:text="8" />
 
     <Button
         android:id="@+id/call"
@@ -53,7 +45,7 @@
 
 
     <TextView
-        android:id="@+id/calculatorText"
+        android:id="@+id/dialerText"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:background="@color/cardview_shadow_start_color"

--- a/projects/GridExperiments/app/src/main/res/layout/keypad.xml
+++ b/projects/GridExperiments/app/src/main/res/layout/keypad.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:background="@color/cardview_shadow_start_color"
+        android:gravity="bottom|right"
+        android:text="100"
+        android:textSize="70dp"
+        android:layout_margin="7dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHeight_percent="0.33"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/btn0"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="0"
+        android:textSize="30dp"
+        app:layout_constraintHeight_percent="0.16"
+        app:layout_constraintWidth_percent="0.32"
+        app:layout_constraintTop_toBottomOf="@id/btn8"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <Button
+        android:id="@+id/btn1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="1"
+        android:textSize="30dp"
+        app:layout_constraintHeight_percent="0.16"
+        app:layout_constraintWidth_percent="0.32"
+        app:layout_constraintEnd_toStartOf="@+id/btn2"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="@id/textView"
+        app:layout_constraintTop_toBottomOf="@id/textView" />
+
+    <Button
+        android:id="@+id/btn2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="2"
+        android:textSize="30dp"
+        app:layout_constraintHeight_percent="0.16"
+        app:layout_constraintWidth_percent="0.32"
+        app:layout_constraintEnd_toStartOf="@+id/btn3"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@id/btn1"
+        app:layout_constraintTop_toBottomOf="@id/textView"/>
+
+    <Button
+        android:id="@+id/btn3"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="3"
+        android:textSize="30dp"
+        app:layout_constraintHeight_percent="0.16"
+        app:layout_constraintWidth_percent="0.32"
+        app:layout_constraintEnd_toEndOf="@id/textView"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@id/btn2"
+        app:layout_constraintTop_toBottomOf="@id/textView"/>
+
+    <Button
+        android:id="@+id/btn4"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="4"
+        android:textSize="30dp"
+        app:layout_constraintHeight_percent="0.16"
+        app:layout_constraintWidth_percent="0.32"
+        app:layout_constraintEnd_toStartOf="@+id/btn5"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/btn1" />
+
+    <Button
+        android:id="@+id/btn5"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="5"
+        android:textSize="30dp"
+        app:layout_constraintHeight_percent="0.16"
+        app:layout_constraintWidth_percent="0.32"
+        app:layout_constraintEnd_toStartOf="@+id/btn6"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@id/btn4"
+        app:layout_constraintTop_toBottomOf="@id/btn2" />
+
+    <Button
+        android:id="@+id/btn6"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="6"
+        android:textSize="30dp"
+        app:layout_constraintHeight_percent="0.16"
+        app:layout_constraintWidth_percent="0.32"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@id/btn5"
+        app:layout_constraintTop_toBottomOf="@id/btn3"  />
+
+    <Button
+        android:id="@+id/btn7"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="7"
+        android:textSize="30dp"
+        app:layout_constraintHeight_percent="0.16"
+        app:layout_constraintWidth_percent="0.32"
+        app:layout_constraintEnd_toStartOf="@+id/btn8"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/btn4" />
+
+    <Button
+        android:id="@+id/btn8"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="8"
+        android:textSize="30dp"
+        app:layout_constraintHeight_percent="0.16"
+        app:layout_constraintWidth_percent="0.32"
+        app:layout_constraintEnd_toStartOf="@+id/btn9"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@id/btn7"
+        app:layout_constraintTop_toBottomOf="@id/btn5" />
+
+    <Button
+        android:id="@+id/btn9"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="9"
+        android:textSize="30dp"
+        app:layout_constraintHeight_percent="0.16"
+        app:layout_constraintWidth_percent="0.32"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@id/btn8"
+        app:layout_constraintTop_toBottomOf="@id/btn6"  />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/projects/GridExperiments/app/src/main/res/layout/medium.xml
+++ b/projects/GridExperiments/app/src/main/res/layout/medium.xml
@@ -9,80 +9,17 @@
         android:id="@+id/grid"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:constraint_referenced_ids="calculatorText,btn0,clear,neg,percent,div,btn7,btn8,btn9,mult,btn4,btn5,btn6,sub,btn1,btn2,btn3,plus,dot,equal"
-        app:grid_columns="4"
-        app:grid_rows="7"
+        android:layout_margin="10dp"
+        app:constraint_referenced_ids="dialerText,btn1,btn2,btn3,btn4,btn5,btn6,btn7,btn8,btn9,btn0"
+        app:grid_columns="3"
+        app:grid_rows="5"
+        app:grid_skips="12:1x1"
+        app:grid_spans="0:1x3"
         app:grid_horizontalGaps="5dp"
-        app:grid_verticalGaps="5dp"
-        app:grid_orientation="horizontal"
-        app:grid_spans="0:2x4,24:1x2" />
-
-    <Button
-        android:id="@+id/clear"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:textSize="30dp"
-        android:text="C" />
-
-    <Button
-        android:id="@+id/neg"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:textSize="30dp"
-        android:text="+/-" />
-
-    <Button
-        android:id="@+id/percent"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:textSize="30dp"
-        android:text="%" />
-
-    <Button
-        android:id="@+id/div"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:textSize="30dp"
-        android:text="/" />
-
-    <Button
-        android:id="@+id/mult"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:textSize="30dp"
-        android:text="X" />
-
-    <Button
-        android:id="@+id/sub"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:textSize="30dp"
-        android:text="-" />
-
-    <Button
-        android:id="@+id/plus"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:textSize="30dp"
-        android:text="+" />
-
-    <Button
-        android:id="@+id/equal"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:textSize="30dp"
-        android:text="=" />
-
-    <Button
-        android:id="@+id/dot"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:textSize="30dp"
-        android:text="." />
-
+        app:grid_rowWeights="2,1,1,1,1"/>
 
     <TextView
-        android:id="@+id/calculatorText"
+        android:id="@+id/dialerText"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:background="@color/cardview_shadow_start_color"
@@ -160,5 +97,5 @@
         android:layout_height="0dp"
         android:textSize="30dp"
         android:text="9" />
-    
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/projects/GridExperiments/app/src/main/res/layout/responsive.xml
+++ b/projects/GridExperiments/app/src/main/res/layout/responsive.xml
@@ -182,6 +182,4 @@
 
     </LinearLayout>
 
-
-
 </LinearLayout>

--- a/projects/GridExperiments/app/src/main/res/layout/row.xml
+++ b/projects/GridExperiments/app/src/main/res/layout/row.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.helper.widget.Grid
+        android:id="@+id/grid"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="5dp"
+        app:constraint_referenced_ids="btn0,btn1,btn2,btn3,btn4"
+        app:grid_horizontalGaps="10dp"
+        app:grid_columns="0"
+        app:grid_rows="1" />
+
+    <Button
+        android:id="@+id/btn0"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="0"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="57dp" />
+
+    <Button
+        android:id="@+id/btn1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="1"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="4dp"
+        tools:layout_editor_absoluteY="301dp" />
+
+    <Button
+        android:id="@+id/btn2"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="2"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="301dp" />
+
+    <Button
+        android:id="@+id/btn3"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="3"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="141dp"
+        tools:layout_editor_absoluteY="545dp" />
+
+    <Button
+        android:id="@+id/btn4"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="4"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="57dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/projects/GridExperiments/app/src/main/res/layout/row_in_column.xml
+++ b/projects/GridExperiments/app/src/main/res/layout/row_in_column.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.helper.widget.Grid
+        android:id="@+id/column"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="5dp"
+        app:constraint_referenced_ids="btn0,row,btn1"
+        app:grid_horizontalGaps="10dp"
+        app:grid_columns="1"
+        app:grid_rows="0" />
+
+    <androidx.constraintlayout.helper.widget.Grid
+        android:id="@+id/row"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_margin="5dp"
+        app:constraint_referenced_ids="btn2,innerColumn,btn3"
+        app:grid_horizontalGaps="10dp"
+        app:grid_columns="0"
+        app:grid_rows="1" />
+
+    <androidx.constraintlayout.helper.widget.Grid
+        android:id="@+id/innerColumn"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_margin="5dp"
+        app:constraint_referenced_ids="btn4,btn5,btn6"
+        app:grid_horizontalGaps="10dp"
+        app:grid_columns="1"
+        app:grid_rows="0" />
+
+    <Button
+        android:id="@+id/btn0"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="0"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="57dp" />
+
+    <Button
+        android:id="@+id/btn1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="1"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="4dp"
+        tools:layout_editor_absoluteY="301dp" />
+
+    <Button
+        android:id="@+id/btn2"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:text="2"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="301dp" />
+
+    <Button
+        android:id="@+id/btn3"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:text="3"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="141dp"
+        tools:layout_editor_absoluteY="545dp" />
+
+    <Button
+        android:id="@+id/btn4"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:text="4"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="57dp" />
+
+    <Button
+        android:id="@+id/btn5"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:text="5"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="141dp"
+        tools:layout_editor_absoluteY="545dp" />
+
+    <Button
+        android:id="@+id/btn6"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:text="6"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="57dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
The main purpose of this PR is to add examples for the medium articles, including:

**Medium**
<img width="320" alt="image" src="https://user-images.githubusercontent.com/20599348/181028727-379085ee-0542-4f7b-820f-5966a60b7050.png">

**Row**
![image](https://user-images.githubusercontent.com/20599348/176016547-1cab02ff-7f67-4fda-a70d-11465a6b795e.png)

**Column**
![image](https://user-images.githubusercontent.com/20599348/176016642-69416fc9-f0c2-473a-bdee-8c3b42cea275.png)

**column_in_row**
![image](https://user-images.githubusercontent.com/20599348/176016680-3934ebfb-9638-498d-869c-e5349f088ab1.png)

**row_in_column**
![image](https://user-images.githubusercontent.com/20599348/176016713-1b3d71fb-97e9-4875-bc27-6b51b92f8cae.png)
