### PR TITLE
[Grid] Migrate the main logic to Core with ConstrainSet

### DIFF
--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/utils/GridEngine.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/utils/GridEngine.java
@@ -1,0 +1,568 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.utils;
+
+import java.util.Arrays;
+
+/**
+ * GridEngine class contains the main logic of the Grid Helper
+ */
+public class GridEngine {
+
+    public static final int VERTICAL = 1;
+    public static final int HORIZONTAL = 0;
+    private final int MAX_ROWS = 50; // maximum number of rows can be specified.
+    private final int MAX_COLUMNS = 50; // maximum number of columns can be specified.
+    private final int DEFAULT_SIZE = 3; // default rows and columns.
+
+    /**
+     * number of rows of the grid
+     */
+    private int mRows;
+
+    /**
+     * number of rows set by the XML or API
+     */
+    private int mRowsSet;
+
+    /**
+     * How many widgets need to be placed in the Grid
+     */
+    private int mNumWidgets;
+
+    /**
+     * number of columns of the grid
+     */
+    private int mColumns;
+
+    /**
+     * number of columns set by the XML or API
+     */
+    private int mColumnsSet;
+
+    /**
+     * string format of the input Spans
+     */
+    private String mStrSpans;
+
+    /**
+     * string format of the input Skips
+     */
+    private String mStrSkips;
+
+    /**
+     * orientation of the view arrangement - vertical or horizontal
+     */
+    private int mOrientation;
+
+    /**
+     * Indicates what is the next available position to place an widget
+     */
+    private int mNextAvailableIndex = 0;
+
+    /**
+     * A boolean matrix that tracks the positions that are occupied by skips and spans
+     * true: available position
+     * false: non-available position
+     */
+    private boolean[][] mPositionMatrix;
+
+    /**
+     * A int matrix that contains the positions where a widget would constraint to at each direction
+     * Each row contains 4 values that indicate the position to constraint of a widget.
+     * Example row: [left, top, right, bottom]
+     */
+    private int[][] mConstraintMatrix;
+
+    public GridEngine() {}
+
+    public GridEngine(int rows, int columns) {
+        mRowsSet = rows;
+        mColumnsSet = columns;
+        if (rows > MAX_ROWS) {
+            mRowsSet = DEFAULT_SIZE;
+        }
+
+        if (columns > MAX_COLUMNS) {
+            mColumnsSet = DEFAULT_SIZE;
+        }
+
+        updateActualRowsAndColumns();
+        initVariables();
+    }
+
+    public GridEngine(int rows, int columns, int numWidgets) {
+        mRowsSet = rows;
+        mColumnsSet = columns;
+        mNumWidgets = numWidgets;
+
+        if (rows > MAX_ROWS) {
+            mRowsSet = DEFAULT_SIZE;
+        }
+
+        if (columns > MAX_COLUMNS) {
+            mColumnsSet = DEFAULT_SIZE;
+        }
+
+        updateActualRowsAndColumns();
+
+        if (numWidgets > mRows * mColumns || numWidgets < 1) {
+            mNumWidgets = mRows * mColumns;
+        }
+
+        initVariables();
+        fillConstraintMatrix(false);
+    }
+
+    /**
+     * Initialize the relevant variables
+     */
+    private void initVariables() {
+        mPositionMatrix = new boolean[mRows][mColumns];
+        for (boolean[] row: mPositionMatrix) {
+            Arrays.fill(row, true);
+        }
+
+        if (mNumWidgets > 0) {
+            mConstraintMatrix = new int[mNumWidgets][4];
+            for (int[] row: mConstraintMatrix) {
+                Arrays.fill(row, -1);
+            }
+        }
+    }
+
+    /**
+     * Convert a 1D index to a 2D index that has index for row and index for column
+     *
+     * @param index index in 1D
+     * @return row as its values.
+     */
+    private int getRowByIndex(int index) {
+        if (mOrientation == 1) {
+            return   index % mRows;
+
+        } else {
+            return index / mColumns;
+        }
+    }
+
+    /**
+     * Convert a 1D index to a 2D index that has index for row and index for column
+     *
+     * @param index index in 1D
+     * @return column as its values.
+     */
+    private int getColByIndex(int index) {
+        if (mOrientation == 1) {
+            return index / mRows;
+        } else {
+            return index % mColumns;
+        }
+    }
+
+    /**
+     * Check if the value of the spans/skips is valid
+     *
+     * @param str spans/skips in string format
+     * @return true if it is valid else false
+     */
+    private boolean isSpansValid(String str) {
+        if (str == null || str.isEmpty() || str.trim().isEmpty()) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * parse the skips/spans in the string format into a int matrix
+     * that each row has the information - [index, row_span, col_span]
+     * the format of the input string is index:row_spanxcol_span.
+     * index - the index of the starting position
+     * row_span - the number of rows to span
+     * col_span- the number of columns to span
+     *
+     * @param str string format of skips or spans
+     * @return a int matrix that contains skip information.
+     */
+    private int[][] parseSpans(String str) {
+        if (!isSpansValid(str)) {
+            return null;
+        }
+
+        String[] spans = str.split(",");
+        int[][] spanMatrix = new int[spans.length][3];
+
+        String[] indexAndSpan;
+        String[] rowAndCol;
+        for (int i = 0; i < spans.length; i++) {
+            indexAndSpan = spans[i].trim().split(":");
+            rowAndCol = indexAndSpan[1].split("x");
+            spanMatrix[i][0] = Integer.parseInt(indexAndSpan[0]);
+            spanMatrix[i][1] = Integer.parseInt(rowAndCol[0]);
+            spanMatrix[i][2] = Integer.parseInt(rowAndCol[1]);
+        }
+        return spanMatrix;
+    }
+
+    /**
+     * fill the constraintMatrix based on the input attributes
+     *
+     * @param isUpdate whether to update the existing grid (true) or create a new one (false)
+     */
+    private void fillConstraintMatrix(boolean isUpdate) {
+        if (isUpdate) {
+            for (int i = 0; i < mPositionMatrix.length; i++) {
+                for (int j = 0; j < mPositionMatrix[0].length; j++) {
+                    mPositionMatrix[i][j] = true;
+                }
+            }
+
+            for (int i = 0; i < mConstraintMatrix.length; i++) {
+                for (int j = 0; j < mConstraintMatrix[0].length; j++) {
+                    mConstraintMatrix[i][j] = -1;
+                }
+            }
+        }
+
+        mNextAvailableIndex = 0;
+
+        if (mStrSkips != null && !mStrSkips.trim().isEmpty()) {
+            int[][] mSkips = parseSpans(mStrSkips);
+            if (mSkips != null) {
+                handleSkips(mSkips);
+            }
+        }
+
+        if (mStrSpans != null && !mStrSpans.trim().isEmpty()) {
+            int[][] mSpans = parseSpans(mStrSpans);
+            if (mSpans != null) {
+                handleSpans(mSpans);
+            }
+        }
+
+        addAllConstraintPositions();
+    }
+
+    /**
+     * Get the next available position for widget arrangement.
+     * @return int[] -> [row, column]
+     */
+    private int getNextPosition() {
+        int position = 0;
+        boolean positionFound = false;
+
+        while (!positionFound) {
+            if (mNextAvailableIndex >= mRows * mColumns) {
+                return -1;
+            }
+
+            position = mNextAvailableIndex;
+            int row = getRowByIndex(mNextAvailableIndex);
+            int col = getColByIndex(mNextAvailableIndex);
+            if (mPositionMatrix[row][col]) {
+                mPositionMatrix[row][col] = false;
+                positionFound = true;
+            }
+
+            mNextAvailableIndex++;
+        }
+        return position;
+    }
+
+    /**
+     * add the constraint position info of a widget based on the input params
+     *
+     * @param widgetId the Id of the widget
+     * @param row row position to place the view
+     * @param column column position to place the view
+     */
+    private void addConstraintPosition(int widgetId, int row, int column,
+                                       int rowSpan, int columnSpan) {
+
+        mConstraintMatrix[widgetId][0] = column;
+        mConstraintMatrix[widgetId][1] = row;
+        mConstraintMatrix[widgetId][2] = column + columnSpan - 1;
+        mConstraintMatrix[widgetId][3] = row + rowSpan - 1;
+    }
+
+    /**
+     * Handle the span use cases
+     *
+     * @param spansMatrix a int matrix that contains span information
+     */
+    private void handleSpans(int[][] spansMatrix) {
+        for (int i = 0; i < spansMatrix.length; i++) {
+            int row = getRowByIndex(spansMatrix[i][0]);
+            int col = getColByIndex(spansMatrix[i][0]);
+            if (!invalidatePositions(row, col,
+                    spansMatrix[i][1], spansMatrix[i][2])) {
+                return;
+            }
+            addConstraintPosition(i, row, col,
+                    spansMatrix[i][1], spansMatrix[i][2]);
+        }
+    }
+
+    /**
+     * Make positions in the grid unavailable based on the skips attr
+     *
+     * @param skipsMatrix a int matrix that contains skip information
+     */
+    private void handleSkips(int[][] skipsMatrix) {
+        for(int i = 0; i < skipsMatrix.length; i++) {
+            int row = getRowByIndex(skipsMatrix[i][0]);
+            int col = getColByIndex(skipsMatrix[i][0]);
+            if (!invalidatePositions(row, col,
+                    skipsMatrix[i][1], skipsMatrix[i][2])) {
+                return;
+            }
+        }
+    }
+
+    /**
+     * Make the specified positions in the grid unavailable.
+     *
+     * @param startRow the row of the staring position
+     * @param startColumn the column of the staring position
+     * @param rowSpan how many rows to span
+     * @param columnSpan how many columns to span
+     * @return true if we could properly invalidate the positions else false
+     */
+    private boolean invalidatePositions(int startRow, int startColumn,
+                                        int rowSpan, int columnSpan) {
+        for (int i = startRow; i < startRow + rowSpan; i++) {
+            for (int j = startColumn; j < startColumn + columnSpan; j++) {
+                if (i >= mPositionMatrix.length || j >= mPositionMatrix[0].length
+                        || !mPositionMatrix[i][j]) {
+                    // the position is already occupied.
+                    return false;
+                }
+                mPositionMatrix[i][j] = false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Arrange the views in the constraint_referenced_ids
+     */
+    private void addAllConstraintPositions() {
+        int position;
+
+        for (int i = 0; i < mNumWidgets; i++) {
+
+            // Already added ConstraintPosition
+            if (leftOfWidget(i) != -1) {
+                continue;
+            }
+
+            position = getNextPosition();
+            int row = getRowByIndex(position);
+            int col = getColByIndex(position);
+            if (position == -1) {
+                // no more available position.
+                return;
+            }
+            addConstraintPosition(i, row, col, 1, 1);
+        }
+    }
+
+    /**
+     * Compute the actual rows and columns given what was set
+     * if 0,0 find the most square rows and columns that fits
+     * if 0,n or n,0 scale to fit
+     */
+    private void updateActualRowsAndColumns() {
+        if (mRowsSet == 0 || mColumnsSet == 0) {
+            if (mColumnsSet > 0) {
+                mColumns = mColumnsSet;
+                mRows = (mNumWidgets + mColumns -1) / mColumnsSet; // round up
+            } else  if (mRowsSet > 0) {
+                mRows = mRowsSet;
+                mColumns= (mNumWidgets + mRowsSet -1) / mRowsSet; // round up
+            } else { // as close to square as possible favoring more rows
+                mRows = (int)  (1.5 + Math.sqrt(mNumWidgets));
+                mColumns = (mNumWidgets + mRows -1) / mRows;
+            }
+        } else {
+            mRows = mRowsSet;
+            mColumns = mColumnsSet;
+        }
+    }
+
+    /**
+     * Set up the Grid engine.
+     */
+    public void setup() {
+        boolean isUpdate = true;
+
+        if (mConstraintMatrix == null
+                || mConstraintMatrix.length != mNumWidgets
+                || mPositionMatrix == null
+                || mPositionMatrix.length != mRows
+                || mPositionMatrix[0].length != mColumns) {
+            isUpdate = false;
+        }
+
+        if (!isUpdate) {
+            initVariables();
+        }
+
+        fillConstraintMatrix(isUpdate);
+    }
+
+    /**
+     * set new spans value and also invoke invalidate
+     *
+     * @param spans new spans value
+     */
+    public void setSpans(String spans) {
+        if (mStrSpans != null && mStrSpans.equals(spans)) {
+            return;
+        }
+
+        mStrSpans = spans;
+    }
+
+    /**
+     * set new skips value and also invoke invalidate
+     *
+     * @param skips new spans value
+     */
+    public void setSkips(String skips) {
+        if (mStrSkips != null && mStrSkips.equals(skips)) {
+            return;
+        }
+
+        mStrSkips = skips;
+
+    }
+
+    /**
+     * set new orientation value and also invoke invalidate
+     *
+     * @param orientation new orientation value
+     */
+    public void setOrientation(int orientation) {
+        if (!(orientation == HORIZONTAL || orientation == VERTICAL)) {
+            return;
+        }
+
+        if (mOrientation == orientation) {
+            return;
+        }
+
+        mOrientation = orientation;
+    }
+
+    public void setNumWidgets(int num) {
+        if (num > mRows * mColumns) {
+            return;
+        }
+
+        mNumWidgets = num;
+    }
+
+    /**
+     * set new rows value and also invoke initVariables and invalidate
+     *
+     * @param rows new rows value
+     */
+    public void setRows(int rows) {
+        if (rows > MAX_ROWS) {
+            return;
+        }
+
+        if (mRowsSet == rows) {
+            return;
+        }
+
+        mRowsSet = rows;
+        updateActualRowsAndColumns();
+
+    }
+
+    /**
+     * set new columns value and also invoke initVariables and invalidate
+     *
+     * @param columns new rows value
+     */
+    public void setColumns(int columns) {
+        if (columns > MAX_COLUMNS) {
+            return;
+        }
+
+        if (mColumnsSet == columns) {
+            return;
+        }
+
+        mColumnsSet = columns;
+        updateActualRowsAndColumns();
+    }
+
+    /**
+     * Get the boxView for the widget i to add a constraint on the left
+     *
+     * @param i the widget that has the order as i in the constraint_reference_ids
+     * @return the boxView to add a constraint on the left
+     */
+    public int leftOfWidget(int i) {
+        if (mConstraintMatrix == null || i >= mConstraintMatrix.length) {
+            return 0;
+        }
+        return mConstraintMatrix[i][0];
+    }
+
+    /**
+     * Get the boxView for the widget i to add a constraint on the top
+     *
+     * @param i the widget that has the order as i in the constraint_reference_ids
+     * @return the boxView to add a constraint on the top
+     */
+    public int topOfWidget(int i) {
+        if (mConstraintMatrix == null || i >= mConstraintMatrix.length) {
+            return 0;
+        }
+        return mConstraintMatrix[i][1];
+    }
+
+    /**
+     * Get the boxView for the widget i to add a constraint on the right
+     *
+     * @param i the widget that has the order as i in the constraint_reference_ids
+     * @return the boxView to add a constraint on the right
+     */
+    public int rightOfWidget(int i) {
+        if (mConstraintMatrix == null || i >= mConstraintMatrix.length) {
+            return 0;
+        }
+        return mConstraintMatrix[i][2];
+    }
+
+    /**
+     * Get the boxView for the widget i to add a constraint on the bottom
+     *
+     * @param i the widget that has the order as i in the constraint_reference_ids
+     * @return the boxView to add a constraint on the bottom
+     */
+    public int bottomOfWidget(int i) {
+        if (mConstraintMatrix == null || i >= mConstraintMatrix.length) {
+            return 0;
+        }
+        return mConstraintMatrix[i][3];
+    }
+}

--- a/constraintlayout/core/src/test/java/androidx/constraintlayout/core/utils/GridEngineTest.java
+++ b/constraintlayout/core/src/test/java/androidx/constraintlayout/core/utils/GridEngineTest.java
@@ -1,0 +1,408 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core;
+
+import static org.junit.Assert.assertEquals;
+
+import androidx.constraintlayout.core.utils.GridEngine;
+
+import org.junit.Test;
+
+public class GridEngineTest {
+
+    @Test
+    public void testNoArgument() {
+        GridEngine engine = new GridEngine();
+        engine.setRows(3);
+        engine.setColumns(3);
+        engine.setNumWidgets(5);
+        engine.setup();
+
+        assertEquals(0, engine.leftOfWidget(0));
+        assertEquals(0, engine.topOfWidget(0));
+        assertEquals(0, engine.rightOfWidget(0));
+        assertEquals(0, engine.bottomOfWidget(0));
+
+        assertEquals(1, engine.leftOfWidget(1));
+        assertEquals(0, engine.topOfWidget(1));
+        assertEquals(1, engine.rightOfWidget(1));
+        assertEquals(0, engine.bottomOfWidget(1));
+
+        assertEquals(2, engine.leftOfWidget(2));
+        assertEquals(0, engine.topOfWidget(2));
+        assertEquals(2, engine.rightOfWidget(2));
+        assertEquals(0, engine.bottomOfWidget(2));
+
+        assertEquals(0, engine.leftOfWidget(3));
+        assertEquals(1, engine.topOfWidget(3));
+        assertEquals(0, engine.rightOfWidget(3));
+        assertEquals(1, engine.bottomOfWidget(3));
+
+        assertEquals(1, engine.leftOfWidget(4));
+        assertEquals(1, engine.topOfWidget(4));
+        assertEquals(1, engine.rightOfWidget(4));
+        assertEquals(1, engine.bottomOfWidget(4));
+
+    }
+
+    @Test
+    public void testSimpleEngineHorizontal() {
+        GridEngine engine = new GridEngine(3, 3, 5);
+
+        assertEquals(0, engine.leftOfWidget(0));
+        assertEquals(0, engine.topOfWidget(0));
+        assertEquals(0, engine.rightOfWidget(0));
+        assertEquals(0, engine.bottomOfWidget(0));
+
+        assertEquals(1, engine.leftOfWidget(1));
+        assertEquals(0, engine.topOfWidget(1));
+        assertEquals(1, engine.rightOfWidget(1));
+        assertEquals(0, engine.bottomOfWidget(1));
+
+        assertEquals(2, engine.leftOfWidget(2));
+        assertEquals(0, engine.topOfWidget(2));
+        assertEquals(2, engine.rightOfWidget(2));
+        assertEquals(0, engine.bottomOfWidget(2));
+
+        assertEquals(0, engine.leftOfWidget(3));
+        assertEquals(1, engine.topOfWidget(3));
+        assertEquals(0, engine.rightOfWidget(3));
+        assertEquals(1, engine.bottomOfWidget(3));
+
+        assertEquals(1, engine.leftOfWidget(4));
+        assertEquals(1, engine.topOfWidget(4));
+        assertEquals(1, engine.rightOfWidget(4));
+        assertEquals(1, engine.bottomOfWidget(4));
+    }
+
+    @Test
+    public void testSimpleEngineVertical() {
+        // Grid engine with 3 rows, 3 columns, and 5 widgets
+        GridEngine engine = new GridEngine(3, 3, 5);
+        // Set the orientation to Vertical
+        engine.setOrientation(1);
+        engine.setup();
+
+        assertEquals(0, engine.leftOfWidget(0));
+        assertEquals(0, engine.topOfWidget(0));
+        assertEquals(0, engine.rightOfWidget(0));
+        assertEquals(0, engine.bottomOfWidget(0));
+
+        assertEquals(0, engine.leftOfWidget(1));
+        assertEquals(1, engine.topOfWidget(1));
+        assertEquals(0, engine.rightOfWidget(1));
+        assertEquals(1, engine.bottomOfWidget(1));
+
+        assertEquals(0, engine.leftOfWidget(2));
+        assertEquals(2, engine.topOfWidget(2));
+        assertEquals(0, engine.rightOfWidget(2));
+        assertEquals(2, engine.bottomOfWidget(2));
+
+        assertEquals(1, engine.leftOfWidget(3));
+        assertEquals(0, engine.topOfWidget(3));
+        assertEquals(1, engine.rightOfWidget(3));
+        assertEquals(0, engine.bottomOfWidget(3));
+
+        assertEquals(1, engine.leftOfWidget(4));
+        assertEquals(1, engine.topOfWidget(4));
+        assertEquals(1, engine.rightOfWidget(4));
+        assertEquals(1, engine.bottomOfWidget(4));
+    }
+
+    @Test
+    public void testSpansSkipsHorizontal() {
+        GridEngine engine = new GridEngine(4, 4, 5);
+        engine.setSkips("0:2x2,6:1x1");
+        engine.setSpans("12:1x3");
+        engine.setup();
+
+        assertEquals(0, engine.leftOfWidget(0));
+        assertEquals(3, engine.topOfWidget(0));
+        assertEquals(2, engine.rightOfWidget(0));
+        assertEquals(3, engine.bottomOfWidget(0));
+
+        assertEquals(2, engine.leftOfWidget(1));
+        assertEquals(0, engine.topOfWidget(1));
+        assertEquals(2, engine.rightOfWidget(1));
+        assertEquals(0, engine.bottomOfWidget(1));
+
+        assertEquals(3, engine.leftOfWidget(2));
+        assertEquals(0, engine.topOfWidget(2));
+        assertEquals(3, engine.rightOfWidget(2));
+        assertEquals(0, engine.bottomOfWidget(2));
+
+        assertEquals(3, engine.leftOfWidget(3));
+        assertEquals(1, engine.topOfWidget(3));
+        assertEquals(3, engine.rightOfWidget(3));
+        assertEquals(1, engine.bottomOfWidget(3));
+
+        assertEquals(0, engine.leftOfWidget(4));
+        assertEquals(2, engine.topOfWidget(4));
+        assertEquals(0, engine.rightOfWidget(4));
+        assertEquals(2, engine.bottomOfWidget(4));
+    }
+
+    @Test
+    public void testSpansSkipsVertical() {
+        GridEngine engine = new GridEngine(4, 4, 5);
+        engine.setOrientation(1);
+        engine.setSkips("0:2x2,6:2x1");
+        engine.setSpans("12:3x1");
+        engine.setup();
+
+        assertEquals(3, engine.leftOfWidget(0));
+        assertEquals(0, engine.topOfWidget(0));
+        assertEquals(3, engine.rightOfWidget(0));
+        assertEquals(2, engine.bottomOfWidget(0));
+
+        assertEquals(0, engine.leftOfWidget(1));
+        assertEquals(2, engine.topOfWidget(1));
+        assertEquals(0, engine.rightOfWidget(1));
+        assertEquals(2, engine.bottomOfWidget(1));
+
+        assertEquals(0, engine.leftOfWidget(2));
+        assertEquals(3, engine.topOfWidget(2));
+        assertEquals(0, engine.rightOfWidget(2));
+        assertEquals(3, engine.bottomOfWidget(2));
+
+        assertEquals(2, engine.leftOfWidget(3));
+        assertEquals(0, engine.topOfWidget(3));
+        assertEquals(2, engine.rightOfWidget(3));
+        assertEquals(0, engine.bottomOfWidget(3));
+
+        assertEquals(2, engine.leftOfWidget(4));
+        assertEquals(1, engine.topOfWidget(4));
+        assertEquals(2, engine.rightOfWidget(4));
+        assertEquals(1, engine.bottomOfWidget(4));
+    }
+
+    @Test
+    public void testSetRows() {
+        GridEngine engine = new GridEngine(4, 4, 5);
+        engine.setRows(3);
+        engine.setup();
+
+        assertEquals(0, engine.leftOfWidget(0));
+        assertEquals(0, engine.topOfWidget(0));
+        assertEquals(0, engine.rightOfWidget(0));
+        assertEquals(0, engine.bottomOfWidget(0));
+
+        assertEquals(1, engine.leftOfWidget(1));
+        assertEquals(0, engine.topOfWidget(1));
+        assertEquals(1, engine.rightOfWidget(1));
+        assertEquals(0, engine.bottomOfWidget(1));
+
+        assertEquals(2, engine.leftOfWidget(2));
+        assertEquals(0, engine.topOfWidget(2));
+        assertEquals(2, engine.rightOfWidget(2));
+        assertEquals(0, engine.bottomOfWidget(2));
+
+        assertEquals(3, engine.leftOfWidget(3));
+        assertEquals(0, engine.topOfWidget(3));
+        assertEquals(3, engine.rightOfWidget(3));
+        assertEquals(0, engine.bottomOfWidget(3));
+
+        assertEquals(0, engine.leftOfWidget(4));
+        assertEquals(1, engine.topOfWidget(4));
+        assertEquals(0, engine.rightOfWidget(4));
+        assertEquals(1, engine.bottomOfWidget(4));
+    }
+
+    @Test
+    public void testSetColumns() {
+        GridEngine engine = new GridEngine(4, 4, 5);
+        engine.setColumns(3);
+        engine.setup();
+
+        assertEquals(0, engine.leftOfWidget(0));
+        assertEquals(0, engine.topOfWidget(0));
+        assertEquals(0, engine.rightOfWidget(0));
+        assertEquals(0, engine.bottomOfWidget(0));
+
+        assertEquals(1, engine.leftOfWidget(1));
+        assertEquals(0, engine.topOfWidget(1));
+        assertEquals(1, engine.rightOfWidget(1));
+        assertEquals(0, engine.bottomOfWidget(1));
+
+        assertEquals(2, engine.leftOfWidget(2));
+        assertEquals(0, engine.topOfWidget(2));
+        assertEquals(2, engine.rightOfWidget(2));
+        assertEquals(0, engine.bottomOfWidget(2));
+
+        assertEquals(0, engine.leftOfWidget(3));
+        assertEquals(1, engine.topOfWidget(3));
+        assertEquals(0, engine.rightOfWidget(3));
+        assertEquals(1, engine.bottomOfWidget(3));
+
+        assertEquals(1, engine.leftOfWidget(4));
+        assertEquals(1, engine.topOfWidget(4));
+        assertEquals(1, engine.rightOfWidget(4));
+        assertEquals(1, engine.bottomOfWidget(4));
+    }
+
+    @Test
+    public void testSetNumWidgets() {
+        GridEngine engine = new GridEngine(3, 3);
+        engine.setNumWidgets(5);
+        engine.setup();
+
+        assertEquals(0, engine.leftOfWidget(0));
+        assertEquals(0, engine.topOfWidget(0));
+        assertEquals(0, engine.rightOfWidget(0));
+        assertEquals(0, engine.bottomOfWidget(0));
+
+        assertEquals(1, engine.leftOfWidget(1));
+        assertEquals(0, engine.topOfWidget(1));
+        assertEquals(1, engine.rightOfWidget(1));
+        assertEquals(0, engine.bottomOfWidget(1));
+
+        assertEquals(2, engine.leftOfWidget(2));
+        assertEquals(0, engine.topOfWidget(2));
+        assertEquals(2, engine.rightOfWidget(2));
+        assertEquals(0, engine.bottomOfWidget(2));
+
+        assertEquals(0, engine.leftOfWidget(3));
+        assertEquals(1, engine.topOfWidget(3));
+        assertEquals(0, engine.rightOfWidget(3));
+        assertEquals(1, engine.bottomOfWidget(3));
+
+        assertEquals(1, engine.leftOfWidget(4));
+        assertEquals(1, engine.topOfWidget(4));
+        assertEquals(1, engine.rightOfWidget(4));
+        assertEquals(1, engine.bottomOfWidget(4));
+    }
+
+    @Test
+    public void testToggleSkips() {
+        GridEngine engine = new GridEngine(4, 4, 5);
+        engine.setSkips("0:2x2,6:1x1");
+        engine.setup();
+
+        assertEquals(2, engine.leftOfWidget(0));
+        assertEquals(0, engine.topOfWidget(0));
+        assertEquals(2, engine.rightOfWidget(0));
+        assertEquals(0, engine.bottomOfWidget(0));
+
+        assertEquals(3, engine.leftOfWidget(1));
+        assertEquals(0, engine.topOfWidget(1));
+        assertEquals(3, engine.rightOfWidget(1));
+        assertEquals(0, engine.bottomOfWidget(1));
+
+        assertEquals(3, engine.leftOfWidget(2));
+        assertEquals(1, engine.topOfWidget(2));
+        assertEquals(3, engine.rightOfWidget(2));
+        assertEquals(1, engine.bottomOfWidget(2));
+
+        assertEquals(0, engine.leftOfWidget(3));
+        assertEquals(2, engine.topOfWidget(3));
+        assertEquals(0, engine.rightOfWidget(3));
+        assertEquals(2, engine.bottomOfWidget(3));
+
+        assertEquals(1, engine.leftOfWidget(4));
+        assertEquals(2, engine.topOfWidget(4));
+        assertEquals(1, engine.rightOfWidget(4));
+        assertEquals(2, engine.bottomOfWidget(4));
+
+        engine.setSkips("");
+        engine.setup();
+
+        assertEquals(0, engine.leftOfWidget(0));
+        assertEquals(0, engine.topOfWidget(0));
+        assertEquals(0, engine.rightOfWidget(0));
+        assertEquals(0, engine.bottomOfWidget(0));
+
+        assertEquals(1, engine.leftOfWidget(1));
+        assertEquals(0, engine.topOfWidget(1));
+        assertEquals(1, engine.rightOfWidget(1));
+        assertEquals(0, engine.bottomOfWidget(1));
+
+        assertEquals(2, engine.leftOfWidget(2));
+        assertEquals(0, engine.topOfWidget(2));
+        assertEquals(2, engine.rightOfWidget(2));
+        assertEquals(0, engine.bottomOfWidget(2));
+
+        assertEquals(3, engine.leftOfWidget(3));
+        assertEquals(0, engine.topOfWidget(3));
+        assertEquals(3, engine.rightOfWidget(3));
+        assertEquals(0, engine.bottomOfWidget(3));
+
+        assertEquals(0, engine.leftOfWidget(4));
+        assertEquals(1, engine.topOfWidget(4));
+        assertEquals(0, engine.rightOfWidget(4));
+        assertEquals(1, engine.bottomOfWidget(4));
+    }
+
+    @Test
+    public void testToggleSpans() {
+        GridEngine engine = new GridEngine(4, 4, 5);
+        engine.setSpans("0:2x2,3:2x1");
+        engine.setup();
+
+        assertEquals(0, engine.leftOfWidget(0));
+        assertEquals(0, engine.topOfWidget(0));
+        assertEquals(1, engine.rightOfWidget(0));
+        assertEquals(1, engine.bottomOfWidget(0));
+
+        assertEquals(3, engine.leftOfWidget(1));
+        assertEquals(0, engine.topOfWidget(1));
+        assertEquals(3, engine.rightOfWidget(1));
+        assertEquals(1, engine.bottomOfWidget(1));
+
+        assertEquals(2, engine.leftOfWidget(2));
+        assertEquals(0, engine.topOfWidget(2));
+        assertEquals(2, engine.rightOfWidget(2));
+        assertEquals(0, engine.bottomOfWidget(2));
+
+        assertEquals(2, engine.leftOfWidget(3));
+        assertEquals(1, engine.topOfWidget(3));
+        assertEquals(2, engine.rightOfWidget(3));
+        assertEquals(1, engine.bottomOfWidget(3));
+
+        assertEquals(0, engine.leftOfWidget(4));
+        assertEquals(2, engine.topOfWidget(4));
+        assertEquals(0, engine.rightOfWidget(4));
+        assertEquals(2, engine.bottomOfWidget(4));
+
+        engine.setSpans("");
+        engine.setup();
+
+        assertEquals(0, engine.leftOfWidget(0));
+        assertEquals(0, engine.topOfWidget(0));
+        assertEquals(0, engine.rightOfWidget(0));
+        assertEquals(0, engine.bottomOfWidget(0));
+
+        assertEquals(1, engine.leftOfWidget(1));
+        assertEquals(0, engine.topOfWidget(1));
+        assertEquals(1, engine.rightOfWidget(1));
+        assertEquals(0, engine.bottomOfWidget(1));
+
+        assertEquals(2, engine.leftOfWidget(2));
+        assertEquals(0, engine.topOfWidget(2));
+        assertEquals(2, engine.rightOfWidget(2));
+        assertEquals(0, engine.bottomOfWidget(2));
+
+        assertEquals(3, engine.leftOfWidget(3));
+        assertEquals(0, engine.topOfWidget(3));
+        assertEquals(3, engine.rightOfWidget(3));
+        assertEquals(0, engine.bottomOfWidget(3));
+
+        assertEquals(0, engine.leftOfWidget(4));
+        assertEquals(1, engine.topOfWidget(4));
+        assertEquals(0, engine.rightOfWidget(4));
+        assertEquals(1, engine.bottomOfWidget(4));
+    }
+}

--- a/projects/GridExperiments/app/src/main/java/android/support/constraint/app/MainActivity.java
+++ b/projects/GridExperiments/app/src/main/java/android/support/constraint/app/MainActivity.java
@@ -32,6 +32,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * MainActivity for Grid helper
@@ -148,13 +150,15 @@ public class MainActivity extends AppCompatActivity {
     private static int[] getLayouts( ) {
         ArrayList<String> list = new ArrayList<>();
         Field[] f = R.layout.class.getDeclaredFields();
+        Set<String> layouts = new HashSet<>(Arrays.asList("activity_main",
+                "column_in_row", "row_in_column"));
 
         int []ret = new int[f.length];
          int count = 0;
         for (int i = 0; i < f.length; i++) {
             try {
                 String name = f[i].getName();
-                if (!name.contains("_") || name.equals("activity_main")) {
+                if (!name.contains("_") || layouts.contains(name)) {
                     ret[count++] = f[i].getInt(null);
                 }
             } catch (IllegalAccessException e) {

--- a/projects/GridExperiments/app/src/main/res/layout/calculator.xml
+++ b/projects/GridExperiments/app/src/main/res/layout/calculator.xml
@@ -9,14 +9,13 @@
         android:id="@+id/grid"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:constraint_referenced_ids="calculatorText,btn0,clear,neg,percent,div,btn7,btn8,btn9,mult,btn4,btn5,btn6,sub,btn1,btn2,btn3,plus,btn0,dot,equal"
+        app:constraint_referenced_ids="calculatorText,btn0,clear,neg,percent,div,btn7,btn8,btn9,mult,btn4,btn5,btn6,sub,btn1,btn2,btn3,plus,dot,equal"
         app:grid_columns="4"
         app:grid_rows="7"
         app:grid_horizontalGaps="5dp"
         app:grid_verticalGaps="5dp"
         app:grid_orientation="horizontal"
         app:grid_spans="0:2x4,24:1x2" />
-
 
     <Button
         android:id="@+id/clear"
@@ -66,13 +65,6 @@
         android:layout_height="0dp"
         android:textSize="30dp"
         android:text="+" />
-
-    <Button
-        android:id="@+id/btn7"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:textSize="30dp"
-        android:text="7" />
 
     <Button
         android:id="@+id/equal"

--- a/projects/GridExperiments/app/src/main/res/layout/column.xml
+++ b/projects/GridExperiments/app/src/main/res/layout/column.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.helper.widget.Grid
+        android:id="@+id/grid"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="5dp"
+        app:constraint_referenced_ids="btn0,btn1,btn2,btn3,btn4"
+        app:grid_columns="1"
+        app:grid_rows="0" />
+
+    <Button
+        android:id="@+id/btn0"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="0"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="57dp" />
+
+    <Button
+        android:id="@+id/btn1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="1"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="4dp"
+        tools:layout_editor_absoluteY="301dp" />
+
+    <Button
+        android:id="@+id/btn2"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="2"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="301dp" />
+
+    <Button
+        android:id="@+id/btn3"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="3"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="141dp"
+        tools:layout_editor_absoluteY="545dp" />
+
+    <Button
+        android:id="@+id/btn4"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="4"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="57dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/projects/GridExperiments/app/src/main/res/layout/column_in_row.xml
+++ b/projects/GridExperiments/app/src/main/res/layout/column_in_row.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.helper.widget.Grid
+        android:id="@+id/row"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="5dp"
+        app:constraint_referenced_ids="btn0,column,btn1,btn2,btn3"
+        app:grid_horizontalGaps="10dp"
+        app:grid_columns="0"
+        app:grid_rows="1" />
+
+    <androidx.constraintlayout.helper.widget.Grid
+        android:id="@+id/column"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_margin="5dp"
+        app:constraint_referenced_ids="btn4,btn5,btn6"
+        app:grid_horizontalGaps="10dp"
+        app:grid_columns="1"
+        app:grid_rows="0" />
+
+    <Button
+        android:id="@+id/btn0"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="0"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="57dp" />
+
+    <Button
+        android:id="@+id/btn1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="1"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="4dp"
+        tools:layout_editor_absoluteY="301dp" />
+
+    <Button
+        android:id="@+id/btn2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="2"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="301dp" />
+
+    <Button
+        android:id="@+id/btn3"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="3"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="141dp"
+        tools:layout_editor_absoluteY="545dp" />
+
+    <Button
+        android:id="@+id/btn4"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="4"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="57dp" />
+
+    <Button
+        android:id="@+id/btn5"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="5"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="141dp"
+        tools:layout_editor_absoluteY="545dp" />
+
+    <Button
+        android:id="@+id/btn6"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:text="6"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="57dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/projects/GridExperiments/app/src/main/res/layout/row.xml
+++ b/projects/GridExperiments/app/src/main/res/layout/row.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.helper.widget.Grid
+        android:id="@+id/grid"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="5dp"
+        app:constraint_referenced_ids="btn0,btn1,btn2,btn3,btn4"
+        app:grid_horizontalGaps="10dp"
+        app:grid_columns="0"
+        app:grid_rows="1" />
+
+    <Button
+        android:id="@+id/btn0"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="0"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="57dp" />
+
+    <Button
+        android:id="@+id/btn1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="1"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="4dp"
+        tools:layout_editor_absoluteY="301dp" />
+
+    <Button
+        android:id="@+id/btn2"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="2"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="301dp" />
+
+    <Button
+        android:id="@+id/btn3"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="3"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="141dp"
+        tools:layout_editor_absoluteY="545dp" />
+
+    <Button
+        android:id="@+id/btn4"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="4"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="57dp" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/projects/GridExperiments/app/src/main/res/layout/row_in_column.xml
+++ b/projects/GridExperiments/app/src/main/res/layout/row_in_column.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.helper.widget.Grid
+        android:id="@+id/column"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="5dp"
+        app:constraint_referenced_ids="btn0,row,btn1"
+        app:grid_horizontalGaps="10dp"
+        app:grid_columns="1"
+        app:grid_rows="0" />
+
+    <androidx.constraintlayout.helper.widget.Grid
+        android:id="@+id/row"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_margin="5dp"
+        app:constraint_referenced_ids="btn2,innerColumn,btn3"
+        app:grid_horizontalGaps="10dp"
+        app:grid_columns="0"
+        app:grid_rows="1" />
+
+    <androidx.constraintlayout.helper.widget.Grid
+        android:id="@+id/innerColumn"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_margin="5dp"
+        app:constraint_referenced_ids="btn4,btn5,btn6"
+        app:grid_horizontalGaps="10dp"
+        app:grid_columns="1"
+        app:grid_rows="0" />
+
+    <Button
+        android:id="@+id/btn0"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="0"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="57dp" />
+
+    <Button
+        android:id="@+id/btn1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="1"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="4dp"
+        tools:layout_editor_absoluteY="301dp" />
+
+    <Button
+        android:id="@+id/btn2"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:text="2"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="301dp" />
+
+    <Button
+        android:id="@+id/btn3"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:text="3"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="141dp"
+        tools:layout_editor_absoluteY="545dp" />
+
+    <Button
+        android:id="@+id/btn4"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:text="4"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="57dp" />
+
+    <Button
+        android:id="@+id/btn5"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:text="5"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="141dp"
+        tools:layout_editor_absoluteY="545dp" />
+
+    <Button
+        android:id="@+id/btn6"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:text="6"
+        android:textSize="30dp"
+        tools:layout_editor_absoluteX="278dp"
+        tools:layout_editor_absoluteY="57dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
### Mark this as a WIP - Even though setters work properly, but it uses the ConstrainSet approach instead of LayoutParams

The main purpose of this PR is to migrate the main logic of the Grid Helper into core library. 
Tasks are accomplished in this PR:

1. created a new GridEngine file in core and migrate the main logic into it.
2. added a test file GridEngineTest.
3. Add more Demos, including row, column, row_in_column, and column_in_row.

**Row**
![image](https://user-images.githubusercontent.com/20599348/176016547-1cab02ff-7f67-4fda-a70d-11465a6b795e.png)

**Column**
![image](https://user-images.githubusercontent.com/20599348/176016642-69416fc9-f0c2-473a-bdee-8c3b42cea275.png)

**column_in_row**
![image](https://user-images.githubusercontent.com/20599348/176016680-3934ebfb-9638-498d-869c-e5349f088ab1.png)

**row_in_column**
![image](https://user-images.githubusercontent.com/20599348/176016713-1b3d71fb-97e9-4875-bc27-6b51b92f8cae.png)
