### PR TITLE
remove unused params

### DIFF
--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionMeasurer.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionMeasurer.kt
@@ -520,6 +520,6 @@ internal class MotionMeasurer : Measurer() {
         start.applyTo(this.transition, Transition.START)
         end.applyTo(this.transition, Transition.END)
         this.transition.interpolate(0, 0, progress)
-        transition?.applyAllTo(this.transition, 0)
+        transition?.applyAllTo(this.transition)
     }
 }

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/Transition.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/Transition.kt
@@ -78,7 +78,7 @@ internal class TransitionImpl(
     /**
      * Applies all Transition properties to [transition].
      */
-    fun applyAllTo(transition: androidx.constraintlayout.core.state.Transition, type: Int) {
+    fun applyAllTo(transition: androidx.constraintlayout.core.state.Transition) {
         try {
             TransitionParser.parse(parsedTransition, transition, pixelDp)
         } catch (e: CLParsingException) {

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/TransitionScope.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/TransitionScope.kt
@@ -39,7 +39,7 @@ fun Transition(
     transitionContent: TransitionScope.() -> Unit
 ): Transition {
     val dpToPixel = with(LocalDensity.current) { 1.dp.toPx() }
-    val transitionScope = remember(from, to) { TransitionScope(from = from, to = to) }
+    val transitionScope = remember(from, to) { TransitionScope() }
     val snapshotObserver = remember {
         // We use a Snapshot observer to know when state within the DSL has changed and recompose
         // the transition object
@@ -79,7 +79,7 @@ fun Transition(
     }
 }
 
-class TransitionScope internal constructor(name: String = "default", from: String, to: String) {
+class TransitionScope internal constructor() {
     private val containerObject = CLObject(charArrayOf())
 
     private val keyFramesObject = CLObject(charArrayOf())


### PR DESCRIPTION
Remove the unused params that causes an issue during the CL presubmit check.

```
> Task :constraintlayout:constraintlayout-compose:compileDebugKotlin
  w: $SUPPORT/constraintlayout/constraintlayout-compose/src/main/java/androidx/constraintlayout/compose/Transition.kt: (81, 81): Parameter 'type' is never used
  w: $SUPPORT/constraintlayout/constraintlayout-compose/src/main/java/androidx/constraintlayout/compose/TransitionScope.kt: (82, 44): Parameter 'name' is never used
  w: $SUPPORT/constraintlayout/constraintlayout-compose/src/main/java/androidx/constraintlayout/compose/TransitionScope.kt: (82, 70): Parameter 'from' is never used
  w: $SUPPORT/constraintlayout/constraintlayout-compose/src/main/java/androidx/constraintlayout/compose/TransitionScope.kt: (82, 84): Parameter 'to' is never used
  ```