### PR TITLE
fix klint issue

### DIFF
--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionLayoutState.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionLayoutState.kt
@@ -270,7 +270,7 @@ internal interface MotionProgress {
 
         fun fromState(
             progressState: State<Float>,
-            onUpdate:  (newProgress: Float) -> Unit
+            onUpdate: (newProgress: Float) -> Unit
         ): MotionProgress =
             object : MotionProgress {
                 override val currentProgress: Float

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionRenderDebug.java
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionRenderDebug.java
@@ -196,8 +196,7 @@ class MotionRenderDebug {
             mPath.lineTo(x, y - mDiamondSize);
             mPath.lineTo(x - mDiamondSize, y);
             mPath.close();
-
-            MotionPaths framePoint = motionController.getKeyFrame(i - 1);
+            
             float dx = 0; //framePoint.translationX
             float dy = 0; //framePoint.translationY
             if (mode == Motion.DRAW_PATH_AS_CONFIGURED) {

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionScene.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionScene.kt
@@ -24,7 +24,6 @@ import androidx.constraintlayout.core.state.ConstraintSetParser
 import androidx.constraintlayout.core.state.CoreMotionScene
 import org.intellij.lang.annotations.Language
 
-
 /**
  * Information for MotionLayout to animate between multiple [ConstraintSet]s.
  */
@@ -43,7 +42,6 @@ fun MotionScene(@Language("json5") content: String): MotionScene {
         JSONMotionScene(content)
     }
 }
-
 
 internal class JSONMotionScene(@Language("json5") content: String) : EditableJSONLayout(content),
     MotionScene {

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/TransitionScope.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/TransitionScope.kt
@@ -330,7 +330,6 @@ data class OnSwipe(
     val onTouchUp: SwipeTouchUp = SwipeTouchUp.AutoComplete
 )
 
-
 class SwipeMode internal constructor(internal val propName: String) {
     companion object {
         val Velocity = SwipeMode("velocity")


### PR DESCRIPTION
Fix the following klint issues.

```
[FAILED] ktlint_hook
    /Users/shanewong/Desktop/Work/androidx-main/frameworks/support/constraintlayout/constraintlayout-compose/src/main/java/androidx/constraintlayout/compose/MotionLayoutState.kt:273:23: Unnecessary long whitespace (no-multi-spaces)
    /Users/shanewong/Desktop/Work/androidx-main/frameworks/support/constraintlayout/constraintlayout-compose/src/main/java/androidx/constraintlayout/compose/MotionScene.kt:27:1: Needless blank line(s) (no-consecutive-blank-lines)
    /Users/shanewong/Desktop/Work/androidx-main/frameworks/support/constraintlayout/constraintlayout-compose/src/main/java/androidx/constraintlayout/compose/MotionScene.kt:47:1: Needless blank line(s) (no-consecutive-blank-lines)
    /Users/shanewong/Desktop/Work/androidx-main/frameworks/support/constraintlayout/constraintlayout-compose/src/main/java/androidx/constraintlayout/compose/TransitionScope.kt:333:1: Needless blank line(s) (no-consecutive-blank-lines)
   ```

Also,
```
.../compose/MotionRenderDebug.java:200: error: [UnusedVariable] The local variable 'framePoint' is never read.
```

