### PR TITLE
[Grid]: override onMeasure to properly set measured dimension

### DIFF
--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/helper/widget/Grid.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/helper/widget/Grid.java
@@ -194,6 +194,7 @@ public class Grid extends VirtualLayout {
     @Override
     protected void init(AttributeSet attrs) {
         super.init(attrs);
+        mUseViewMeasure = true;
 
         // Parse the relevant attributes from layout xml
         if (attrs != null) {
@@ -1009,12 +1010,5 @@ public class Grid extends VirtualLayout {
         mVerticalGaps = verticalGaps;
         generateGrid(true);
         invalidate();
-    }
-
-    @SuppressLint("WrongCall")
-    @Override
-    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        mUseViewMeasure = true;
-        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
     }
 }

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/helper/widget/Grid.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/helper/widget/Grid.java
@@ -1014,10 +1014,7 @@ public class Grid extends VirtualLayout {
     @SuppressLint("WrongCall")
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        ConstraintLayout.LayoutParams params = params(this);
-        setMeasuredDimension(mContainer.getMeasuredWidth()
-                        - params.leftMargin - params.rightMargin
-                , mContainer.getMeasuredHeight()
-                        - params.topMargin - params.bottomMargin);
+        mUseViewMeasure = true;
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
     }
 }

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/helper/widget/Grid.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/helper/widget/Grid.java
@@ -1010,4 +1010,14 @@ public class Grid extends VirtualLayout {
         generateGrid(true);
         invalidate();
     }
+
+    @SuppressLint("WrongCall")
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        ConstraintLayout.LayoutParams params = params(this);
+        setMeasuredDimension(mContainer.getMeasuredWidth()
+                        - params.leftMargin - params.rightMargin
+                , mContainer.getMeasuredHeight()
+                        - params.topMargin - params.bottomMargin);
+    }
 }

--- a/projects/GridExperiments/app/src/main/java/android/support/constraint/app/MainActivity.java
+++ b/projects/GridExperiments/app/src/main/java/android/support/constraint/app/MainActivity.java
@@ -151,7 +151,7 @@ public class MainActivity extends AppCompatActivity {
         ArrayList<String> list = new ArrayList<>();
         Field[] f = R.layout.class.getDeclaredFields();
         Set<String> layouts = new HashSet<>(Arrays.asList("activity_main",
-                "column_in_row", "row_in_column"));
+                "column_in_row", "row_in_column", "view_only"));
 
         int []ret = new int[f.length];
          int count = 0;

--- a/projects/GridExperiments/app/src/main/res/layout/view_only.xml
+++ b/projects/GridExperiments/app/src/main/res/layout/view_only.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/rootView"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#59EAE16E">
+
+    <androidx.constraintlayout.helper.widget.Grid
+        android:id="@+id/grid"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#59EA6EC7"
+        android:layout_margin="32dp"
+        app:grid_horizontalGaps="32dp"
+        app:grid_verticalGaps="32dp"
+        app:grid_rows="2"
+        app:grid_columns="2"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:constraint_referenced_ids="g1,g2,g3,g4"
+        />
+    <View
+        android:id="@+id/grid2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#27C343FA"
+        android:layout_margin="32dp"
+
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+
+        />
+    <View
+        android:id="@+id/g1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:visibility="gone"
+        android:background="#FDFA7E"
+        />
+    <View
+        android:id="@+id/g2"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#B5FF80"
+        />
+    <View
+        android:id="@+id/g3"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#817DF8"
+        />
+    <View
+        android:id="@+id/g4"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#FD7FB1"
+        />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/projects/GridExperiments/app/src/main/res/layout/view_only.xml
+++ b/projects/GridExperiments/app/src/main/res/layout/view_only.xml
@@ -11,8 +11,8 @@
 
     <androidx.constraintlayout.helper.widget.Grid
         android:id="@+id/grid"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:background="#59EA6EC7"
         android:layout_margin="32dp"
         app:grid_horizontalGaps="32dp"
@@ -42,7 +42,6 @@
         android:id="@+id/g1"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:visibility="gone"
         android:background="#FDFA7E"
         />
     <View

--- a/projects/GridExperiments/app/src/main/res/layout/view_only.xml
+++ b/projects/GridExperiments/app/src/main/res/layout/view_only.xml
@@ -11,8 +11,8 @@
 
     <androidx.constraintlayout.helper.widget.Grid
         android:id="@+id/grid"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         android:background="#59EA6EC7"
         android:layout_margin="32dp"
         app:grid_horizontalGaps="32dp"
@@ -62,6 +62,5 @@
         android:layout_height="0dp"
         android:background="#FD7FB1"
         />
-
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Previously if we have only views in a Grid Helper, the layout doesn't render properly. See view_only.xml for example.

To resolve this issue, the onMeasure is override to set the width and height of a VirtualLayout properly. 
Tested the following cases:

1. 0dp to parent - **passed**
2. 0dp to parent & another view - **passed**
3. 0dp with margin to parent - **passed**
4. 0dp with margin to parent & another view - **passed**
5. MATCH_PARENT - **passed** 
6. 200dp (fix) to parent and another view - **passed** 
7. WRAP_CONTENT (I assume all forms fail ) - **failed** It has the same behavior as **match_parent**.

- 0dp to parent
![image](https://user-images.githubusercontent.com/20599348/183991268-e43f73f5-2bc3-4029-83e3-7c6e8c2b473c.png)

- 0dp to parent & another view
![image](https://user-images.githubusercontent.com/20599348/183995948-e6ce3af4-23cf-4f3a-9d3c-208c56e207bb.png)


- 0dp with margin to parent
![image](https://user-images.githubusercontent.com/20599348/183991033-ea7c2aea-e80a-41fe-b2a6-33850948a2dc.png)

- 0dp with margin to parent & another view
![image](https://user-images.githubusercontent.com/20599348/183990932-e68a5928-d58b-4e8e-a41b-6e11e25d3cd1.png)
 
- MATCH_PARENT
![image](https://user-images.githubusercontent.com/20599348/183996159-07144e8a-82c5-4090-a700-56539f9a63e1.png)

- 200dp (fix) to parent and another view
![image](https://user-images.githubusercontent.com/20599348/183996558-5eb90b54-3d6d-4e96-9e3b-5222f9110393.png)

- WRAP_CONTENT (I assume all forms fail )
![image](https://user-images.githubusercontent.com/20599348/183996759-896a7303-ebe0-4afd-a9f9-b5b8887c8c87.png)

- WRAP_CONTENT with margin
![image](https://user-images.githubusercontent.com/20599348/183996886-728336e1-c422-4895-a019-ff633ddf988f.png)
