### PR TITLE
Fix AOSP presubmit warnings

### DIFF
--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionRenderDebug.java
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionRenderDebug.java
@@ -196,7 +196,6 @@ class MotionRenderDebug {
             mPath.lineTo(x, y - mDiamondSize);
             mPath.lineTo(x - mDiamondSize, y);
             mPath.close();
-            
             float dx = 0; //framePoint.translationX
             float dy = 0; //framePoint.translationY
             if (mode == Motion.DRAW_PATH_AS_CONFIGURED) {

--- a/constraintlayout/constraintlayout/README.md
+++ b/constraintlayout/constraintlayout/README.md
@@ -2,7 +2,7 @@
 
 ![core](https://github.com/androidx/constraintlayout/workflows/core/badge.svg) [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
 
-<img src="https://img.shields.io/badge/stable-2.1.1-blue"/><img src="https://img.shields.io/badge/compose-1.0.0--rc01-blue"/> 
+<img src="https://img.shields.io/badge/stable-2.1.1-blue"/><img src="https://img.shields.io/badge/compose-1.0.0--rc01-blue"/>
 
 
 ConstraintLayout is a layout manager for Android which allows you to position and size widgets in a flexible way. It's available for both the Android view system and Jetpack Compose.

--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintLayout.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintLayout.java
@@ -1793,7 +1793,8 @@ public class ConstraintLayout extends ViewGroup {
         }
         mDirtyHierarchy |= dynamicUpdateConstraints(widthMeasureSpec,  heightMeasureSpec);
 
-        @SuppressWarnings({"PointlessBooleanExpression", "ConstantConditions", "ComplexBooleanConstant"})  // TODO re-enable
+        @SuppressWarnings({"PointlessBooleanExpression", "ConstantConditions",
+                "ComplexBooleanConstant"})  // TODO re-enable
         boolean sameSpecsAsPreviousMeasure =
                 false && (mOnMeasureWidthMeasureSpec == widthMeasureSpec
                 && mOnMeasureHeightMeasureSpec == heightMeasureSpec);

--- a/constraintlayout/constraintlayout/src/main/res/values/attrs.xml
+++ b/constraintlayout/constraintlayout/src/main/res/values/attrs.xml
@@ -8,7 +8,8 @@
     <attr name="layout_constraintGuide_begin" format="dimension" />
     <!-- The space from the ending edge of the parent to this  guideline. -->
     <attr name="layout_constraintGuide_end" format="dimension" />
-    <!-- The percent of total space from the beginning of the parent to this guideline. (e.g. 0.50 = middle)-->
+    <!-- The percent of total space from the beginning of the parent to this guideline.
+        (e.g. 0.50 = middle)-->
     <attr name="layout_constraintGuide_percent" format="float" />
     <!-- Let a chain helper be rtl or not default is true -->
     <attr name="guidelineUseRtl" format="boolean" />
@@ -145,9 +146,11 @@
         <enum name="skipped" value="3" />
     </attr>
 
-    <!-- Fraction of excess space to distribute on the left when constrained on left & right edges (e.g. .5 = middle)-->
+    <!-- Fraction of excess space to distribute on the left when constrained on left & right edges
+        (e.g. .5 = middle)-->
     <attr name="layout_constraintHorizontal_bias" format="float" />
-    <!-- Fraction of excess space to distribute on the top when constrained on top & bottom edges (e.g. .5 = middle)-->
+    <!-- Fraction of excess space to distribute on the top when constrained on top & bottom edges
+        (e.g. .5 = middle)-->
     <attr name="layout_constraintVertical_bias" format="float" />
 
     <!-- Used at design time to define who created the constraint -->
@@ -164,21 +167,25 @@
     Note it only works if one of the dimensions is set to 0dp.-->
     <attr name="layout_constraintDimensionRatio" format="string" />
 
-    <!-- In a Chain, the amount of weight used to spread available horizontal space if the widget is set to MATCH_CONSTRAINT -->
+    <!-- In a Chain, the amount of weight used to spread available horizontal space
+        if the widget is set to MATCH_CONSTRAINT -->
     <attr name="layout_constraintHorizontal_weight" format="float" />
-    <!-- In a Chain, the amount of weight used to spread available vertical space if the widget is set to MATCH_CONSTRAINT -->
+    <!-- In a Chain, the amount of weight used to spread available vertical space
+        if the widget is set to MATCH_CONSTRAINT -->
     <attr name="layout_constraintVertical_weight" format="float" />
 
-    <!-- Set a chain to be packed or not. If true and the widget is the first element of a chain, the chain will not spread,
-    and the bias will affect the position of the chain elements. It will only work if all elements have a set size (i.e. not MATCH_CONSTRAINT) -->
+    <!-- Set a chain to be packed or not. If true and the widget is the first element of a chain,
+        the chain will not spread, and the bias will affect the position of the chain elements.
+        It will only work if all elements have a set size (i.e. not MATCH_CONSTRAINT) -->
     <attr name="layout_constraintHorizontal_chainStyle" format="enum">
         <enum name="spread" value="0" />
         <enum name="spread_inside" value="1" />
         <enum name="packed" value="2" />
     </attr>
 
-    <!-- Set a chain to be packed or not. If true and the widget is the first element of a chain, the chain will not spread,
-    and the bias will affect the position of the chain elements. It will only work if all elements have a set size (i.e. not MATCH_CONSTRAINT) -->
+    <!-- Set a chain to be packed or not. If true and the widget is the first element of a chain,
+        the chain will not spread, and the bias will affect the position of the chain elements.
+        It will only work if all elements have a set size (i.e. not MATCH_CONSTRAINT) -->
     <attr name="layout_constraintVertical_chainStyle" format="enum">
         <enum name="spread" value="0" />
         <enum name="spread_inside" value="1" />
@@ -338,7 +345,7 @@
             <enum name="west" value="3" />
         </attr>
         <attr name="motionEffect_strict" format="boolean" />
-    </declare-styleable>    <!-- =============================== End FadeMove =============================== -->
+    </declare-styleable>    <!-- ========================= End FadeMove ====================== -->
 
     <!-- Used at design time to define to position the view -->
     <attr name="layout_editor_absoluteX" format="dimension" />
@@ -994,8 +1001,9 @@
         <attr name="quantizeMotionInterpolator" />
     </declare-styleable>
 
-    <!--    This is used in ConstraintSet to allow a more compact expression of changes to the original-->
-    <!--    Only changes need be defined. It does not support layout_constraint*_to* attributes  -->
+    <!--   This is used in ConstraintSet to allow a more compact expression of changes
+        to the original-->
+    <!--   Only changes need be defined. It does not support layout_constraint*_to* attributes  -->
     <declare-styleable name="ConstraintOverride">
         <attr name="android:orientation" />
         <attr name="android:id" />
@@ -1425,10 +1433,12 @@
              or perpendicular to the path in pathRelative. -->
         <attr name="percentY" format="float" />
 
-        <!-- Percent of change in the width. Note if the width does not change this has no effect.This overrides sizePercent. -->
+        <!-- Percent of change in the width. Note if the width does not change this has no effect.
+            This overrides sizePercent. -->
         <attr name="percentWidth" format="float" />
 
-        <!-- Percent of change in the width. Note if the width does not change this has no effect.This overrides sizePercent. -->
+        <!-- Percent of change in the width. Note if the width does not change this has no effect.
+            This overrides sizePercent. -->
         <attr name="percentHeight" format="float" />
         <attr name="framePosition" />
         <attr name="motionTarget" />
@@ -1780,7 +1790,7 @@
     <declare-styleable name="include">
         <attr name="constraintSet" />
     </declare-styleable>
-    <!-- ======================================ViewTransitions===================================== -->
+    <!-- ===================================ViewTransitions================================== -->
 
     <attr name="onStateTransition" format="enum">
         <enum name="actionDown" value="1" />

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/motion/key/MotionKey.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/motion/key/MotionKey.java
@@ -25,9 +25,7 @@ import java.util.HashSet;
 /**
  * Base class in an element in a KeyFrame
  *
- 
  */
-
 public abstract class MotionKey implements TypedValues {
     public static int UNSET = -1;
     public int mFramePosition = UNSET;
@@ -66,14 +64,12 @@ public abstract class MotionKey implements TypedValues {
      * The values are written to the spline
      *
      * @param splines splines to write values to
-     
      */
     public abstract void addValues(HashMap<String, SplineSet> splines);
 
     /**
      * Return the float given a value. If the value is a "Float" object it is casted
      *
-     
      */
     float toFloat(Object value) {
         return (value instanceof Float) ? (Float) value : Float.parseFloat(value.toString());

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/utils/GridEngine.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/utils/GridEngine.java
@@ -471,7 +471,7 @@ public class GridEngine {
 
     /**
      * Set new NumWidgets value
-     * @param num how man widgets to be arranged in Grid
+     * @param num how many widgets to be arranged in Grid
      */
     public void setNumWidgets(int num) {
         if (num > mRows * mColumns) {

--- a/constraintlayout/core/src/test/resources/check10.xml
+++ b/constraintlayout/core/src/test/resources/check10.xml
@@ -23,8 +23,9 @@
 
     <TextView android:id="@+id/textView4" android:layout_width="0dp"
         android:layout_height="wrap_content" android:tag="48,48,984,204"
-        android:text="12345678 12345678 12345678 12345678 12345678 12345678 12345678 12345678
-            12345678 12345678 12345678 12345678 12345678 12345678"
+
+        android:text= "12345678 12345678 12345678 12345678 12345678 12345678 12345678 12345678
+12345678 12345678 12345678 12345678 12345678 12345678"
         tools:layout_constraintTop_creator="1" tools:layout_constraintRight_creator="1"
         android:layout_marginStart="16dp" android:layout_marginEnd="16dp"
         app:layout_constraintRight_toRightOf="parent" android:layout_marginTop="16dp"

--- a/constraintlayout/core/src/test/resources/check10.xml
+++ b/constraintlayout/core/src/test/resources/check10.xml
@@ -23,7 +23,8 @@
 
     <TextView android:id="@+id/textView4" android:layout_width="0dp"
         android:layout_height="wrap_content" android:tag="48,48,984,204"
-        android:text="12345678 12345678 12345678 12345678 12345678 12345678 12345678 12345678 12345678 12345678 12345678 12345678 12345678 12345678"
+        android:text="12345678 12345678 12345678 12345678 12345678 12345678 12345678 12345678
+            12345678 12345678 12345678 12345678 12345678 12345678"
         tools:layout_constraintTop_creator="1" tools:layout_constraintRight_creator="1"
         android:layout_marginStart="16dp" android:layout_marginEnd="16dp"
         app:layout_constraintRight_toRightOf="parent" android:layout_marginTop="16dp"

--- a/constraintlayout/core/src/test/resources/check12.xml
+++ b/constraintlayout/core/src/test/resources/check12.xml
@@ -30,7 +30,8 @@
 
     <TextView android:id="@+id/textView4" android:layout_width="0dp"
         android:layout_height="wrap_content" android:tag="48,48,984,204"
-        android:text="12345678 12345678 12345678 12345678 12345678 12345678 12345678 12345678 12345678 12345678 12345678 12345678 12345678 12345678"
+        android:text="12345678 12345678 12345678 12345678 12345678 12345678 12345678 12345678
+            12345678 12345678 12345678 12345678 12345678 12345678"
         tools:layout_constraintTop_creator="1" tools:layout_constraintRight_creator="1"
         android:layout_marginStart="16dp" android:layout_marginEnd="16dp"
         app:layout_constraintRight_toRightOf="parent" android:layout_marginTop="16dp"

--- a/constraintlayout/core/src/test/resources/check12.xml
+++ b/constraintlayout/core/src/test/resources/check12.xml
@@ -31,7 +31,7 @@
     <TextView android:id="@+id/textView4" android:layout_width="0dp"
         android:layout_height="wrap_content" android:tag="48,48,984,204"
         android:text="12345678 12345678 12345678 12345678 12345678 12345678 12345678 12345678
-            12345678 12345678 12345678 12345678 12345678 12345678"
+12345678 12345678 12345678 12345678 12345678 12345678"
         tools:layout_constraintTop_creator="1" tools:layout_constraintRight_creator="1"
         android:layout_marginStart="16dp" android:layout_marginEnd="16dp"
         app:layout_constraintRight_toRightOf="parent" android:layout_marginTop="16dp"


### PR DESCRIPTION
Fix the warnings of the AOSP presubmit checks.
There are three issues:
1. length exceed 100
2. trailing space
3. typo