### PR TITLE
Enable the Flow helper in the JSON syntax

### DIFF
--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintReference.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintReference.java
@@ -1055,19 +1055,7 @@ public class ConstraintReference implements Reference {
         }
     }
 
-    // @TODO: add description
-    @Override
-    public void apply() {
-        if (mConstraintWidget == null) {
-            return;
-        }
-        if (mFacade != null) {
-            mFacade.apply();
-        }
-        mHorizontalDimension.apply(mState, mConstraintWidget, HORIZONTAL);
-        mVerticalDimension.apply(mState, mConstraintWidget, VERTICAL);
-        dereference();
-
+    public void applyWidgetConstraints() {
         applyConnection(mConstraintWidget, mLeftToLeft, State.Constraint.LEFT_TO_LEFT);
         applyConnection(mConstraintWidget, mLeftToRight, State.Constraint.LEFT_TO_RIGHT);
         applyConnection(mConstraintWidget, mRightToLeft, State.Constraint.RIGHT_TO_LEFT);
@@ -1086,6 +1074,22 @@ public class ConstraintReference implements Reference {
         applyConnection(mConstraintWidget, mBaselineToBottom, State.Constraint.BASELINE_TO_BOTTOM);
         applyConnection(mConstraintWidget, mCircularConstraint,
                 State.Constraint.CIRCULAR_CONSTRAINT);
+    }
+
+    // @TODO: add description
+    @Override
+    public void apply() {
+        if (mConstraintWidget == null) {
+            return;
+        }
+        if (mFacade != null) {
+            mFacade.apply();
+        }
+        mHorizontalDimension.apply(mState, mConstraintWidget, HORIZONTAL);
+        mVerticalDimension.apply(mState, mConstraintWidget, VERTICAL);
+        dereference();
+
+        applyWidgetConstraints();
 
         if (mHorizontalChainStyle != ConstraintWidget.CHAIN_SPREAD) {
             mConstraintWidget.setHorizontalChainStyle(mHorizontalChainStyle);

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/State.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/State.java
@@ -16,18 +16,25 @@
 
 package androidx.constraintlayout.core.state;
 
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.CHAIN_PACKED;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.CHAIN_SPREAD;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.CHAIN_SPREAD_INSIDE;
+
 import androidx.constraintlayout.core.state.helpers.AlignHorizontallyReference;
 import androidx.constraintlayout.core.state.helpers.AlignVerticallyReference;
 import androidx.constraintlayout.core.state.helpers.BarrierReference;
 import androidx.constraintlayout.core.state.helpers.GuidelineReference;
 import androidx.constraintlayout.core.state.helpers.HorizontalChainReference;
+import androidx.constraintlayout.core.state.helpers.HorizontalFlowReference;
 import androidx.constraintlayout.core.state.helpers.VerticalChainReference;
+import androidx.constraintlayout.core.state.helpers.VerticalFlowReference;
 import androidx.constraintlayout.core.widgets.ConstraintWidget;
 import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer;
 import androidx.constraintlayout.core.widgets.HelperWidget;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Represents a full state of a ConstraintLayout
@@ -84,13 +91,93 @@ public class State {
         ALIGN_VERTICALLY,
         BARRIER,
         LAYER,
+        HORIZONTAL_FLOW,
+        VERTICAL_FLOW,
         FLOW
     }
 
     public enum Chain {
         SPREAD,
         SPREAD_INSIDE,
-        PACKED
+        PACKED;
+
+        public static Map<String, Chain> chainMap = new HashMap<>();
+        public static Map<String, Integer> valueMap = new HashMap<>();
+        static {
+            chainMap.put("packed", PACKED);
+            chainMap.put("spread_inside", SPREAD_INSIDE);
+            chainMap.put("spread", SPREAD);
+
+            valueMap.put("packed", CHAIN_PACKED);
+            valueMap.put("spread_inside", CHAIN_SPREAD_INSIDE);
+            valueMap.put("spread", CHAIN_SPREAD);
+        }
+
+        /**
+         * Get the Enum value with a String
+         * @param str a String representation of a Enum value
+         * @return a Enum value
+         */
+        public static int getValueByString(String str) {
+            if (valueMap.containsKey(str)) {
+                return valueMap.get(str);
+            }
+            return UNKNOWN;
+        }
+
+        /**
+         * Get the actual int value with a String
+         * @param str a String representation of a Enum value
+         * @return an actual int value
+         */
+        public static Chain getChainByString(String str) {
+            if (chainMap.containsKey(str)) {
+                return chainMap.get(str);
+            }
+            return null;
+        }
+
+    }
+
+    public enum Wrap {
+        NONE,
+        CHAIN,
+        ALIGNED;
+        public static Map<String, Wrap> wrapMap = new HashMap<>();
+        public static Map<String, Integer> valueMap = new HashMap<>();
+        static {
+            wrapMap.put("none", NONE);
+            wrapMap.put("chain", CHAIN);
+            wrapMap.put("aligned", ALIGNED);
+
+            valueMap.put("none", 0);
+            valueMap.put("chain", 1);
+            valueMap.put("aligned", 2);
+        }
+
+        /**
+         * Get the actual int value with a String
+         * @param str a String representation of a Enum value
+         * @return a actual int value
+         */
+        public static int getValueByString(String str) {
+            if (valueMap.containsKey(str)) {
+                return valueMap.get(str);
+            }
+            return UNKNOWN;
+        }
+
+        /**
+         * Get the Enum value with a String
+         * @param str a String representation of a Enum value
+         * @return a Enum value
+         */
+        public static Wrap getChainByString(String str) {
+            if (wrapMap.containsKey(str)) {
+                return wrapMap.get(str);
+            }
+            return null;
+        }
     }
 
     public State() {
@@ -231,6 +318,14 @@ public class State {
                     reference = new BarrierReference(this);
                 }
                 break;
+                case HORIZONTAL_FLOW: {
+                    reference = new HorizontalFlowReference(this);
+                }
+                break;
+                case VERTICAL_FLOW: {
+                    reference = new VerticalFlowReference(this);
+                }
+                break;
                 default: {
                     reference = new HelperReference(this, type);
                 }
@@ -297,6 +392,46 @@ public class State {
     public HorizontalChainReference horizontalChain(Object... references) {
         HorizontalChainReference reference =
                 (HorizontalChainReference) helper(null, Helper.HORIZONTAL_CHAIN);
+        reference.add(references);
+        return reference;
+    }
+
+    /**
+     * Get a VerticalFlowReference
+     * @return a VerticalFlowReference
+     */
+    public VerticalFlowReference verticalFlow() {
+        return (VerticalFlowReference) helper(null, Helper.VERTICAL_FLOW);
+    }
+
+    /**
+     * Get a VerticalFlowReference and add it to references
+     * @param references where we add the VerticalFlowReference
+     * @return a VerticalFlowReference
+     */
+    public VerticalFlowReference verticalFlow(Object... references) {
+        VerticalFlowReference reference =
+                (VerticalFlowReference) helper(null, State.Helper.VERTICAL_FLOW);
+        reference.add(references);
+        return reference;
+    }
+
+    /**
+     * Get a HorizontalFlowReference
+     * @return a HorizontalFlowReference
+     */
+    public HorizontalFlowReference horizontalFlow() {
+        return (HorizontalFlowReference) helper(null, Helper.HORIZONTAL_FLOW);
+    }
+
+    /**
+     * Get a HorizontalFlowReference and add it to references
+     * @param references references where we the HorizontalFlowReference
+     * @return a HorizontalFlowReference
+     */
+    public HorizontalFlowReference horizontalFlow(Object... references) {
+        HorizontalFlowReference reference =
+                (HorizontalFlowReference) helper(null, Helper.HORIZONTAL_FLOW);
         reference.add(references);
         return reference;
     }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/FlowReference.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/FlowReference.java
@@ -535,6 +535,7 @@ abstract public class FlowReference extends HelperReference {
     @Override
     public void apply() {
         getHelperWidget();
+        this.setConstraintWidget(mFlow);
         mFlow.setOrientation(mOrientation);
         mFlow.setWrapMode(mWrapMode);
 
@@ -602,38 +603,7 @@ abstract public class FlowReference extends HelperReference {
         }
 
         // Constraint
-        if (mStartToStart != null) {mFlow.connect(ConstraintAnchor.Type.LEFT,
-                ((ConstraintReference) mStartToStart).getConstraintWidget(),
-                ConstraintAnchor.Type.LEFT);
-        }
-        if (mStartToEnd != null) {mFlow.connect(ConstraintAnchor.Type.LEFT,
-                ((ConstraintReference) mStartToEnd).getConstraintWidget(),
-                ConstraintAnchor.Type.RIGHT);
-        }
-        if (mEndToStart != null) {mFlow.connect(ConstraintAnchor.Type.RIGHT,
-                ((ConstraintReference) mEndToStart).getConstraintWidget(),
-                ConstraintAnchor.Type.LEFT);
-        }
-        if (mEndToEnd != null) {mFlow.connect(ConstraintAnchor.Type.RIGHT,
-                ((ConstraintReference) mEndToEnd).getConstraintWidget(),
-                ConstraintAnchor.Type.RIGHT);
-        }
-        if (mTopToTop != null) { mFlow.connect(ConstraintAnchor.Type.TOP,
-                ((ConstraintReference) mTopToTop).getConstraintWidget(),
-                ConstraintAnchor.Type.TOP);
-        }
-        if (mTopToBottom != null) {mFlow.connect(ConstraintAnchor.Type.TOP,
-                ((ConstraintReference) mTopToBottom).getConstraintWidget(),
-                ConstraintAnchor.Type.BOTTOM);
-        }
-        if (mBottomToTop != null) {mFlow.connect(ConstraintAnchor.Type.BOTTOM,
-                ((ConstraintReference) mBottomToTop).getConstraintWidget(),
-                ConstraintAnchor.Type.TOP);
-        }
-        if (mBottomToBottom != null) {mFlow.connect(ConstraintAnchor.Type.BOTTOM,
-                ((ConstraintReference) mBottomToBottom).getConstraintWidget(),
-                ConstraintAnchor.Type.BOTTOM);
-        }
+        applyWidgetConstraints();
 
         // TODO - Need to figure out how to set these values properly.
         mFlow.measure(AT_MOST, 1000, AT_MOST,1000);

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/FlowReference.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/FlowReference.java
@@ -1,0 +1,641 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.state.helpers;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.HORIZONTAL;
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.UNKNOWN;
+import static androidx.constraintlayout.core.widgets.analyzer.BasicMeasure.AT_MOST;
+
+import androidx.constraintlayout.core.state.ConstraintReference;
+import androidx.constraintlayout.core.state.HelperReference;
+import androidx.constraintlayout.core.state.State;
+import androidx.constraintlayout.core.widgets.ConstraintAnchor;
+import androidx.constraintlayout.core.widgets.Flow;
+import androidx.constraintlayout.core.widgets.HelperWidget;
+
+import java.util.HashMap;
+
+/**
+ * The FlowReference class can be used to store the relevant properties of a Flow Helper
+ * when parsing the Flow Helper information in a JSON representation.
+ *
+ */
+abstract public class FlowReference extends HelperReference {
+
+    public static final int HORIZONTAL_ALIGN_START = 0;
+    public static final int HORIZONTAL_ALIGN_END = 1;
+    public static final int HORIZONTAL_ALIGN_CENTER = 2;
+
+    public static final int VERTICAL_ALIGN_TOP = 0;
+    public static final int VERTICAL_ALIGN_BOTTOM = 1;
+    public static final int VERTICAL_ALIGN_CENTER = 2;
+    public static final int VERTICAL_ALIGN_BASELINE = 3;
+
+    public static final int WRAP_NONE = 0;
+    public static final int WRAP_CHAIN = 1;
+    public static final int WRAP_ALIGNED = 2;
+    public static final int WRAP_CHAIN_NEW = 3;
+
+    protected Flow mFlow;
+
+    protected HashMap<String, Float> mMapWeights;
+    protected HashMap<String, Float> mMapPreMargin;
+    protected HashMap<String, Float> mMapPostMargin;
+
+    protected int mWrapMode = WRAP_NONE;
+
+    protected int mVerticalStyle = UNKNOWN;
+    protected int mFirstVerticalStyle = UNKNOWN;
+    protected int mLastVerticalStyle = UNKNOWN;
+    protected int mHorizontalStyle = UNKNOWN;
+    protected int mFirstHorizontalStyle = UNKNOWN;
+    protected int mLastHorizontalStyle = UNKNOWN;
+
+    protected int mVerticalAlign = HORIZONTAL_ALIGN_CENTER;
+    protected int mHorizontalAlign = VERTICAL_ALIGN_CENTER;
+
+    protected int mVerticalGap = 0;
+    protected int mHorizontalGap = 0;
+
+    protected int mPadding = 0;
+
+    protected int mMaxElementsWrap = UNKNOWN;
+
+    protected int mOrientation = HORIZONTAL;
+
+    protected float mVerticalBias = 0.5f;
+    protected float mFirstVerticalBias = 0.5f;
+    protected float mLastVerticalBias = 0.5f;
+    protected float mHorizontalBias = 0.5f;
+    protected float mFirstHorizontalBias = 0.5f;
+    protected float mLastHorizontalBias = 0.5f;
+
+    public FlowReference(State state, State.Helper type) {
+        super(state, type);
+    }
+
+    /**
+     * Relate widgets to the FlowReference
+     * @param id id of a widget
+     * @param weight weight of a widget
+     * @param preMargin preMargin of a widget
+     * @param postMargin postMargin of a widget
+     */
+    public void addFlowElement(String id, float weight, float preMargin, float postMargin) {
+        super.add(id);
+        if (!Float.isNaN(weight)) {
+            if (mMapWeights == null) {
+                mMapWeights = new HashMap<>();
+            }
+            mMapWeights.put(id, weight);
+        }
+        if (!Float.isNaN(preMargin)) {
+            if (mMapPreMargin == null) {
+                mMapPreMargin = new HashMap<>();
+            }
+            mMapPreMargin.put(id, preMargin);
+        }
+        if (!Float.isNaN(postMargin)) {
+            if (mMapPostMargin == null) {
+                mMapPostMargin = new HashMap<>();
+            }
+            mMapPostMargin.put(id, postMargin);
+        }
+    }
+
+    /**
+     * Get the weight of a widget
+     * @param id id of a widget
+     * @return the weight of a widget
+     */
+    protected float getWeight(String id) {
+        if (mMapWeights == null) {
+            return UNKNOWN;
+        }
+        if (mMapWeights.containsKey(id)) {
+            return mMapWeights.get(id);
+        }
+        return UNKNOWN;
+    }
+
+    /**
+     * Get the post margin of a widget
+     * @param id id id of a widget
+     * @return the post margin of a widget
+     */
+    protected float getPostMargin(String id) {
+        if (mMapPreMargin != null  && mMapPreMargin.containsKey(id)) {
+            return mMapPreMargin.get(id);
+        }
+        return 0;
+    }
+
+    /**
+     * Get the pre margin of a widget
+     * @param id id id of a widget
+     * @return the pre margin of a widget
+     */
+    protected float getPreMargin(String id) {
+        if (mMapPostMargin != null  && mMapPostMargin.containsKey(id)) {
+            return mMapPostMargin.get(id);
+        }
+        return 0;
+    }
+
+    /**
+     * Get wrap mode
+     * @return wrap mode
+     */
+    public int getWrapMode() {
+        return mWrapMode;
+    }
+
+    /**
+     * Set wrap Mode
+     * @param wrap wrap Mode
+     * @return FlowReference (this)
+     */
+    public FlowReference wrapMode(int wrap) {
+        this.mWrapMode = wrap;
+        return this;
+    }
+
+    /**
+     * Get padding
+     * @return padding value
+     */
+    public int getPadding() {
+        return mPadding;
+    }
+
+    /**
+     * Set padding
+     * @param padding padding value
+     * @return FlowReference (this)
+     */
+    public FlowReference padding(int padding) {
+        this.mPadding = padding;
+        return this;
+    }
+
+    /**
+     * Get vertical style
+     * @return vertical style
+     */
+    public int getVerticalStyle() {
+        return mVerticalStyle;
+    }
+
+    /**
+     * set vertical sytle
+     * @param verticalStyle Flow vertical style
+     * @return FlowReference (this)
+     */
+    public FlowReference verticalStyle(int verticalStyle) {
+        this.mVerticalStyle = verticalStyle;
+        return this;
+    }
+
+    /**
+     * Get first vertical style
+     * @return first vertical style
+     */
+    public int getFirstVerticalStyle() {
+        return mFirstVerticalStyle;
+    }
+
+    /**
+     * Set first vertical style
+     * @param firstVerticalStyle Flow first vertical style
+     * @return FlowReference (this)
+     */
+    public FlowReference firstVerticalStyle(int firstVerticalStyle) {
+        this.mFirstVerticalStyle = firstVerticalStyle;
+        return this;
+    }
+
+    /**
+     * Get last vertical style
+     * @return last vertical style
+     */
+    public int getLastVerticalStyle() {
+        return mLastVerticalStyle;
+    }
+
+    /**
+     * Set last vertical style
+     * @param lastVerticalStyle Flow last vertical style
+     * @return FlowReference (this)
+     */
+    public FlowReference lastVerticalStyle(int lastVerticalStyle) {
+        this.mLastVerticalStyle = lastVerticalStyle;
+        return this;
+    }
+
+    /**
+     * Get horizontal style
+     * @return horizontal style
+     */
+    public int getHorizontalStyle() {
+        return mHorizontalStyle;
+    }
+
+    /**
+     * Set horizontal style
+     * @param horizontalStyle Flow horizontal style
+     * @return FlowReference (this)
+     */
+    public FlowReference horizontalStyle(int horizontalStyle) {
+        this.mHorizontalStyle = horizontalStyle;
+        return this;
+    }
+
+    /**
+     * Get first horizontal style
+     * @return first horizontal style
+     */
+    public int getFirstHorizontalStyle() {
+        return mFirstHorizontalStyle;
+    }
+
+    /**
+     * Set first horizontal style
+     * @param firstHorizontalStyle Flow first horizontal style
+     * @return FlowReference (this)
+     */
+    public FlowReference firstHorizontalStyle(int firstHorizontalStyle) {
+        this.mFirstHorizontalStyle = firstHorizontalStyle;
+        return this;
+    }
+
+    /**
+     * Get last horizontal style
+     * @return last horizontal style
+     */
+    public int getLastHorizontalStyle() {
+        return mLastHorizontalStyle;
+    }
+
+    /**
+     * Set last horizontal style
+     * @param lastHorizontalStyle Flow last horizontal style
+     * @return FlowReference (this)
+     */
+    public FlowReference lastHorizontalStyle(int lastHorizontalStyle) {
+        this.mLastHorizontalStyle = lastHorizontalStyle;
+        return this;
+    }
+
+    /**
+     * Get vertical align
+     * @return vertical align value
+     */
+    public int getVerticalAlign() {
+        return mVerticalAlign;
+    }
+
+    /**
+     * Set vertical align
+     * @param verticalAlign vertical align value
+     * @return FlowReference (this)
+     */
+    public FlowReference verticalAlign(int verticalAlign) {
+        this.mVerticalAlign = verticalAlign;
+        return this;
+    }
+
+    /**
+     * Get horizontal align
+     * @return horizontal align value
+     */
+    public int getHorizontalAlign() {
+        return mHorizontalAlign;
+    }
+
+    /**
+     * Set horizontal align
+     * @param horizontalAlign horizontal align value
+     * @return FlowReference (this)
+     */
+    public FlowReference horizontalAlign(int horizontalAlign) {
+        this.mHorizontalAlign = horizontalAlign;
+        return this;
+    }
+
+    /**
+     * Get vertical gap
+     * @return vertical gap value
+     */
+    public int getVerticalGap() {
+        return mVerticalGap;
+    }
+
+    /**
+     * Set vertical gap
+     * @param verticalGap vertical gap value
+     * @return FlowReference (this)
+     */
+    public FlowReference verticalGap(int verticalGap) {
+        this.mVerticalGap = verticalGap;
+        return this;
+    }
+
+    /**
+     * Get horizontal gap
+     * @return horizontal gap value
+     */
+    public int getHorizontalGap() {
+        return mHorizontalGap;
+    }
+
+    /**
+     * Set horizontal gap
+     * @param horizontalGap horizontal gap value
+     * @return FlowReference (this)
+     */
+    public FlowReference horizontalGap(int horizontalGap) {
+        mHorizontalGap = horizontalGap;
+        return this;
+    }
+
+    /**
+     * Get max element wrap
+     * @return max element wrap value
+     */
+    public int getMaxElementsWrap() {
+        return mMaxElementsWrap;
+    }
+
+    /**
+     * Set max element wrap
+     * @param maxElementsWrap max element wrap value
+     * @return FlowReference (this)
+     */
+    public FlowReference maxElementsWrap(int maxElementsWrap) {
+        this.mMaxElementsWrap = maxElementsWrap;
+        return this;
+    }
+
+    /**
+     * Get the orientation of a Flow
+     * @return orientation value
+     */
+    public int getOrientation() {
+        return mOrientation;
+    }
+
+    /**
+     * Set the orientation of a Flow
+     * @param mOrientation orientation value
+     * @return FlowReference (this)
+     */
+    public FlowReference orientation(int mOrientation) {
+        this.mOrientation = mOrientation;
+        return this;
+    }
+
+    /**
+     * Get vertical bias
+     * @return vertical bias value
+     */
+    public float getVerticalBias() {
+        return mVerticalBias;
+    }
+
+    /**
+     * Set vertical bias value
+     * @param verticalBias vertical bias value
+     * @return FlowReference (this)
+     */
+    public FlowReference verticalBias(float verticalBias) {
+        this.mVerticalBias = verticalBias;
+        return this;
+    }
+
+    /**
+     * Get first vertical bias
+     * @return first vertical bias value
+     */
+    public float getFirstVerticalBias() {
+        return mFirstVerticalBias;
+    }
+
+    /**
+     * Set first vertical bias
+     * @param firstVerticalBias first vertical bias value
+     * @return FlowReference (this)
+     */
+    public FlowReference firstVerticalBias(float firstVerticalBias) {
+        this.mFirstVerticalBias = firstVerticalBias;
+        return this;
+    }
+
+    /**
+     * Get last vertical bias
+     * @return last vertical bias
+     */
+    public float getLastVerticalBias() {
+        return mLastVerticalBias;
+    }
+
+    /**
+     * Set last vertical bias
+     * @param lastVerticalBias last vertical bias value
+     * @return FlowReference (this)
+     */
+    public FlowReference lastVerticalBias(float lastVerticalBias) {
+        this.mLastVerticalBias = lastVerticalBias;
+        return this;
+    }
+
+    /**
+     * Get horizontal bias
+     * @return horizontal bias value
+     */
+    public float getHorizontalBias() {
+        return mHorizontalBias;
+    }
+
+    /**
+     * Set horizontal bias
+     * @param horizontalBias horizontal bias value
+     * @return FlowReference (this)
+     */
+    public FlowReference horizontalBias(float horizontalBias) {
+        this.mHorizontalBias = horizontalBias;
+        return this;
+    }
+
+    /**
+     * Get first horizontal bias
+     * @return first horizontal bias
+     */
+    public float getFirstHorizontalBias() {
+        return mFirstHorizontalBias;
+    }
+
+    /**
+     * Set first horizontal bias
+     * @param firstHorizontalBias first horizontal bias value
+     * @return FlowReference (this)
+     */
+    public FlowReference firstHorizontalBias(float firstHorizontalBias) {
+        this.mFirstHorizontalBias = firstHorizontalBias;
+        return this;
+    }
+
+    /**
+     * Get last horizontal bias
+     * @return last horizontal bias value
+     */
+    public float getLastHorizontalBias() {
+        return mLastHorizontalBias;
+    }
+
+    /**
+     * Set last horizontal bias
+     * @param lastHorizontalBias last horizontal bias value
+     * @return FlowReference (this)
+     */
+    public FlowReference lastHorizontalBias(float lastHorizontalBias) {
+        this.mLastHorizontalBias = lastHorizontalBias;
+        return this;
+    }
+
+    @Override
+    public HelperWidget getHelperWidget() {
+        if (mFlow == null) {
+            mFlow = new Flow();
+        }
+        return mFlow;
+    }
+
+    @Override
+    public void setHelperWidget(HelperWidget widget) {
+        if (widget instanceof Flow) {
+            mFlow = (Flow) widget;
+        } else {
+            mFlow = null;
+        }
+    }
+
+    @Override
+    public void apply() {
+        getHelperWidget();
+        mFlow.setOrientation(mOrientation);
+        mFlow.setWrapMode(mWrapMode);
+
+        if (mMaxElementsWrap != UNKNOWN) {
+            mFlow.setMaxElementsWrap(mMaxElementsWrap);
+        }
+        if (mPadding != 0) {
+            mFlow.setPadding(mPadding);
+        }
+
+        // Gap
+        if (mHorizontalGap != 0) {
+            mFlow.setHorizontalGap(mHorizontalGap);
+        }
+        if (mVerticalGap != 0) {
+            mFlow.setVerticalGap(mVerticalGap);
+        }
+
+        // Bias
+        if (mHorizontalBias != 0.5f) {
+            mFlow.setHorizontalBias(mHorizontalBias);
+        }
+        if (mFirstHorizontalBias != 0.5f) {
+            mFlow.setFirstHorizontalBias(mFirstHorizontalBias);
+        }
+        if (mLastHorizontalBias != 0.5f) {
+            mFlow.setLastHorizontalBias(mLastHorizontalBias);
+        }
+        if (mVerticalBias != 0.5f) {
+            mFlow.setVerticalBias(mVerticalBias);
+        }
+        if (mFirstVerticalBias != 0.5f) {
+            mFlow.setFirstVerticalBias(mFirstVerticalBias);
+        }
+        if (mLastVerticalBias != 0.5f) {
+            mFlow.setLastVerticalBias(mLastVerticalBias);
+        }
+
+        // Align
+        if (mHorizontalAlign != HORIZONTAL_ALIGN_CENTER) {
+            mFlow.setHorizontalAlign(mHorizontalAlign);
+        }
+        if (mVerticalAlign != VERTICAL_ALIGN_CENTER) {
+            mFlow.setVerticalAlign(mVerticalAlign);
+        }
+
+        // Style
+        if (mVerticalStyle != UNKNOWN) {
+            mFlow.setVerticalStyle(mVerticalStyle);
+        }
+        if (mFirstVerticalStyle != UNKNOWN) {
+            mFlow.setFirstVerticalStyle(mFirstVerticalStyle);
+        }
+        if (mLastVerticalStyle != UNKNOWN) {
+            mFlow.setLastVerticalStyle(mLastVerticalStyle);
+        }
+        if (mHorizontalStyle != UNKNOWN) {
+            mFlow.setHorizontalStyle(mHorizontalStyle);
+        }
+        if (mFirstHorizontalStyle != UNKNOWN) {
+            mFlow.setFirstVerticalStyle(mFirstHorizontalStyle);
+        }
+        if (mLastVerticalStyle != UNKNOWN) {
+            mFlow.setLastVerticalStyle(mLastVerticalStyle);
+        }
+
+        // Constraint
+        if (mStartToStart != null) {mFlow.connect(ConstraintAnchor.Type.LEFT,
+                ((ConstraintReference) mStartToStart).getConstraintWidget(),
+                ConstraintAnchor.Type.LEFT);
+        }
+        if (mStartToEnd != null) {mFlow.connect(ConstraintAnchor.Type.LEFT,
+                ((ConstraintReference) mStartToEnd).getConstraintWidget(),
+                ConstraintAnchor.Type.RIGHT);
+        }
+        if (mEndToStart != null) {mFlow.connect(ConstraintAnchor.Type.RIGHT,
+                ((ConstraintReference) mEndToStart).getConstraintWidget(),
+                ConstraintAnchor.Type.LEFT);
+        }
+        if (mEndToEnd != null) {mFlow.connect(ConstraintAnchor.Type.RIGHT,
+                ((ConstraintReference) mEndToEnd).getConstraintWidget(),
+                ConstraintAnchor.Type.RIGHT);
+        }
+        if (mTopToTop != null) { mFlow.connect(ConstraintAnchor.Type.TOP,
+                ((ConstraintReference) mTopToTop).getConstraintWidget(),
+                ConstraintAnchor.Type.TOP);
+        }
+        if (mTopToBottom != null) {mFlow.connect(ConstraintAnchor.Type.TOP,
+                ((ConstraintReference) mTopToBottom).getConstraintWidget(),
+                ConstraintAnchor.Type.BOTTOM);
+        }
+        if (mBottomToTop != null) {mFlow.connect(ConstraintAnchor.Type.BOTTOM,
+                ((ConstraintReference) mBottomToTop).getConstraintWidget(),
+                ConstraintAnchor.Type.TOP);
+        }
+        if (mBottomToBottom != null) {mFlow.connect(ConstraintAnchor.Type.BOTTOM,
+                ((ConstraintReference) mBottomToBottom).getConstraintWidget(),
+                ConstraintAnchor.Type.BOTTOM);
+        }
+
+        // TODO - Need to figure out how to set these values properly.
+        mFlow.measure(AT_MOST, 1000, AT_MOST,1000);
+    }
+}

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/HorizontalFlowReference.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/HorizontalFlowReference.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.state.helpers;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.HORIZONTAL;
+
+import androidx.constraintlayout.core.state.State;
+
+public class HorizontalFlowReference extends FlowReference {
+    public HorizontalFlowReference(State state) {
+        super(state, State.Helper.HORIZONTAL_FLOW);
+        mOrientation = HORIZONTAL;
+    }
+}

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/VerticalFlowReference.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/VerticalFlowReference.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.constraintlayout.core.state.helpers;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.VERTICAL;
+
+import androidx.constraintlayout.core.state.State;
+
+/**
+ * The VerticalFlowReference class can be used to store the relevant properties of a Flow Helper
+ * when parsing the Flow Helper information in a JSON representation
+ */
+public class VerticalFlowReference extends FlowReference {
+    public VerticalFlowReference(State state) {
+        super(state, State.Helper.VERTICAL_FLOW);
+        mOrientation = VERTICAL;
+    }
+}

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/FlowDemo.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/FlowDemo.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.constraintlayout
+
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.constraintlayout.compose.*
+
+
+@Preview(group = "flow")
+@Composable
+public fun FlowDemo1() {
+    // Currently, we still have problem with positioning the Flow Helper
+    // and/or setting the width/height properly.
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            flow1: { 
+                width: 'match_parent',
+                height: 'match_parent',
+                type: 'hFlow',
+                wrap: 'none',
+                contains: ['1', '2', '3', '4'],
+              }
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val numArray = arrayOf("1", "2", "3", "4")
+        for (num in numArray) {
+            Button(
+                modifier = Modifier.layoutId(num),
+                onClick = {},
+            ) {
+                Text(text = num)
+            }
+        }
+    }
+}
+
+@Preview(group = "flow")
+@Composable
+public fun FlowDemo2() {
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            flow1: { 
+                width: 'match_parent',
+                height: 'match_parent',
+                type: 'vFlow',
+                wrap: 'none',
+                contains: ['1', '2', '3', '4'],
+                centerVertically: 'parent',
+                centerHorizontally: 'parent',
+              }
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val numArray = arrayOf("1", "2", "3", "4")
+        for (num in numArray) {
+            Button(
+                modifier = Modifier.layoutId(num),
+                onClick = {},
+            ) {
+                Text(text = num)
+            }
+        }
+    }
+}
+
+@Preview(group = "flow")
+@Composable
+public fun FlowDemo3() {
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            flow1: { 
+                width: 'match_parent',
+                height: 'match_parent',
+                type: 'hFlow',
+                wrap: 'chain',
+                vFlowBias: 0.1,
+                hFlowBias: 0.8,
+                maxElement: 4,
+                contains: ['1', '2', '3', '4', '5', '6', '7'],
+                start: ['parent', 'start'],
+                end: ['parent', 'end'],
+                top: ['parent', 'top'],
+                bottom: ['parent', 'bottom'],
+              }
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val numArray = arrayOf("1", "2", "3", "4", "5", "6", "7")
+        for (num in numArray) {
+            Button(
+                modifier = Modifier.layoutId(num),
+                onClick = {},
+            ) {
+                Text(text = num)
+            }
+        }
+    }
+}
+
+@Preview(group = "flow")
+@Composable
+public fun FlowDemo4() {
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            flow1: { 
+                width: 'match_parent',
+                height: 'match_parent',
+                type: 'vFlow',
+                vGap: 32,
+                hGap: 32,
+                wrap: 'aligned',
+                center: 'parent',
+                maxElement: 3,
+                contains: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
+              }
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val chArray = arrayOf("a", "b", "c", "d", "e", "f", "g", "h")
+        for (ch in chArray) {
+            Button(
+                modifier = Modifier.layoutId(ch),
+                onClick = {},
+            ) {
+                Text(text = ch)
+            }
+        }
+    }
+}
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
The Initial work to enable the Flow Helper in the JSON syntax within a ConstraintSet.

Add a parseFlowType function in CosntraintSetParser.java to parse the attributes of a Flow helper.
Add reference class for the Flow Helper, including FlowReference.java, HorizontalFlowReference.java, and VerticalFlowReference.java
Also, add new functions, switch statements in State.java to enable this work.