### PR TITLE
Fix issues with the FlowReference

### DIFF
--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintSetParser.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintSetParser.java
@@ -940,6 +940,7 @@ public class ConstraintSetParser {
                     } else {
                         flow.setOrientation(VERTICAL);
                     }
+                    break;
                 case "wrap":
                     String wrapValue = element.get(param).content();
                     flow.setWrapMode(State.Wrap.getValueByString(wrapValue));

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/HelperReference.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/HelperReference.java
@@ -63,4 +63,11 @@ public class HelperReference extends ConstraintReference implements Facade {
     public void apply() {
         // nothing
     }
+
+    /**
+     * Allows the derived classes to invoke the apply method in the ConstraintReference
+     */
+    public void applyBase() {
+        super.apply();
+    }
 }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/FlowReference.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/FlowReference.java
@@ -594,8 +594,8 @@ public class FlowReference extends HelperReference {
             mFlow.setLastHorizontalStyle(mLastVerticalStyle);
         }
 
-        // Constraint
-        applyWidgetConstraints();
+        // General attributes of a widget
+        applyBase();
 
         // TODO - Need to figure out how to set these values properly.
         mFlow.measure(AT_MOST, 1000, AT_MOST,1000);


### PR DESCRIPTION
Fix issues of the FlowReference relevant code.
1. add break; for the switch statement in parseFlowType.
2. invoke the apply method in ConstraintReference to ensure that the general attributes of a Widget can be handled properly