### PR TITLE
[JSON] Enable match_parent width and height for Flow

### DIFF
--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayout.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayout.kt
@@ -95,6 +95,7 @@ import androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviou
 import androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_SPREAD
 import androidx.constraintlayout.core.widgets.ConstraintWidget.MATCH_CONSTRAINT_WRAP
 import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer
+import androidx.constraintlayout.core.widgets.Flow
 import androidx.constraintlayout.core.widgets.Guideline
 import androidx.constraintlayout.core.widgets.HelperWidget
 import androidx.constraintlayout.core.widgets.Optimizer
@@ -1271,6 +1272,14 @@ internal open class Measurer : BasicMeasure.Measurer, DesignInfoProvider {
             Log.d("CCL", root.toDebugString())
             for (child in root.children) {
                 Log.d("CCL", child.toDebugString())
+            }
+        }
+
+        // invoke the measure method of a Flow helper to properly measure the widgets
+        // associated with the Flow helper
+        for (child in root.children) {
+            if (child is Flow) {
+                child.measure(BasicMeasure.UNSPECIFIED, root.width, BasicMeasure.UNSPECIFIED, root.height)
             }
         }
 

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintReference.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintReference.java
@@ -68,8 +68,8 @@ public class ConstraintReference implements Reference {
     float mHorizontalChainWeight = UNKNOWN;
     float mVerticalChainWeight = UNKNOWN;
 
-    float mHorizontalBias = 0.5f;
-    float mVerticalBias = 0.5f;
+    protected float mHorizontalBias = 0.5f;
+    protected float mVerticalBias = 0.5f;
 
     protected int mMarginLeft = 0;
     protected int mMarginRight = 0;

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintSetParser.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintSetParser.java
@@ -1027,7 +1027,7 @@ public class ConstraintSetParser {
                         vBiasValue = vBiasObject.getFloat();
                     }
                     try {
-                        flow.setVerticalBias(vBiasValue);
+                        flow.verticalBias(vBiasValue);
                         if (vFirstBiasValue != 0.5f) {
                             flow.setFirstVerticalBias(vFirstBiasValue);
                         }
@@ -1053,7 +1053,7 @@ public class ConstraintSetParser {
                         hBiasValue = hBiasObject.getFloat();
                     }
                     try {
-                        flow.setHorizontalBias(hBiasValue);
+                        flow.horizontalBias(hBiasValue);
                         if (hFirstBiasValue != 0.5f) {
                             flow.setFirstHorizontalBias(hFirstBiasValue);
                         }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/Dimension.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/Dimension.java
@@ -27,12 +27,12 @@ import androidx.constraintlayout.core.widgets.ConstraintWidget;
  */
 public class Dimension {
 
-    public static final Object FIXED_DIMENSION = new Object();
-    public static final Object WRAP_DIMENSION = new Object();
-    public static final Object SPREAD_DIMENSION = new Object();
-    public static final Object PARENT_DIMENSION = new Object();
-    public static final Object PERCENT_DIMENSION = new Object();
-    public static final Object RATIO_DIMENSION = new Object();
+    public static final Object FIXED_DIMENSION = new String("FIXED_DIMENSION");
+    public static final Object WRAP_DIMENSION = new String("WRAP_DIMENSION");
+    public static final Object SPREAD_DIMENSION = new String("SPREAD_DIMENSION");
+    public static final Object PARENT_DIMENSION = new String("PARENT_DIMENSION");
+    public static final Object PERCENT_DIMENSION = new String("PERCENT_DIMENSION");
+    public static final Object RATIO_DIMENSION = new String("RATIO_DIMENSION");
 
     private final int mWrapContent = -2;
 

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/State.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/State.java
@@ -20,6 +20,7 @@ import static androidx.constraintlayout.core.widgets.ConstraintWidget.CHAIN_PACK
 import static androidx.constraintlayout.core.widgets.ConstraintWidget.CHAIN_SPREAD;
 import static androidx.constraintlayout.core.widgets.ConstraintWidget.CHAIN_SPREAD_INSIDE;
 
+import androidx.constraintlayout.core.motion.utils.Utils;
 import androidx.constraintlayout.core.state.helpers.AlignHorizontallyReference;
 import androidx.constraintlayout.core.state.helpers.AlignVerticallyReference;
 import androidx.constraintlayout.core.state.helpers.BarrierReference;
@@ -272,10 +273,21 @@ public class State {
     // @TODO: add description
     public ConstraintReference constraints(Object key) {
         Reference reference = mReferences.get(key);
+
         if (reference == null) {
-            reference = createConstraintReference(key);
-            mReferences.put(key, reference);
-            reference.setKey(key);
+            // if it's flow, reuse the reference instead of creating a new one.
+            // Therefore, the value of attributes such as mHorizontalDimension can be preserved
+            if (mHelperReferences.containsKey(key)
+                    && (mHelperReferences.get(key).getType().equals(Helper.HORIZONTAL_FLOW)
+                        || mHelperReferences.get(key).getType().equals(Helper.VERTICAL_FLOW))
+            ) {
+                reference = mHelperReferences.get(key);
+                mReferences.put(key, reference);
+            } else {
+                reference = createConstraintReference(key);
+                mReferences.put(key, reference);
+                reference.setKey(key);
+            }
         }
         if (reference instanceof ConstraintReference) {
             return (ConstraintReference) reference;

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/FlowReference.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/FlowReference.java
@@ -21,7 +21,6 @@ import static androidx.constraintlayout.core.widgets.ConstraintWidget.VERTICAL;
 import static androidx.constraintlayout.core.widgets.Flow.HORIZONTAL_ALIGN_CENTER;
 import static androidx.constraintlayout.core.widgets.Flow.VERTICAL_ALIGN_CENTER;
 import static androidx.constraintlayout.core.widgets.Flow.WRAP_NONE;
-import static androidx.constraintlayout.core.widgets.analyzer.BasicMeasure.AT_MOST;
 
 import androidx.constraintlayout.core.state.HelperReference;
 import androidx.constraintlayout.core.state.State;
@@ -63,10 +62,8 @@ public class FlowReference extends HelperReference {
 
     protected int mOrientation = HORIZONTAL;
 
-    protected float mVerticalBias = 0.5f;
     protected float mFirstVerticalBias = 0.5f;
     protected float mLastVerticalBias = 0.5f;
-    protected float mHorizontalBias = 0.5f;
     protected float mFirstHorizontalBias = 0.5f;
     protected float mLastHorizontalBias = 0.5f;
 
@@ -409,14 +406,6 @@ public class FlowReference extends HelperReference {
         return mVerticalBias;
     }
 
-    /**
-     * Set vertical bias value
-     *
-     * @param verticalBias vertical bias value
-     */
-    public void setVerticalBias(float verticalBias) {
-        this.mVerticalBias = verticalBias;
-    }
 
     /**
      * Get first vertical bias
@@ -460,15 +449,6 @@ public class FlowReference extends HelperReference {
      */
     public float getHorizontalBias() {
         return mHorizontalBias;
-    }
-
-    /**
-     * Set horizontal bias
-     *
-     * @param horizontalBias horizontal bias value
-     */
-    public void setHorizontalBias(float horizontalBias) {
-        this.mHorizontalBias = horizontalBias;
     }
 
     /**
@@ -596,8 +576,5 @@ public class FlowReference extends HelperReference {
 
         // General attributes of a widget
         applyBase();
-
-        // TODO - Need to figure out how to set these values properly.
-        mFlow.measure(AT_MOST, 1000, AT_MOST,1000);
     }
 }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/widgets/ConstraintWidget.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/widgets/ConstraintWidget.java
@@ -672,6 +672,16 @@ public class ConstraintWidget {
         ret.append(",\n");
     }
 
+    private void serializeAttribute(StringBuilder ret, String type, String value, String def) {
+        if (def.equals(value)) {
+            return;
+        }
+        ret.append(type);
+        ret.append(" :   ");
+        ret.append(value);
+        ret.append(",\n");
+    }
+
     private void serializeDimensionRatio(StringBuilder ret,
             String type,
             float value,
@@ -3763,6 +3773,7 @@ public class ConstraintWidget {
                 mMatchConstraintMinWidth,
                 mMatchConstraintDefaultWidth,
                 mMatchConstraintPercentWidth,
+                mListDimensionBehaviors[HORIZONTAL],
                 mWeight[DIMENSION_HORIZONTAL]
         );
 
@@ -3774,6 +3785,7 @@ public class ConstraintWidget {
                 mMatchConstraintMinHeight,
                 mMatchConstraintDefaultHeight,
                 mMatchConstraintPercentHeight,
+                mListDimensionBehaviors[VERTICAL],
                 mWeight[DIMENSION_VERTICAL]);
         serializeDimensionRatio(ret, "    dimensionRatio", mDimensionRatio, mDimensionRatioSide);
         serializeAttribute(ret, "    horizontalBias", mHorizontalBiasPercent, DEFAULT_BIAS);
@@ -3790,9 +3802,11 @@ public class ConstraintWidget {
             @SuppressWarnings("unused") int override,
             int matchConstraintMin, int matchConstraintDefault,
             float matchConstraintPercent,
+            DimensionBehaviour behavior,
             @SuppressWarnings("unused") float weight) {
         ret.append(type);
         ret.append(" :  {\n");
+        serializeAttribute(ret, "      behavior", behavior.toString(), DimensionBehaviour.FIXED.toString());
         serializeAttribute(ret, "      size", size, 0);
         serializeAttribute(ret, "      min", min, 0);
         serializeAttribute(ret, "      max", max, Integer.MAX_VALUE);

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/FlowDemo2.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/FlowDemo2.kt
@@ -18,35 +18,33 @@ package com.example.constraintlayout
 
 
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.*
 
-// Currently, we have an issue setting a fixed width and height
-@Preview(group = "flow-invalid")
+
+@Preview(group = "flow-chain")
 @Composable
-fun FlowInvalidDemo1() {
+fun FlowChainDemo1() {
     ConstraintLayout(
         ConstraintSet("""
         {
             flow1: { 
-                width: 500,
-                height: 500,
+                width: 'parent',
+                height: 'parent',
                 type: 'hFlow',
-                contains: ['btn1', 'btn2'],
+                wrap: 'chain',
+                maxElement: 3,
+                contains: ['1', '2', '3', '4', '5'],
               }
         }
         """.trimIndent()),
         modifier = Modifier.fillMaxSize()) {
-        val numArray = arrayOf("btn1", "btn2")
+        val numArray = arrayOf("1", "2", "3", "4", "5")
         for (num in numArray) {
             Button(
                 modifier = Modifier.layoutId(num),
@@ -58,24 +56,55 @@ fun FlowInvalidDemo1() {
     }
 }
 
-// With some specific Ids such as "1", "11", "111" or "a", "aa", "aaa"
-// The left position would become 0
-@Preview(group = "flow-invalid")
+@Preview(group = "flow-chain")
 @Composable
-fun FlowInvalidDemo2() {
+fun FlowChainDemo2() {
     ConstraintLayout(
         ConstraintSet("""
         {
-            flow: { 
+            flow1: { 
+                width: 'parent',
+                height: 'parent',
+                type: 'hFlow',
+                wrap: 'chain',
+                maxElement: 2,
+                hBias: 0.1,
+                contains: ['1', '2', '3', '4', '5'],
+              }
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val numArray = arrayOf("1", "2", "3", "4", "5")
+        for (num in numArray) {
+            Button(
+                modifier = Modifier.layoutId(num),
+                onClick = {},
+            ) {
+                Text(text = num)
+            }
+        }
+    }
+}
+
+@Preview(group = "flow-chain")
+@Composable
+fun FlowChainDemo3() {
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            flow1: { 
                 width: 'parent',
                 height: 'parent',
                 type: 'vFlow',
-                contains: ['1', '2', '3', '4'],
+                wrap: 'chain',
+                maxElement: 2,
+                vFlowBias: 0.1,
+                contains: ['1', '2', '3', '4', '5'],
               }
         }
         """.trimIndent()),
         modifier = Modifier.fillMaxSize()) {
-        val numArray = arrayOf("1", "2", "3", "4")
+        val numArray = arrayOf("1", "2", "3", "4", "5")
         for (num in numArray) {
             Button(
                 modifier = Modifier.layoutId(num),
@@ -87,57 +116,26 @@ fun FlowInvalidDemo2() {
     }
 }
 
-
-
-@Preview(group = "flow-basic")
+@Preview(group = "flow-chain")
 @Composable
-fun FlowBasicDemo1() {
-    // Currently, we still have problem with positioning the Flow Helper
-    // and/or setting the width/height properly.
+fun FlowChainDemo4() {
     ConstraintLayout(
         ConstraintSet("""
         {
             flow1: { 
                 width: 'parent',
                 height: 'parent',
-                type: 'hFlow',
-                contains: ['btn1', 'btn2', 'btn3', 'btn4'],
-              }
-        }
-        """.trimIndent()),
-        modifier = Modifier.fillMaxSize()) {
-        val numArray = arrayOf("btn1", "btn2", "btn3", "btn4")
-        for (num in numArray) {
-            Button(
-                modifier = Modifier.layoutId(num),
-                onClick = {},
-            ) {
-                Text(text = num)
-            }
-        }
-    }
-}
-
-
-
-@Preview(group = "flow-basic")
-@Composable
-fun FlowBasicDemo2() {
-    ConstraintLayout(
-        ConstraintSet("""
-        {
-            flow: { 
-                width: 'parent',
-                height: 'parent',
-                type: 'hFlow',
+                vStyle: 'spread_inside',
                 hStyle: 'packed',
-                hGap: 10,
-                contains: ['btn1', 'btn2', 'btn3', 'btn4'],
+                type: 'vFlow',
+                wrap: 'chain',
+                maxElement: 3,
+                contains: ['1', '2', '3', '4', '5'],
               }
         }
         """.trimIndent()),
         modifier = Modifier.fillMaxSize()) {
-        val numArray = arrayOf("btn1", "btn2", "btn3", "btn4")
+        val numArray = arrayOf("1", "2", "3", "4", "5")
         for (num in numArray) {
             Button(
                 modifier = Modifier.layoutId(num),
@@ -149,119 +147,123 @@ fun FlowBasicDemo2() {
     }
 }
 
-@Preview(group = "flow-basic")
+@Preview(group = "flow-aligned")
 @Composable
-fun FlowBasicDemo3() {
+fun FlowAlignedDemo1() {
     ConstraintLayout(
         ConstraintSet("""
         {
-            flow: { 
-                type: 'hFlow',
-                contains: ['btn1', 'btn2', 'btn3', 'btn4'],
-                top: ['btn5', 'bottom', 100],
-                left: ['btn5', 'right', 50]
-              }
-        }
-        """.trimIndent()),
-        modifier = Modifier.fillMaxSize()) {
-        Button(
-            modifier = Modifier.layoutId("btn5").height(500.dp).width(100.dp),
-            onClick = {},
-        ) {
-            Text(text = "btn5")
-        }
-        val numArray = arrayOf("btn1", "btn2", "btn3", "btn4")
-        for (num in numArray) {
-            Button(
-                modifier = Modifier.layoutId(num),
-                onClick = {},
-            ) {
-                Text(text = num)
-            }
-        }
-    }
-}
-
-@Preview(group = "flow-basic")
-@Composable
-fun FlowBasicDemo4() {
-    ConstraintLayout(
-        ConstraintSet("""
-        {
-            flow: { 
+            flow1: { 
                 width: 'parent',
                 height: 'parent',
                 type: 'vFlow',
-                contains: ['btn1', 'btn2', 'btn3', 'btn4'],
+                wrap: 'aligned',
+                center: 'parent',
+                maxElement: 3,
+                contains: ['1', '2', '3', '4', '5'],
               }
         }
         """.trimIndent()),
         modifier = Modifier.fillMaxSize()) {
-        val numArray = arrayOf("btn1", "btn2", "btn3", "btn4")
-        for (num in numArray) {
+        val chArray = arrayOf("1", "2", "3", "4", "5")
+        for (ch in chArray) {
             Button(
-                modifier = Modifier.layoutId(num),
+                modifier = Modifier.layoutId(ch),
                 onClick = {},
             ) {
-                Text(text = num)
+                Text(text = ch)
             }
         }
     }
 }
 
-@Preview(group = "flow-basic")
+@Preview(group = "flow-aligned")
 @Composable
-fun FlowBasicDemo5() {
+fun FlowAlignedDemo2() {
     ConstraintLayout(
         ConstraintSet("""
         {
-            flow: { 
+            flow1: { 
                 width: 'parent',
                 height: 'parent',
                 type: 'vFlow',
+                wrap: 'aligned',
+                center: 'parent',
+                maxElement: 3,
                 vStyle: 'packed',
-                vGap: 100,
-                contains: ['btn1', 'btn2', 'btn3', 'btn4'],
+                contains: ['1', '2', '3', '4', '5'],
               }
         }
         """.trimIndent()),
         modifier = Modifier.fillMaxSize()) {
-        val numArray = arrayOf("btn1", "btn2", "btn3", "btn4")
-        for (num in numArray) {
+        val chArray = arrayOf("1", "2", "3", "4", "5")
+        for (ch in chArray) {
             Button(
-                modifier = Modifier.layoutId(num),
+                modifier = Modifier.layoutId(ch),
                 onClick = {},
             ) {
-                Text(text = num)
+                Text(text = ch)
             }
         }
     }
 }
 
-@Preview(group = "flow-basic")
+@Preview(group = "flow-aligned")
 @Composable
-fun FlowBasicDemo6() {
+fun FlowAlignedDemo4() {
     ConstraintLayout(
         ConstraintSet("""
         {
-            flow: { 
-                type: 'vFlow',
-                contains: ['btn1', 'btn2', 'btn3', 'btn4'],
-                start: ['parent', 'start'],
-                top: ['parent', 'top'],
-                bottom: ['parent', 'bottom'],
-                end: ['parent', 'end']
+            flow1: { 
+                width: 'parent',
+                height: 'parent',
+                type: 'hFlow',
+                wrap: 'aligned',
+                center: 'parent',
+                maxElement: 3,
+                contains: ['1', '2', '3', '4', '5'],
               }
         }
         """.trimIndent()),
         modifier = Modifier.fillMaxSize()) {
-        val numArray = arrayOf("btn1", "btn2", "btn3", "btn4")
-        for (num in numArray) {
+        val chArray = arrayOf("1", "2", "3", "4", "5")
+        for (ch in chArray) {
             Button(
-                modifier = Modifier.layoutId(num),
+                modifier = Modifier.layoutId(ch),
                 onClick = {},
             ) {
-                Text(text = num)
+                Text(text = ch)
+            }
+        }
+    }
+}
+
+@Preview(group = "flow-aligned")
+@Composable
+fun FlowAlignedDemo3() {
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            flow1: { 
+                width: 'parent',
+                height: 'parent',
+                type: 'hFlow',
+                wrap: 'aligned',
+                center: 'parent',
+                maxElement: 3,
+                hStyle: 'spread_inside',
+                contains: ['1', '2', '3', '4', '5'],
+              }
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val chArray = arrayOf("1", "2", "3", "4", "5")
+        for (ch in chArray) {
+            Button(
+                modifier = Modifier.layoutId(ch),
+                onClick = {},
+            ) {
+                Text(text = ch)
             }
         }
     }


### PR DESCRIPTION
The main objective this PR is to enable match_parent for the width and height of a Flow for the JSON representation. Also, I updated the existing demos and added more demos for this change.

<img width="500" alt="image" src="https://user-images.githubusercontent.com/20599348/189182714-1d71a94b-85d6-4b6e-8889-026f5599f801.png">
<img width="500" alt="image" src="https://user-images.githubusercontent.com/20599348/189182912-97eab96f-ce86-4ff0-97ed-53c71cfaa0e2.png">


Previously, when we set match_parent for the width and height, it won't work properly. The main reason is that when the  **constraints** function is invoked in https://github.com/androidx/constraintlayout/blob/main/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/State.java#L544 it would created a new reference for the Flow. However, the new created reference has the default values of **mHorizontalDimension** and **mVerticalDimension** as **WRAP_CONTENT**. Therefore, no matter what values are set in the flowReference, the **WRAP_CONTENT** value will still be applied.

## Other issues to be resolved

### Fixed value for width and height
There is still an issue setting a fixed value for the width and height of a Flow (see **FlowInvalidDemo1** as an example). I am still investigating the cause, but I suspect that we might need to treat a Flow helper as a measurable to make the Flow itself be properly measured. For example, https://github.com/androidx/constraintlayout/blob/ea5299efaeed6ca8cd55267faf929f15c33aa8dc/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayout.kt#L994. 


### Issue with the Id
Another issue need to be investigated is that the id of a button would affect the result of the solver. For example, if I set the id of a button as "1" or "a", the left position value would become 0 (see **FlowInvalidDemo2** as an example)

<img width="977" alt="image" src="https://user-images.githubusercontent.com/20599348/189181207-4d70132b-fbd3-4844-8ba5-c67ba92c0096.png">

However, if I change the id to "btn1", it would then work as expected.
<img width="977" alt="image" src="https://user-images.githubusercontent.com/20599348/189181674-fcb67753-6b02-4ba2-a833-2853d94f2133.png">



