### PR TITLE
Fix OnSwipeTest

### DIFF
--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/OnSwipeTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/OnSwipeTest.kt
@@ -66,7 +66,6 @@ class OnSwipeTest {
         testMotionLayoutSwipe { OnSwipeTestJson() }
     }
 
-    @Ignore("Fails with left = 52.72 instead of 51.6")
     @Test
     fun simpleCornerToCornerRightSwipe_Dsl() {
         testMotionLayoutSwipe { OnSwipeTestDsl() }
@@ -201,7 +200,7 @@ private fun OnSwipeTestDsl() {
             onSwipe = OnSwipe(
                 anchor = "box",
                 direction = SwipeDirection.End,
-                side = SwipeSide.Right,
+                side = SwipeSide.End,
                 mode = SwipeMode.Spring,
                 onTouchUp = SwipeTouchUp.NeverCompleteStart,
                 springThreshold = 0.0001f

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/TransitionScope.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/TransitionScope.kt
@@ -133,14 +133,14 @@ class TransitionScope internal constructor(
     }
 
     fun keyPositions(vararg targets: Any, keyPositionsContent: KeyPositionsScope.() -> Unit) {
-        val scope = KeyPositionsScope(* targets)
+        val scope = KeyPositionsScope(*targets)
         keyPositionsContent(scope)
         addKeyPositionsIfMissing()
         keyPositionsArray.add(scope.keyFramePropsObject)
     }
 
     fun keyCycles(vararg targets: Any, keyCyclesContent: KeyCyclesScope.() -> Unit) {
-        val scope = KeyCyclesScope(* targets)
+        val scope = KeyCyclesScope(*targets)
         keyCyclesContent(scope)
         addKeyCyclesIfMissing()
         keyCyclesArray.add(scope.keyFramePropsObject)
@@ -150,8 +150,10 @@ class TransitionScope internal constructor(
         containerObject.putString("pathMotionArc", motionArc.name)
         containerObject.putString("from", from)
         containerObject.putString("to", to)
-        containerObject.putString("interpolator", easing.name)
-        containerObject.putNumber("duration", durationMs.toFloat())
+        // TODO: Uncomment once we decide how to deal with Easing discrepancy from user driven
+        //  `progress` value. Eg: `animateFloat(tween(duration, LinearEasing))`
+//        containerObject.putString("interpolator", easing.name)
+//        containerObject.putNumber("duration", durationMs.toFloat())
         onSwipe?.let {
             containerObject.put("onSwipe", onSwipeObject)
             onSwipeObject.putString("direction", it.direction.name)
@@ -281,7 +283,7 @@ abstract class BaseKeyFrameScope internal constructor() {
 }
 
 @ExperimentalMotionApi
-class KeyAttributeScope internal constructor(): BaseKeyFrameScope() {
+class KeyAttributeScope internal constructor() : BaseKeyFrameScope() {
     var alpha by addOnPropertyChange(1f, "alpha")
     var scaleX by addOnPropertyChange(1f, "scaleX")
     var scaleY by addOnPropertyChange(1f, "scaleY")
@@ -294,7 +296,7 @@ class KeyAttributeScope internal constructor(): BaseKeyFrameScope() {
 }
 
 @ExperimentalMotionApi
-class KeyPositionScope internal constructor(): BaseKeyFrameScope() {
+class KeyPositionScope internal constructor() : BaseKeyFrameScope() {
     var percentX by addOnPropertyChange(1f)
     var percentY by addOnPropertyChange(1f)
     var percentWidth by addOnPropertyChange(1f)
@@ -303,7 +305,7 @@ class KeyPositionScope internal constructor(): BaseKeyFrameScope() {
 }
 
 @ExperimentalMotionApi
-class KeyCycleScope internal constructor(): BaseKeyFrameScope() {
+class KeyCycleScope internal constructor() : BaseKeyFrameScope() {
     var alpha by addOnPropertyChange(1f)
     var scaleX by addOnPropertyChange(1f)
     var scaleY by addOnPropertyChange(1f)
@@ -325,7 +327,7 @@ internal interface NamedPropertyOrValue {
 }
 
 @ExperimentalMotionApi
-data class OnSwipe (
+data class OnSwipe(
     val anchor: Any,
     val side: SwipeSide,
     val direction: SwipeDirection,
@@ -409,6 +411,7 @@ class SwipeSide internal constructor(val name: String) {
     companion object {
         val Top: SwipeSide = SwipeSide("top")
         val Right: SwipeSide = SwipeSide("right")
+        val End: SwipeSide = SwipeSide("end")
         val Bottom: SwipeSide = SwipeSide("bottom")
         val Left: SwipeSide = SwipeSide("left")
         val Middle: SwipeSide = SwipeSide("middle")


### PR DESCRIPTION
Test was failing due to setting a default interpolation easing curve in the DSL.

For now the Easing and duration will be ignored since it creates a discrepancy from user driven progress value which will have its own easing curve, defined from an AnimationSpec such as `tween()` or `spring()`.