### PR TITLE
[Compose] Fix Flow not working in MotionLayout

### DIFF
--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/MotionFlowTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/MotionFlowTest.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalMotionApi::class)
+
+package androidx.constraintlayout.compose
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.platform.isDebugInspectorInfoEnabled
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertPositionInRootIsEqualTo
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@MediumTest
+@RunWith(AndroidJUnit4::class)
+class MotionFlowTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Before
+    fun setup() {
+        isDebugInspectorInfoEnabled = true
+    }
+
+    @After
+    fun tearDown() {
+        isDebugInspectorInfoEnabled = false
+    }
+
+
+    @Test
+    fun horizontalToVerticalFlow() {
+        val rootSize = 200.dp
+        var animateToEnd by mutableStateOf(false)
+        rule.setContent {
+            val progress by animateFloatAsState(targetValue = if (animateToEnd) 1f else 0f)
+
+            MotionLayout(
+                modifier = Modifier
+                    .size(rootSize),
+                motionScene = MotionScene(
+                    """
+            {
+                ConstraintSets: {
+                  start: {
+                    flow1: { 
+                        width: 'parent',
+                        height: 'parent',
+                        type: 'hFlow',
+                        wrap: 'none',
+                        centerVertically: 'parent',
+                        centerHorizontally: 'parent',
+                        contains: ['1', '2', '3', '4'],
+                      }
+                  },
+                  
+                  end: {
+                    flow2: { 
+                        width: 'parent',
+                        height: 'parent',
+                        type: 'vFlow',
+                        wrap: 'none',
+                        centerVertically: 'parent',
+                        centerHorizontally: 'parent',
+                        contains: ['1', '2', '3', '4'],
+                      }
+                  }
+                },
+                
+                Transitions: {
+                  default: {
+                    from: 'start',   to: 'end',
+                  }
+                }
+            }
+            """
+                ),
+                progress = progress
+            ) {
+                val numArray = arrayOf("1", "2", "3", "4")
+                for (num in numArray) {
+                    Box(
+                        modifier = Modifier
+                            .size(10.dp)
+                            .layoutId(num)
+                            .testTag(num)
+                            .background(Color.Red)
+                    )
+                }
+            }
+        }
+        rule.waitForIdle()
+
+        // (rootSize - (boxSize * boxCount)) / (boxCount + 1)
+        val gapSize = (rootSize - (10.dp * 4)) / 5
+
+        var expectedPosition = gapSize
+        rule.onNodeWithTag("1").assertPositionInRootIsEqualTo(expectedPosition, 94.9.dp)
+        expectedPosition += gapSize + 10.dp
+        rule.onNodeWithTag("2").assertPositionInRootIsEqualTo(expectedPosition, 94.9.dp)
+        expectedPosition += gapSize + 10.dp
+        rule.onNodeWithTag("3").assertPositionInRootIsEqualTo(expectedPosition, 94.9.dp)
+        expectedPosition += gapSize + 10.dp
+        rule.onNodeWithTag("4").assertPositionInRootIsEqualTo(expectedPosition, 94.9.dp)
+
+        animateToEnd = true
+        rule.waitForIdle()
+
+        expectedPosition = gapSize
+        rule.onNodeWithTag("1").assertPositionInRootIsEqualTo(94.9.dp, expectedPosition)
+        expectedPosition += gapSize + 10.dp
+        rule.onNodeWithTag("2").assertPositionInRootIsEqualTo(94.9.dp, expectedPosition)
+        expectedPosition += gapSize + 10.dp
+        rule.onNodeWithTag("3").assertPositionInRootIsEqualTo(94.9.dp, expectedPosition)
+        expectedPosition += gapSize + 10.dp
+        rule.onNodeWithTag("4").assertPositionInRootIsEqualTo(94.9.dp, expectedPosition)
+    }
+}

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionMeasurer.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionMeasurer.kt
@@ -72,12 +72,6 @@ internal class MotionMeasurer : Measurer() {
             }
         }
 
-        root.children.forEach { child ->
-            val measurable = (child.companionWidget as? Measurable)
-            val id = measurable?.layoutId ?: measurable?.constraintLayoutId
-            child.stringId = id?.toString()
-        }
-
         root.optimizationLevel = optimizationLevel
         // No need to set sizes and size modes as we passed them to the state above.
         root.measure(Optimizer.OPTIMIZATION_NONE, 0, 0, 0, 0, 0, 0, 0, 0)

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintSetParser.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintSetParser.java
@@ -889,10 +889,8 @@ public class ConstraintSetParser {
                                        String flowName,
                                        LayoutVariables layoutVariables,
                                        CLObject element) throws CLParsingException {
-
-        FlowReference flow = (flowType.charAt(0) == 'h')
-                ? state.getHorizontalFlow() : state.getVerticalFlow();
-        flow.setKey(flowName);
+        boolean isVertical = flowType.charAt(0) == 'v';
+        FlowReference flow = state.getFlow(flowName, isVertical);
 
         for (String param : element.names()) {
             switch (param) {
@@ -1115,7 +1113,10 @@ public class ConstraintSetParser {
                     }
                     break;
                 default:
-                    applyAttribute(state, layoutVariables, flow, element, param);
+                    // Get the underlying reference for the flow, apply the constraints
+                    // attributes to it
+                    ConstraintReference reference = state.constraints(flowName);
+                    applyAttribute(state, layoutVariables, reference, element, param);
             }
         }
     }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/State.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/State.java
@@ -275,19 +275,9 @@ public class State {
         Reference reference = mReferences.get(key);
 
         if (reference == null) {
-            // if it's flow, reuse the reference instead of creating a new one.
-            // Therefore, the value of attributes such as mHorizontalDimension can be preserved
-            if (mHelperReferences.containsKey(key)
-                    && (mHelperReferences.get(key).getType().equals(Helper.HORIZONTAL_FLOW)
-                        || mHelperReferences.get(key).getType().equals(Helper.VERTICAL_FLOW))
-            ) {
-                reference = mHelperReferences.get(key);
-                mReferences.put(key, reference);
-            } else {
-                reference = createConstraintReference(key);
-                mReferences.put(key, reference);
-                reference.setKey(key);
-            }
+            reference = createConstraintReference(key);
+            mReferences.put(key, reference);
+            reference.setKey(key);
         }
         if (reference instanceof ConstraintReference) {
             return (ConstraintReference) reference;
@@ -386,12 +376,12 @@ public class State {
      */
     public FlowReference getFlow(Object key, boolean vertical) {
         ConstraintReference reference = constraints(key);
-        if (reference.getFacade() == null || !(reference.getFacade() instanceof BarrierReference)) {
-            FlowReference barrierReference =
+        if (reference.getFacade() == null || !(reference.getFacade() instanceof FlowReference)) {
+            FlowReference flowReference =
                     (vertical) ? new FlowReference(this, Helper.VERTICAL_FLOW)
                             : new FlowReference(this, Helper.HORIZONTAL_FLOW);
 
-            reference.setFacade(barrierReference);
+            reference.setFacade(flowReference);
         }
         return (FlowReference) reference.getFacade();
     }
@@ -572,19 +562,6 @@ public class State {
                 container.add(widget);
             } else {
                 reference.setConstraintWidget(container);
-            }
-        }
-        for (Object key : mHelperReferences.keySet()) {
-            HelperReference reference = mHelperReferences.get(key);
-            HelperWidget helperWidget = reference.getHelperWidget();
-            if (helperWidget != null) {
-                for (Object keyRef : reference.mReferences) {
-                    Reference constraintReference = mReferences.get(keyRef);
-                    reference.getHelperWidget().add(constraintReference.getConstraintWidget());
-                }
-                reference.apply();
-            } else {
-                reference.apply();
             }
         }
         for (Object key : mReferences.keySet()) {


### PR DESCRIPTION
FlowReference would not get reused properly and so in MotionLayout it would cause an NPE for missing child references.

This also makes it so that the constraints are applied to the underlying ConstraintReference of FlowRerence, to allow removing some redundant code.