### PR TITLE
[Compose] Make TransitionScope use ConstrainedLayoutReference

### DIFF
--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/ConstraintLayoutTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/ConstraintLayoutTest.kt
@@ -419,15 +419,20 @@ class ConstraintLayoutTest {
     // region positioning tests
 
     @Test
-    @Ignore
     fun testConstraintLayout_withInlineDSL() = with(rule.density) {
+        var rootSize: IntSize = IntSize.Zero
         val boxSize = 100
         val offset = 150
 
         val position = Array(3) { Ref<Offset>() }
 
         rule.setContent {
-            ConstraintLayout(Modifier.fillMaxSize()) {
+            ConstraintLayout(
+                Modifier
+                    .fillMaxSize()
+                    .onGloballyPositioned {
+                        rootSize = it.size
+                    }) {
                 val (box0, box1, box2) = createRefs()
                 Box(
                     Modifier
@@ -465,8 +470,8 @@ class ConstraintLayoutTest {
             }
         }
 
-        val displayWidth = displaySize.width
-        val displayHeight = displaySize.height
+        val displayWidth = rootSize.width
+        val displayHeight = rootSize.height
 
         rule.runOnIdle {
             assertEquals(
@@ -494,8 +499,8 @@ class ConstraintLayoutTest {
     }
 
     @Test
-    @Ignore
     fun testConstraintLayout_withConstraintSet() = with(rule.density) {
+        var rootSize: IntSize = IntSize.Zero
         val boxSize = 100
         val offset = 150
 
@@ -503,7 +508,7 @@ class ConstraintLayoutTest {
 
         rule.setContent {
             ConstraintLayout(
-                ConstraintSet {
+                constraintSet = ConstraintSet {
                     val box0 = createRefFor("box0")
                     val box1 = createRefFor("box1")
                     val box2 = createRefFor("box2")
@@ -523,7 +528,11 @@ class ConstraintLayoutTest {
                         bottom.linkTo(parent.bottom, margin = offset.toDp())
                     }
                 },
-                Modifier.fillMaxSize()
+                modifier = Modifier
+                    .fillMaxSize()
+                    .onGloballyPositioned {
+                        rootSize = it.size
+                    }
             ) {
                 for (i in 0..2) {
                     Box(
@@ -538,8 +547,8 @@ class ConstraintLayoutTest {
             }
         }
 
-        val displayWidth = displaySize.width
-        val displayHeight = displaySize.height
+        val displayWidth = rootSize.width
+        val displayHeight = rootSize.height
 
         rule.runOnIdle {
             assertEquals(
@@ -551,7 +560,7 @@ class ConstraintLayoutTest {
             )
             assertEquals(
                 Offset(
-                    (displayWidth / 2f + offset).toFloat(),
+                    (displayWidth / 2f + offset),
                     ((displayHeight - boxSize) / 2 - boxSize).toFloat()
                 ),
                 position[1].value

--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/OnSwipeTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/OnSwipeTest.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.lerp
@@ -40,7 +39,6 @@ import androidx.test.filters.MediumTest
 import kotlin.math.roundToInt
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -171,40 +169,37 @@ private fun OnSwipeTestJson() {
 
 @Composable
 private fun OnSwipeTestDsl() {
-    val start = remember {
-        ConstraintSet {
-            constrain(createRefFor("box")) {
-                width = Dimension.value(20.dp)
-                height = Dimension.value(20.dp)
-                bottom.linkTo(parent.bottom, 10.dp)
-                start.linkTo(parent.start, 10.dp)
-            }
-        }
-    }
-    val end = remember {
-        ConstraintSet(start) {
-            constrain(createRefFor("box")) {
-                clearConstraints()
-                top.linkTo(parent.top, 10.dp)
-                end.linkTo(parent.end, 10.dp)
-            }
-        }
-    }
     MotionLayout(
         modifier = Modifier
             .testTag("MyMotion")
             .size(200.dp),
-        start = start,
-        end = end,
-        transition = Transition {
-            onSwipe = OnSwipe(
-                anchor = "box",
-                direction = SwipeDirection.End,
-                side = SwipeSide.End,
-                mode = SwipeMode.Spring,
-                onTouchUp = SwipeTouchUp.NeverCompleteStart,
-                springThreshold = 0.0001f
-            )
+        motionScene = MotionScene {
+            val box = createRefFor("box")
+            val from: ConstraintSetRef = constraintSet {
+                constrain(box) {
+                    width = Dimension.value(20.dp)
+                    height = Dimension.value(20.dp)
+                    bottom.linkTo(parent.bottom, 10.dp)
+                    start.linkTo(parent.start, 10.dp)
+                }
+            }
+            val to = constraintSet(extendConstraintSet = from) {
+                constrain(box) {
+                    clearConstraints()
+                    top.linkTo(parent.top, 10.dp)
+                    end.linkTo(parent.end, 10.dp)
+                }
+            }
+            defaultTransition(from, to) {
+                onSwipe = OnSwipe(
+                    anchor = box,
+                    direction = SwipeDirection.End,
+                    side = SwipeSide.End,
+                    mode = SwipeMode.Spring,
+                    onTouchUp = SwipeTouchUp.NeverCompleteStart,
+                    springThreshold = 0.0001f
+                )
+            }
         },
         progress = 0.0f
     ) {

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/TransitionScope.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/TransitionScope.kt
@@ -125,26 +125,32 @@ class TransitionScope internal constructor(
 
     var onSwipe: OnSwipe? = null
 
-    fun keyAttributes(vararg targets: Any, keyAttributesContent: KeyAttributesScope.() -> Unit) {
+    fun keyAttributes(vararg targets: ConstrainedLayoutReference, keyAttributesContent: KeyAttributesScope.() -> Unit) {
         val scope = KeyAttributesScope(*targets)
         keyAttributesContent(scope)
         addKeyAttributesIfMissing()
         keyAttributesArray.add(scope.keyFramePropsObject)
     }
 
-    fun keyPositions(vararg targets: Any, keyPositionsContent: KeyPositionsScope.() -> Unit) {
+    fun keyPositions(vararg targets: ConstrainedLayoutReference, keyPositionsContent: KeyPositionsScope.() -> Unit) {
         val scope = KeyPositionsScope(*targets)
         keyPositionsContent(scope)
         addKeyPositionsIfMissing()
         keyPositionsArray.add(scope.keyFramePropsObject)
     }
 
-    fun keyCycles(vararg targets: Any, keyCyclesContent: KeyCyclesScope.() -> Unit) {
+    fun keyCycles(vararg targets: ConstrainedLayoutReference, keyCyclesContent: KeyCyclesScope.() -> Unit) {
         val scope = KeyCyclesScope(*targets)
         keyCyclesContent(scope)
         addKeyCyclesIfMissing()
         keyCyclesArray.add(scope.keyFramePropsObject)
     }
+
+    /**
+     * Creates one [ConstrainedLayoutReference] corresponding to the [ConstraintLayout] element
+     * with [id].
+     */
+    fun createRefFor(id: Any): ConstrainedLayoutReference = ConstrainedLayoutReference(id)
 
     internal fun getObject(): CLObject {
         containerObject.putString("pathMotionArc", motionArc.name)
@@ -158,7 +164,7 @@ class TransitionScope internal constructor(
             containerObject.put("onSwipe", onSwipeObject)
             onSwipeObject.putString("direction", it.direction.name)
             onSwipeObject.putString("mode", it.mode.name)
-            onSwipeObject.putString("anchor", it.anchor.toString())
+            onSwipeObject.putString("anchor", it.anchor.id.toString())
             onSwipeObject.putString("side", it.side.name)
             onSwipeObject.putString("touchUp", it.onTouchUp.name)
             onSwipeObject.putNumber("stopThreshold", it.springThreshold)
@@ -168,7 +174,7 @@ class TransitionScope internal constructor(
 }
 
 @ExperimentalMotionApi
-open class BaseKeyFramesScope internal constructor(vararg targets: Any) {
+open class BaseKeyFramesScope internal constructor(vararg targets: ConstrainedLayoutReference) {
     internal val keyFramePropsObject = CLObject(charArrayOf()).apply {
         clear()
     }
@@ -182,10 +188,10 @@ open class BaseKeyFramesScope internal constructor(vararg targets: Any) {
         keyFramePropsObject.put("target", targetsContainer)
         keyFramePropsObject.put("frames", framesContainer)
         targets.forEach {
-            val stringChars = it.toString().toCharArray()
-            targetsContainer.add(CLString(stringChars).apply {
+            val targetChars = it.id.toString().toCharArray()
+            targetsContainer.add(CLString(targetChars).apply {
                 start = 0
-                end = stringChars.size.toLong() - 1
+                end = targetChars.size.toLong() - 1
             })
         }
     }
@@ -205,7 +211,7 @@ open class BaseKeyFramesScope internal constructor(vararg targets: Any) {
 }
 
 @ExperimentalMotionApi
-class KeyAttributesScope internal constructor(vararg targets: Any) : BaseKeyFramesScope(*targets) {
+class KeyAttributesScope internal constructor(vararg targets: ConstrainedLayoutReference) : BaseKeyFramesScope(*targets) {
     fun frame(frame: Float, keyFrameContent: KeyAttributeScope.() -> Unit) {
         val scope = KeyAttributeScope()
         keyFrameContent(scope)
@@ -215,7 +221,7 @@ class KeyAttributesScope internal constructor(vararg targets: Any) : BaseKeyFram
 }
 
 @ExperimentalMotionApi
-class KeyPositionsScope internal constructor(vararg targets: Any) : BaseKeyFramesScope(* targets) {
+class KeyPositionsScope internal constructor(vararg targets: ConstrainedLayoutReference) : BaseKeyFramesScope(*targets) {
     var type by addNameOnPropertyChange(RelativePosition.Parent)
 
     fun frame(frame: Float, keyFrameContent: KeyPositionScope.() -> Unit) {
@@ -227,7 +233,7 @@ class KeyPositionsScope internal constructor(vararg targets: Any) : BaseKeyFrame
 }
 
 @ExperimentalMotionApi
-class KeyCyclesScope internal constructor(vararg targets: Any) : BaseKeyFramesScope(* targets) {
+class KeyCyclesScope internal constructor(vararg targets: ConstrainedLayoutReference) : BaseKeyFramesScope(*targets) {
     fun frame(frame: Float, keyFrameContent: KeyCycleScope.() -> Unit) {
         val scope = KeyCycleScope()
         keyFrameContent(scope)
@@ -328,7 +334,7 @@ internal interface NamedPropertyOrValue {
 
 @ExperimentalMotionApi
 data class OnSwipe(
-    val anchor: Any,
+    val anchor: ConstrainedLayoutReference,
     val side: SwipeSide,
     val direction: SwipeDirection,
     val mode: SwipeMode = SwipeMode.Velocity,

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/MotionCarouselDemos.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/MotionCarouselDemos.kt
@@ -72,9 +72,11 @@ val cardsExample = arrayListOf<CardInfo>(
  * in the center of the screen, slot0 on its left, slot2 on its right.
  * As slot1 is the "initial" slot, initialSlotIndex is 1 and numSlots is 3.
  *
+ * ```
  * next        [slot0] [slot1] | [slot2] |
  * start               [slot0] | [slot1] | [slot2]
  * previous                    | [slot0] | [slot1] [slot2]
+ * ```
  *
  * We are using the above data (cardsExample) that we pass to the
  * items() function, which leads to the item passed to be a CardInfo.
@@ -520,7 +522,7 @@ fun MySimpleCarouselDSL(content: MotionCarouselScope.() -> Unit) {
             }
         }
         transition("forward", startState, nextState) {
-            keyAttributes("slot0", "slot1", "slot2") {
+            keyAttributes(slot0, slot1, slot2) {
                 frame(50f) {
                     scaleX = .3f
                     scaleY = .3f
@@ -528,7 +530,7 @@ fun MySimpleCarouselDSL(content: MotionCarouselScope.() -> Unit) {
             }
         }
         transition("backward", startState, previousState) {
-            keyAttributes("slot0", "slot1", "slot2") {
+            keyAttributes(slot0, slot1, slot2) {
                 frame(50f) {
                     scaleX = .3f
                     scaleY = .3f

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/OnSwipeExperiment.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/OnSwipeExperiment.kt
@@ -576,7 +576,7 @@ fun SimpleSwipeDsl(config: SimpleSwipeConfig) {
                 to = to
             ) {
                 onSwipe = OnSwipe(
-                    anchor = "box",
+                    anchor = box,
                     direction = SwipeDirection.Right,
                     side = SwipeSide.Left,
                     mode = mode,

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/motion/dsl/transition/Common.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/motion/dsl/transition/Common.kt
@@ -24,6 +24,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.Button
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Android
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -31,17 +33,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.layoutId
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstrainedLayoutReference
 import androidx.constraintlayout.compose.ConstraintSet
 import androidx.constraintlayout.compose.Dimension
 import androidx.constraintlayout.compose.MotionLayout
 import androidx.constraintlayout.compose.Transition
-import com.example.constraintlayout.R
+import androidx.constraintlayout.compose.TransitionScope
 
-@Suppress("NOTHING_TO_INLINE")
 @Composable
-inline fun TwoItemLayout(transition: Transition) {
+fun TwoItemLayout(transitionContent: TransitionScope.(img1: ConstrainedLayoutReference, img2: ConstrainedLayoutReference) -> Unit) {
     var atStart by remember { mutableStateOf(true) }
     val progress by animateFloatAsState(if (atStart) 0f else 1f, tween(2000))
 
@@ -88,17 +89,21 @@ inline fun TwoItemLayout(transition: Transition) {
                 .weight(1.0f, true),
             start = start,
             end = end,
-            transition = transition,
+            transition = Transition {
+                val img1 = createRefFor("img1")
+                val img2 = createRefFor("img2")
+                this.transitionContent(img1, img2)
+            },
             progress = progress
         ) {
             Image(
                 modifier = Modifier.layoutId("img1"),
-                painter = painterResource(id = R.drawable.intercom_snooze),
+                imageVector = Icons.Default.Android,
                 contentDescription = null
             )
             Image(
                 modifier = Modifier.layoutId("img2"),
-                painter = painterResource(id = R.drawable.intercom_snooze),
+                imageVector = Icons.Default.Android,
                 contentDescription = null
             )
         }

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/motion/dsl/transition/KeyAttributesDsl.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/motion/dsl/transition/KeyAttributesDsl.kt
@@ -22,31 +22,26 @@ import androidx.constraintlayout.compose.OnSwipe
 import androidx.constraintlayout.compose.SwipeDirection
 import androidx.constraintlayout.compose.SwipeMode
 import androidx.constraintlayout.compose.SwipeSide
-import androidx.constraintlayout.compose.Transition
-import androidx.constraintlayout.compose.TransitionScope
 
 @Preview
 @Composable
 fun KeyAttributesSimpleDslExample() {
-    TwoItemLayout(transition = Transition {
+    TwoItemLayout(transitionContent = { img1, img2 ->
         onSwipe = OnSwipe(
-            anchor = "img1",
+            anchor = img1,
             side = SwipeSide.Right,
             direction = SwipeDirection.Right,
             mode = SwipeMode.Spring
         )
-        keyAttributes("img1") {
+        keyAttributes(img1) {
             frame(50f) {
                 scaleX = 1.5f
                 scaleY = 1.5f
             }
         }
-        keyAttributes("img2") {
+        keyAttributes(img2) {
             frame(25f) {
                 rotationZ = -45f
-            }
-            frame(50f) {
-                // Do nothing
             }
             frame(75f) {
                 rotationZ = 45f

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/motion/dsl/transition/KeyCyclesDsl.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/motion/dsl/transition/KeyCyclesDsl.kt
@@ -22,20 +22,18 @@ import androidx.constraintlayout.compose.OnSwipe
 import androidx.constraintlayout.compose.SwipeDirection
 import androidx.constraintlayout.compose.SwipeMode
 import androidx.constraintlayout.compose.SwipeSide
-import androidx.constraintlayout.compose.Transition
-import androidx.constraintlayout.compose.TransitionScope
 
 @Preview
 @Composable
 fun KeyCyclesSimpleDslExample() {
-    TwoItemLayout(transition = Transition {
+    TwoItemLayout(transitionContent = { img1, img2 ->
         onSwipe = OnSwipe(
-            anchor = "img1",
+            anchor = img1,
             side = SwipeSide.Right,
             direction = SwipeDirection.Right,
             mode = SwipeMode.Spring
         )
-        keyCycles("img1") {
+        keyCycles(img1) {
             // TODO: Consider supporting common/base values declared at this level, eg: offset = 1
             frame(0f) {
                 scaleX = 0f
@@ -53,7 +51,7 @@ fun KeyCyclesSimpleDslExample() {
                 offset = 1f
             }
         }
-        keyCycles("img2") {
+        keyCycles(img2) {
             // TODO: Consider supporting common/base values declared at this level, eg: translationX = 50f
             frame(0f) {
                 translationX = 50f

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/motion/dsl/transition/KeyPositionsDsl.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/motion/dsl/transition/KeyPositionsDsl.kt
@@ -23,26 +23,24 @@ import androidx.constraintlayout.compose.RelativePosition
 import androidx.constraintlayout.compose.SwipeDirection
 import androidx.constraintlayout.compose.SwipeMode
 import androidx.constraintlayout.compose.SwipeSide
-import androidx.constraintlayout.compose.Transition
-import androidx.constraintlayout.compose.TransitionScope
 
 @Preview
 @Composable
 fun KeyPositionsSimpleDslExample() {
-    TwoItemLayout(transition = Transition {
+    TwoItemLayout(transitionContent = { img1, img2 ->
         onSwipe = OnSwipe(
-            anchor = "img1",
-            side = SwipeSide.Right,
-            direction = SwipeDirection.Right,
+            anchor = img1,
+            side = SwipeSide.Top,
+            direction = SwipeDirection.Up,
             mode = SwipeMode.Spring
         )
-        keyPositions("img1") {
+        keyPositions(img1) {
             type = RelativePosition.Delta
             frame(50f) {
                 percentX = -0.2f
             }
         }
-        keyPositions("img2") {
+        keyPositions(img2) {
             type = RelativePosition.Parent
             frame(25f) {
                 percentX = 0.2f


### PR DESCRIPTION
For consistency with MotionScope and ConstraintSetScope.

Updated tests and samples.

Additionally, fixed a couple of failing ConstraintLayout tests.