### PR TITLE
add support for custom Attributess in KeyAttributes

### DIFF
--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionMeasurer.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionMeasurer.kt
@@ -501,17 +501,9 @@ internal class MotionMeasurer : Measurer() {
         if (!transition.contains(id)) {
             return 0f
         }
-        val startFrame = transition.getStart(id)
-        val endFrame = transition.getEnd(id)
-        var startFloat = startFrame.getCustomFloat(name)
-        var endFloat = endFrame.getCustomFloat(name)
-        if (startFloat.isNaN()) {
-            startFloat = 0f
-        }
-        if (endFloat.isNaN()) {
-            endFloat = 0f
-        }
-        return (1f - progress) * startFloat + progress * endFloat
+        transition.interpolate(root.width, root.height, progress)
+        val interpolatedFrame = transition.getInterpolated(id)
+        return interpolatedFrame.getCustomFloat(name)
     }
 
     fun clearConstraintSets() {

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/Transition.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/Transition.java
@@ -921,7 +921,6 @@ public class Transition implements TypedValues {
                 for (int i = 0; i < custom.length; i++) {
                     keyAttributes.mCustom.put( custom[i].getName(), custom[i]);
                 }
-
             }
             mMotionControl.addKey(keyAttributes);
         }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/Transition.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/Transition.java
@@ -16,6 +16,7 @@
 
 package androidx.constraintlayout.core.state;
 
+import androidx.constraintlayout.core.motion.CustomVariable;
 import androidx.constraintlayout.core.motion.Motion;
 import androidx.constraintlayout.core.motion.MotionWidget;
 import androidx.constraintlayout.core.motion.key.MotionKeyAttributes;
@@ -660,6 +661,16 @@ public class Transition implements TypedValues {
         getWidgetState(target, null, 0).setKeyAttribute(bundle);
     }
 
+    /**
+     * Add a key attribute and the custom variables into the
+     * @param target the id of the target
+     * @param bundle the key attributes bundle containing position etc.
+     * @param custom the customVariables to add at that position
+     */
+    public void addKeyAttribute(String target, TypedBundle bundle, CustomVariable[]custom) {
+        getWidgetState(target, null, 0).setKeyAttribute(bundle,custom);
+    }
+
     // @TODO: add description
     public void addKeyCycle(String target, TypedBundle bundle) {
         getWidgetState(target, null, 0).setKeyCycle(bundle);
@@ -895,6 +906,23 @@ public class Transition implements TypedValues {
         public void setKeyAttribute(TypedBundle prop) {
             MotionKeyAttributes keyAttributes = new MotionKeyAttributes();
             prop.applyDelta(keyAttributes);
+            mMotionControl.addKey(keyAttributes);
+        }
+
+        /**
+         * Set tge keyAttribute bundle and associated custom attributes
+         * @param prop
+         * @param custom
+         */
+        public void setKeyAttribute(TypedBundle prop, CustomVariable[] custom) {
+            MotionKeyAttributes keyAttributes = new MotionKeyAttributes();
+            prop.applyDelta(keyAttributes);
+            if (custom != null) {
+                for (int i = 0; i < custom.length; i++) {
+                    keyAttributes.mCustom.put( custom[i].getName(), custom[i]);
+                }
+
+            }
             mMotionControl.addKey(keyAttributes);
         }
 

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/TransitionParser.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/TransitionParser.java
@@ -335,30 +335,21 @@ public class TransitionParser {
         if (customElement != null && customElement instanceof CLObject) {
             CLObject customObj = ((CLObject) customElement);
             int n = customObj.size();
-            customVars =  new CustomVariable[frames.size()][n];
+            customVars = new CustomVariable[frames.size()][n];
             for (int i = 0; i < n; i++) {
                 CLKey key = (CLKey) customObj.get(i);
                 String customName = key.content();
-                Utils.log(" >>>>customObj  "+customObj.content());
-                Utils.log(" >>>>key "+key.content());
-                Utils.log(" >>>>key.value "+key.getValue());
-                Utils.log(" >>>> "+customName);
-
                 if (key.getValue() instanceof CLArray) {
-                    Utils.log(" >>>> "+ customName+" CLArray ");
-                    CLArray arrayValues = (CLArray) key.getValue() ;
+                    CLArray arrayValues = (CLArray) key.getValue();
                     int vSize = arrayValues.size();
                     if (vSize == bundles.length && vSize > 0) {
                         if (arrayValues.get(0) instanceof CLNumber) {
-                            Utils.log(" >>>> "+ customName+" CLNumber's");
                             for (int j = 0; j < bundles.length; j++) {
                                 customVars[j][i] = new CustomVariable(customName,
                                         TypedValues.Custom.TYPE_FLOAT,
                                         arrayValues.get(j).getFloat());
                             }
-                        } else {
-                            Utils.log(" >>>> "+ customName+" color's");
-
+                        } else {  // since it is not a number switching to custom color parsing
                             for (int j = 0; j < bundles.length; j++) {
                                 long color = parseColorString(arrayValues.get(j).content());
                                 if (color != -1) {
@@ -372,7 +363,6 @@ public class TransitionParser {
                 } else {
                     CLElement value = key.getValue();
                     if (value instanceof CLNumber) {
-                        Utils.log(" >>>> "+ customName+" CLNumber");
                         float fValue = value.getFloat();
                         for (int j = 0; j < bundles.length; j++) {
                             customVars[j][i] = new CustomVariable(customName,
@@ -381,7 +371,6 @@ public class TransitionParser {
                         }
                     } else {
                         long cValue = parseColorString(value.content());
-                        Utils.log(" >>>> "+ customName+" color");
                         if (cValue != -1) {
                             for (int j = 0; j < bundles.length; j++) {
                                 customVars[j][i] = new CustomVariable(customName,
@@ -400,7 +389,6 @@ public class TransitionParser {
             for (int j = 0; j < bundles.length; j++) {
                 String target = targets.getString(i);
                 TypedBundle bundle = bundles[j];
-
                 if (curveFit != null) {
                     bundle.add(TypedValues.PositionType.TYPE_CURVE_FIT,
                             map(curveFit, "spline", "linear"));
@@ -409,10 +397,8 @@ public class TransitionParser {
                         transitionEasing);
                 int frame = frames.getInt(j);
                 bundle.add(TypedValues.TYPE_FRAME_POSITION, frame);
-
                 transition.addKeyAttribute(target, bundle, (customVars != null) ? customVars[j] :
                         null);
-
             }
         }
     }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/WidgetFrame.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/WidgetFrame.java
@@ -382,11 +382,19 @@ public class WidgetFrame {
         }
     }
 
-    // @TODO: add description
+    /**
+     * Get the custom attribute given Nam
+     * @param name Name of the custom attribut
+     * @return The customAttribute
+     */
     public CustomVariable getCustomAttribute(String name) {
         return mCustom.get(name);
     }
 
+    /**
+     * Get the known custom Attributes names
+     * @return set of custom attribute names
+     */
     public Set<String> getCustomAttributeNames() {
         return mCustom.keySet();
     }

--- a/projects/ComposeConstraintLayout/.idea/inspectionProfiles/Project_Default.xml
+++ b/projects/ComposeConstraintLayout/.idea/inspectionProfiles/Project_Default.xml
@@ -49,11 +49,47 @@
       <option name="IGNORE_POINT_TO_ITSELF" value="false" />
       <option name="myAdditionalJavadocTags" value="hide" />
     </inspection_tool>
+    <inspection_tool class="JavadocDeclaration" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ADDITIONAL_TAGS" value="hide" />
+    </inspection_tool>
     <inspection_tool class="JavadocReference" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="REPORT_INACCESSIBLE" value="false" />
     </inspection_tool>
     <inspection_tool class="KDocUnresolvedReference" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="MissingDeprecatedAnnotation" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="MissingJavadoc" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="PACKAGE_SETTINGS">
+        <Options>
+          <option name="ENABLED" value="false" />
+        </Options>
+      </option>
+      <option name="MODULE_SETTINGS">
+        <Options>
+          <option name="ENABLED" value="false" />
+        </Options>
+      </option>
+      <option name="TOP_LEVEL_CLASS_SETTINGS">
+        <Options>
+          <option name="ENABLED" value="false" />
+        </Options>
+      </option>
+      <option name="INNER_CLASS_SETTINGS">
+        <Options>
+          <option name="ENABLED" value="false" />
+        </Options>
+      </option>
+      <option name="METHOD_SETTINGS">
+        <Options>
+          <option name="REQUIRED_TAGS" value="@return@param@throws or @exception" />
+          <option name="ENABLED" value="false" />
+        </Options>
+      </option>
+      <option name="FIELD_SETTINGS">
+        <Options>
+          <option name="ENABLED" value="false" />
+        </Options>
+      </option>
+    </inspection_tool>
     <inspection_tool class="NullableProblems" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="REPORT_NULLABLE_METHOD_OVERRIDES_NOTNULL" value="true" />
       <option name="REPORT_NOT_ANNOTATED_METHOD_OVERRIDES_NOTNULL" value="true" />
@@ -64,6 +100,42 @@
       <option name="REPORT_ANNOTATION_NOT_PROPAGATED_TO_OVERRIDERS" value="true" />
       <option name="REPORT_NULLS_PASSED_TO_NON_ANNOTATED_METHOD" value="true" />
       <option name="REPORT_NULLS_PASSED_TO_NOT_NULL_PARAMETER" value="false" />
+    </inspection_tool>
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PrivatePropertyName" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <scope name="Compose" level="WEAK WARNING" enabled="true">

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/AttributesDemo.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/AttributesDemo.kt
@@ -25,17 +25,20 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material.Button
 import androidx.compose.material.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.constraintlayout.compose.ConstraintSet
 import androidx.constraintlayout.compose.MotionLayout
 import androidx.constraintlayout.compose.MotionLayoutDebugFlags
 import androidx.constraintlayout.compose.MotionScene
-import java.util.*
+import java.util.EnumSet
 
 @Preview(group = "motion8")
 @Composable
@@ -323,7 +326,8 @@ public fun AttributesRotationXY() {
                           target: ['a'],
                           frames: [25,50,75],
                           rotationX: [0, 45, 60],
-                          rotationY: [60, 45, 0], 
+                          rotationY: [60, 45, 0],
+                          
                         }
                       ]
                     }
@@ -335,6 +339,93 @@ public fun AttributesRotationXY() {
             Box(modifier = Modifier
                 .layoutId("a")
                 .background(Color.Red))
+        }
+
+        Button(onClick = { animateToEnd = !animateToEnd }) {
+            Text(text = "Run")
+        }
+    }
+}
+
+
+@Preview(group = "customMotion")
+@Composable
+public fun AttributesCustom() {
+    var animateToEnd by remember { mutableStateOf(false) }
+
+    val progress by animateFloatAsState(
+        targetValue = if (animateToEnd) 1f else 0f,
+        animationSpec = tween(6000)
+    )
+    Column {
+        MotionLayout(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(400.dp)
+                .background(Color.White),
+            motionScene = MotionScene("""{
+                ConstraintSets: {
+                  start: {
+                    a: {
+                      width: 40,
+                      height: 40,
+                      start: ['parent', 'start', 16],
+                      bottom: ['parent', 'bottom', 16],
+                      custom: {
+                        background: '#FF0000',
+                        count: 0.0
+                      }
+                    }
+                  },
+                  end: {
+                    a: {
+                      width: 40,
+                      height: 40,
+                      //rotationZ: 390,
+                      end: ['parent', 'end', 16],
+                      top: ['parent', 'top', 16],
+                      custom: {
+                        background: '#0000FF',
+                        count: 100.0
+                      }
+                    }
+                  }
+                },
+                Transitions: {
+                  default: {
+                    from: 'start',
+                    to: 'end',
+                    pathMotionArc: 'startHorizontal',
+                    KeyFrames: {
+ 
+                      KeyAttributes: [
+                        {
+                          target: ['a'],
+                          frames: [25,50,75],
+                          rotationX: [0, 45, 60],
+                          rotationY: [60, 45, 0],
+                          custom: {
+                            background: ['#FFFFFF', '#000000','#FFFFFF'],
+                            count: [50,50,50]
+                          }
+                          
+                        }
+                      ]
+                    }
+                  }
+                }
+            }"""),
+            debug = EnumSet.of(MotionLayoutDebugFlags.SHOW_ALL),
+            progress = progress) {
+            val  color = motionProperties("a").value.color("background")
+            var  count = motionProperties("a").value.float("count")
+            count = (count * 100).toInt() / 100f
+
+            Box(modifier = Modifier
+                .layoutId("a")
+                .background(color)){
+                Text(text = " $count ")
+            }
         }
 
         Button(onClick = { animateToEnd = !animateToEnd }) {

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/AttributesDemo.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/AttributesDemo.kt
@@ -327,7 +327,6 @@ public fun AttributesRotationXY() {
                           frames: [25,50,75],
                           rotationX: [0, 45, 60],
                           rotationY: [60, 45, 0],
-                          
                         }
                       ]
                     }
@@ -363,7 +362,8 @@ public fun AttributesCustom() {
                 .fillMaxWidth()
                 .height(400.dp)
                 .background(Color.White),
-            motionScene = MotionScene("""{
+            motionScene = MotionScene(
+                """{
                 ConstraintSets: {
                   start: {
                     a: {
@@ -414,16 +414,20 @@ public fun AttributesCustom() {
                     }
                   }
                 }
-            }"""),
+            }"""
+            ),
             debug = EnumSet.of(MotionLayoutDebugFlags.SHOW_ALL),
-            progress = progress) {
-            val  color = motionProperties("a").value.color("background")
-            var  count = motionProperties("a").value.float("count")
+            progress = progress
+        ) {
+            val color = motionProperties("a").value.color("background")
+            var count = motionProperties("a").value.float("count")
             count = (count * 100).toInt() / 100f
 
-            Box(modifier = Modifier
-                .layoutId("a")
-                .background(color)){
+            Box(
+                modifier = Modifier
+                    .layoutId("a")
+                    .background(color)
+            ) {
                 Text(text = " $count ")
             }
         }

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/LaMotion.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/LaMotion.kt
@@ -17,11 +17,14 @@
 package com.example.constraintlayout
 
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -37,76 +40,56 @@ import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintSet
+import androidx.constraintlayout.compose.Motion
 import androidx.constraintlayout.compose.MotionLayout
 import androidx.constraintlayout.compose.MotionLayoutDebugFlags
 import androidx.constraintlayout.compose.MotionScene
+import androidx.constraintlayout.compose.RelativePosition
+import androidx.constraintlayout.compose.rememberMotionContent
 import java.util.*
+import kotlin.collections.ArrayList
 
-@Preview(group = "motion_2")
+@Preview(group = "LookAheadMotion")
 @Composable
-public fun MotionDemo3() {
-    var animateToEnd by remember { mutableStateOf(false) }
+public fun LaMotion01() {
+    var vert: Boolean by remember { mutableStateOf(true) }
+    var words = "This is a test of motionLayout".split(' ')
+    val animationSpec: AnimationSpec<Float> = tween(2000)
+    val s = rememberMotionContent {
+        for (word in words) {
+            Text(modifier = Modifier
+                .padding(2.dp)
+                .motion(animationSpec) {
+                    keyPositions {
+                        frame(50f) {
+                            type = RelativePosition.Delta
+                            percentX = if (vert) 0f else 1.0f
 
-    val progress  = remember { Animatable(0f) }
-
-    LaunchedEffect(animateToEnd) {
-        progress.animateTo(if (animateToEnd) 1f else 0f,
-            animationSpec = tween(3000))
+                        }
+                    }
+                }, text = word)
+        }
     }
 
-    Column( modifier = Modifier.background(Color.Gray)) {
-
-        val scene1 = MotionScene("""
-            {
-                Header: {
-                  name: 'motion26'
-                },
-                
-                ConstraintSets: {
-                  start: {
-                    id1: {
-                      width: 400, height: 40,
-                      start:  ['parent', 'start' , 16],
-                      bottom: ['parent', 'bottom', 16]
-                    }
-                  },
-                  
-                  end: {
-                    id1: {
-                      width: 40, height: 40,
-                      end: ['parent', 'end', 16],
-                      top: ['parent', 'top', 16]
-                    }
-                  }
-                },
-                
-                Transitions: {
-                  default: {
-                    from: 'start',   to: 'end',
-                  }
-                }
+    Motion(modifier = Modifier
+        .fillMaxWidth()
+        .fillMaxHeight()) {
+        Column(modifier = Modifier.background(Color.LightGray)) {
+            Button(onClick = { vert = !vert }) {
+                Text(modifier = Modifier.motion(), text = "Click")
             }
-            """)
+            if (vert) {
+                Row() {
+                    s()
+                }
+            } else Column() {
+                s()
+            }
 
-        MotionLayout(
-            modifier    = Modifier
-                .wrapContentWidth()
-                .align(CenterHorizontally)
-                .height(400.dp)
-                .background(Color.Cyan),
-            motionScene = scene1,
-            progress   = progress.value) {
 
-            Box(modifier = Modifier
-                .layoutId("id1")
-                .background(Color.Red))
-        }
-
-        Button(onClick = { animateToEnd = !animateToEnd },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(3.dp)) {
-            Text(text = "Wrap Content MotionLayout")
         }
     }
-}
+
+   }
+
+

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/LaMotion.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/LaMotion.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.constraintlayout
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Alignment.Companion.CenterHorizontally
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintSet
+import androidx.constraintlayout.compose.MotionLayout
+import androidx.constraintlayout.compose.MotionLayoutDebugFlags
+import androidx.constraintlayout.compose.MotionScene
+import java.util.*
+
+@Preview(group = "motion_2")
+@Composable
+public fun MotionDemo3() {
+    var animateToEnd by remember { mutableStateOf(false) }
+
+    val progress  = remember { Animatable(0f) }
+
+    LaunchedEffect(animateToEnd) {
+        progress.animateTo(if (animateToEnd) 1f else 0f,
+            animationSpec = tween(3000))
+    }
+
+    Column( modifier = Modifier.background(Color.Gray)) {
+
+        val scene1 = MotionScene("""
+            {
+                Header: {
+                  name: 'motion26'
+                },
+                
+                ConstraintSets: {
+                  start: {
+                    id1: {
+                      width: 400, height: 40,
+                      start:  ['parent', 'start' , 16],
+                      bottom: ['parent', 'bottom', 16]
+                    }
+                  },
+                  
+                  end: {
+                    id1: {
+                      width: 40, height: 40,
+                      end: ['parent', 'end', 16],
+                      top: ['parent', 'top', 16]
+                    }
+                  }
+                },
+                
+                Transitions: {
+                  default: {
+                    from: 'start',   to: 'end',
+                  }
+                }
+            }
+            """)
+
+        MotionLayout(
+            modifier    = Modifier
+                .wrapContentWidth()
+                .align(CenterHorizontally)
+                .height(400.dp)
+                .background(Color.Cyan),
+            motionScene = scene1,
+            progress   = progress.value) {
+
+            Box(modifier = Modifier
+                .layoutId("id1")
+                .background(Color.Red))
+        }
+
+        Button(onClick = { animateToEnd = !animateToEnd },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(3.dp)) {
+            Text(text = "Wrap Content MotionLayout")
+        }
+    }
+}


### PR DESCRIPTION
This adds support for custom attributes in KeyAttributes:
```json5
KeyAttributes: [
                        {
                          target: ['a'],
                          frames: [25,50,75],
                          rotationX: [0, 45, 60],
                          rotationY: [60, 45, 0],
                          custom: {
                            background: ['#FFFFFF', '#000000','#FFFFFF'],
                            count: [50,50,50]
                          }
                          
                        }
                      ]
```


https://user-images.githubusercontent.com/15019413/190953090-d2dd7417-67a7-4e83-9d9a-2b6886f13be7.mp4




