### PR TITLE
Guidelines fix

### DIFF
--- a/constraintlayout/swing/src/main/java/org/constraintlayout/swing/core/GuidelinesState.java
+++ b/constraintlayout/swing/src/main/java/org/constraintlayout/swing/core/GuidelinesState.java
@@ -145,7 +145,7 @@ public class GuidelinesState {
                 g = guideline;
                 layout.add(g);
             }
-            applyGuideline(mapIdsToIdx.get(id), g);
+            applyGuideline(2*mapIdsToIdx.get(id), g);
         }
     }
 


### PR DESCRIPTION
Multiply the index by 2 to fetch the correct type/value in the table