### PR TITLE
[Grid] Enable the Grid helper in Compose using JSON representation

### DIFF
--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/GridTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/GridTest.kt
@@ -1,0 +1,520 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.compose
+
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.platform.isDebugInspectorInfoEnabled
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertPositionInRootIsEqualTo
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@MediumTest
+@RunWith(AndroidJUnit4::class)
+class GridTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Before
+    fun setup() {
+        isDebugInspectorInfoEnabled = true
+    }
+
+    @After
+    fun tearDown() {
+        isDebugInspectorInfoEnabled = false
+    }
+
+    @Test
+    fun testTwoByTwo() {
+        val rootSize = 200.dp
+        val boxesCount = 4
+        val rows = 2
+        val columns = 2
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                width = "'parent'",
+                height = "'parent'",
+                boxesCount = boxesCount,
+                orientation = 0,
+                rows = rows,
+                columns = columns,
+                hGap = 0,
+                vGap = 0,
+                spans = "''",
+                skips = "''",
+                rowWeights = "''",
+                columnWeights = "''"
+            )
+        }
+        var leftX = 0.dp
+        var topY = 0.dp
+        var rightX = 0.dp
+        var bottomY = 0.dp
+
+        // 10.dp is the size of a singular box
+        val gapSize = (rootSize - (10.dp * 2f)) / (columns * 2f)
+        rule.waitForIdle()
+        leftX += gapSize
+        topY += gapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(leftX, topY)
+        rightX = leftX + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(rightX, topY)
+        bottomY = topY + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(leftX, bottomY)
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(rightX, bottomY)
+    }
+
+    @Test
+    fun testOrientation() {
+        val rootSize = 200.dp
+        val boxesCount = 4
+        val rows = 2
+        val columns = 2
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                width = "'parent'",
+                height = "'parent'",
+                boxesCount = boxesCount,
+                orientation = 1,
+                rows = rows,
+                columns = columns,
+                hGap = 0,
+                vGap = 0,
+                spans = "''",
+                skips = "''",
+                rowWeights = "''",
+                columnWeights = "''"
+            )
+        }
+        var leftX = 0.dp
+        var topY = 0.dp
+        var rightX = 0.dp
+        var bottomY = 0.dp
+
+        // 10.dp is the size of a singular box
+        val gapSize = (rootSize - (10.dp * 2f)) / (columns * 2f)
+        rule.waitForIdle()
+        leftX += gapSize
+        topY += gapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(leftX, topY)
+        rightX = leftX + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(rightX, topY)
+        bottomY = topY + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(leftX, bottomY)
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(rightX, bottomY)
+    }
+
+
+    @Test
+    fun testRows() {
+        val rootSize = 200.dp
+        val boxesCount = 4
+        val rows = 0
+        val columns = 1
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                width = "'parent'",
+                height = "'parent'",
+                boxesCount = boxesCount,
+                orientation = 0,
+                rows = rows,
+                columns = columns,
+                hGap = 0,
+                vGap = 0,
+                spans = "''",
+                skips = "''",
+                rowWeights = "''",
+                columnWeights = "''"
+            )
+        }
+        var expectedX = 0.dp
+        var expectedY = 0.dp
+
+        // 10.dp is the size of a singular box
+        val hGapSize = (rootSize - 10.dp) / 2f
+        val vGapSize = (rootSize - (10.dp * 4f)) / (boxesCount * 2f)
+        rule.waitForIdle()
+        expectedX += hGapSize
+        expectedY += vGapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp;
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX , expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp;
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp;
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
+    }
+
+    @Test
+    fun testColumns() {
+        val rootSize = 200.dp
+        val boxesCount = 4
+        val rows = 1
+        val columns = 0
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                width = "'parent'",
+                height = "'parent'",
+                boxesCount = boxesCount,
+                orientation = 0,
+                rows = rows,
+                columns = columns,
+                hGap = 0,
+                vGap = 0,
+                spans = "''",
+                skips = "''",
+                rowWeights = "''",
+                columnWeights = "''"
+            )
+        }
+        var expectedX = 0.dp
+        var expectedY = 0.dp
+
+        // 10.dp is the size of a singular box
+        val hGapSize = (rootSize - (10.dp * 4f)) / (boxesCount * 2f)
+        val vGapSize = (rootSize - 10.dp) / 2f
+        rule.waitForIdle()
+        expectedX += hGapSize
+        expectedY += vGapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp;
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX , expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp;
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp;
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
+    }
+
+    @Test
+    fun testSkips() {
+        val rootSize = 200.dp
+        val boxesCount = 3
+        val rows = 2
+        val columns = 2
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                width = "'parent'",
+                height = "'parent'",
+                boxesCount = boxesCount,
+                orientation = 0,
+                rows = rows,
+                columns = columns,
+                hGap = 0,
+                vGap = 0,
+                spans = "''",
+                skips = "'0:1x1'",
+                rowWeights = "''",
+                columnWeights = "''"
+            )
+        }
+        var leftX = 0.dp
+        var topY = 0.dp
+        var rightX = 0.dp
+        var bottomY = 0.dp
+
+        // 10.dp is the size of a singular box
+        val gapSize = (rootSize - (10.dp * 2f)) / (columns * 2f)
+        rule.waitForIdle()
+        leftX += gapSize
+        topY += gapSize
+        rightX = leftX + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(rightX, topY)
+        bottomY = topY + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(leftX, bottomY)
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(rightX, bottomY)
+    }
+
+    @Test
+    fun testSpans() {
+        val rootSize = 200.dp
+        val boxesCount = 3
+        val rows = 2
+        val columns = 2
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                width = "'parent'",
+                height = "'parent'",
+                boxesCount = boxesCount,
+                orientation = 0,
+                rows = rows,
+                columns = columns,
+                hGap = 0,
+                vGap = 0,
+                spans = "'0:1x2'",
+                skips = "''",
+                rowWeights = "''",
+                columnWeights = "''"
+            )
+        }
+        var leftX = 0.dp
+        var topY = 0.dp
+        var rightX = 0.dp
+        var bottomY = 0.dp
+
+        // 10.dp is the size of a singular box
+        var spanLeft = (rootSize - 10.dp) / 2f
+        val gapSize = (rootSize - (10.dp * 2f)) / (columns * 2f)
+        rule.waitForIdle()
+        leftX += gapSize
+        topY += gapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(spanLeft, topY)
+        rightX = leftX + 10.dp + gapSize + gapSize
+        bottomY = topY + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(leftX, bottomY)
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(rightX, bottomY)
+    }
+
+    @Test
+    fun testRowWeights() {
+        val rootSize = 200.dp
+        val boxesCount = 2
+        val rows = 0
+        val columns = 1
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                width = "'parent'",
+                height = "'parent'",
+                boxesCount = boxesCount,
+                orientation = 0,
+                rows = rows,
+                columns = columns,
+                hGap = 0,
+                vGap = 0,
+                spans = "''",
+                skips = "''",
+                rowWeights = "'1,3'",
+                columnWeights = "''"
+            )
+        }
+        var expectedLeft = (rootSize - 10.dp) / 2f
+        var expectedTop = 0.dp
+
+        // 10.dp is the size of a singular box
+        // first box takes the 1/4 of the height
+        val firstGapSize = (rootSize / 4 - 10.dp) / 2
+        // second box takes the 3/4 of the height
+        val secondGapSize = ((rootSize * 3 / 4) - 10.dp) / 2
+        rule.waitForIdle()
+        expectedTop += firstGapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedLeft, expectedTop)
+        expectedTop += 10.dp + firstGapSize + secondGapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedLeft, expectedTop)
+
+    }
+
+    @Test
+    fun testColumnWeights() {
+        val rootSize = 200.dp
+        val boxesCount = 2
+        val rows = 1
+        val columns = 0
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                width = "'parent'",
+                height = "'parent'",
+                boxesCount = boxesCount,
+                orientation = 0,
+                rows = rows,
+                columns = columns,
+                hGap = 0,
+                vGap = 0,
+                spans = "''",
+                skips = "''",
+                rowWeights = "''",
+                columnWeights = "'1,3'"
+            )
+        }
+        var expectedLeft = 0.dp
+        var expectedTop = (rootSize - 10.dp) / 2f
+
+        // 10.dp is the size of a singular box
+        // first box takes the 1/4 of the width
+        val firstGapSize = (rootSize / 4 - 10.dp) / 2
+        // second box takes the 3/4 of the width
+        val secondGapSize = ((rootSize * 3 / 4) - 10.dp) / 2
+        rule.waitForIdle()
+        expectedLeft += firstGapSize
+
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedLeft, expectedTop)
+        expectedLeft += 10.dp + firstGapSize + secondGapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedLeft, expectedTop)
+    }
+
+    @Test
+    fun testGaps() {
+        val rootSize = 200.dp
+        val hGap = 10.dp
+        val vGap = 20.dp
+        rule.setContent {
+            gridComposableGapTest(
+                modifier = Modifier.size(rootSize),
+                width = "'parent'",
+                height = "'parent'",
+                hGap = Math.round(hGap.value),
+                vGap = Math.round(vGap.value),
+            )
+        }
+        var expectedLeft = 0.dp
+        var expectedTop = 0.dp
+
+        val boxWidth = (rootSize - hGap) / 2f
+        val boxHeight = (rootSize - vGap) / 2f
+
+        rule.waitForIdle()
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(0.dp, 0.dp)
+        expectedLeft += boxWidth + hGap
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedLeft, 0.dp)
+        expectedTop += boxHeight + vGap
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(0.dp, expectedTop)
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedLeft, expectedTop)
+    }
+
+    @Composable
+    private fun gridComposableTest(
+        modifier: Modifier = Modifier,
+        width: String,
+        height: String,
+        rows: Int,
+        columns: Int,
+        spans: String,
+        skips: String,
+        rowWeights: String,
+        columnWeights: String,
+        boxesCount: Int,
+        orientation: Int,
+        vGap: Int,
+        hGap: Int,
+    ) {
+        val ids = (0 until boxesCount).map { "box$it" }.toTypedArray()
+        val gridContains = ids.joinToString(separator = ", ") { "'$it'" }
+        ConstraintLayout(
+            modifier = modifier,
+            constraintSet = ConstraintSet(
+                """
+        {
+            grid: {
+                width: $width,
+                height: $height,
+                type: 'Grid',
+                rows: $rows,
+                columns $columns,
+                vGap: $vGap,
+                hGap: $hGap,
+                spans: $spans,
+                skips: $skips,
+                rowWeights: $rowWeights,
+                columnWeights: $columnWeights
+                orientation: $orientation,
+                contains: [$gridContains],
+              }
+        }
+        """.trimIndent()
+            )
+        ) {
+            ids.forEach { id ->
+                Box(
+                    Modifier
+                        .layoutId(id)
+                        .size(10.dp)
+                        .background(Color.Red)
+                        .testTag(id)
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun gridComposableGapTest(
+        modifier: Modifier = Modifier,
+        width: String,
+        height: String,
+        vGap: Int,
+        hGap: Int,
+    ) {
+        val ids = (0 until 4).map { "box$it" }.toTypedArray()
+        val gridContains = ids.joinToString(separator = ", ") { "'$it'" }
+
+        ConstraintLayout(
+            modifier = modifier,
+            constraintSet = ConstraintSet(
+                """
+        {
+            grid: {
+                width: $width,
+                height: $height,
+                type: 'Grid',
+                rows: 2,
+                columns: 2,
+                vGap: $vGap,
+                hGap: $hGap,
+                contains: [$gridContains],
+              },
+              box0: {
+                width: 'spread',
+                height: 'spread',
+              },
+              box1: {
+                width: 'spread',
+                height: 'spread',
+              },
+              box2: {
+                width: 'spread',
+                height: 'spread',
+              },
+              box3: {
+                width: 'spread',
+                height: 'spread',
+              }
+        }
+        """.trimIndent()
+            )
+        ) {
+            ids.forEach { id ->
+                Box(
+                    Modifier
+                        .layoutId(id)
+                        .background(Color.Red)
+                        .testTag(id)
+                )
+            }
+        }
+    }
+}

--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/MotionGridTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/MotionGridTest.kt
@@ -1,0 +1,304 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalMotionApi::class)
+
+package androidx.constraintlayout.compose
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.isDebugInspectorInfoEnabled
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertPositionInRootIsEqualTo
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@MediumTest
+@RunWith(AndroidJUnit4::class)
+class MotionGridTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Before
+    fun setup() {
+        isDebugInspectorInfoEnabled = true
+    }
+
+    @After
+    fun tearDown() {
+        isDebugInspectorInfoEnabled = false
+    }
+
+    @Test
+    fun rowToColumnGrid() {
+        val rootSize = 200.dp
+        var animateToEnd by mutableStateOf(false)
+        rule.setContent {
+            val progress by animateFloatAsState(targetValue = if (animateToEnd) 1f else 0f)
+
+            MotionLayout(
+                modifier = Modifier
+                    .size(rootSize),
+                motionScene = MotionScene(
+                    """
+            {
+                ConstraintSets: {
+                  start: {
+                    grid1: { 
+                        width: 200,
+                        height: 200,
+                        type: "Grid",
+                        orientation: 0,
+                        rows: 0,
+                        columns: 1,
+                        hGap: 0,
+                        vGap: 0,
+                        spans: "",
+                        skips: "",
+                        rowWeights: "",
+                        columnWeights: "",
+                        contains: ["box1", "box2", "box3", "box4"],
+                      }
+                  },
+                  end: {
+                    grid2: { 
+                        width: 200,
+                        height: 200,
+                        type: "Grid",
+                        orientation: 0,
+                        rows: 1,
+                        columns: 0,
+                        hGap: 0,
+                        vGap: 0,
+                        spans: "",
+                        skips: "",
+                        rowWeights: "",
+                        columnWeights: "",
+                        contains: ["box1", "box2", "box3", "box4"],
+                      }
+                  }
+                },
+                Transitions: {
+                  default: {
+                    from: 'start', to: 'end',
+                  }
+                }
+            }
+            """
+                ),
+                progress = progress
+            ) {
+                val numArray = arrayOf("box1", "box2", "box3", "box4")
+                for (num in numArray) {
+                    Box(
+                        modifier = Modifier
+                            .size(10.dp)
+                            .layoutId(num)
+                            .testTag(num)
+                            .background(Color.Red)
+                    )
+                }
+            }
+        }
+        rule.waitForIdle()
+
+        val boxesCount = 4
+        var expectedX = 0.dp
+        var expectedY = 0.dp
+
+        // 10.dp is the size of a singular box
+        var hGapSize = (rootSize - 10.dp) / 2f
+        var vGapSize = (rootSize - (10.dp * 4f)) / (boxesCount * 2f)
+        rule.waitForIdle()
+        expectedX += hGapSize
+        expectedY += vGapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp;
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX , expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp;
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp;
+        rule.onNodeWithTag("box4").assertPositionInRootIsEqualTo(expectedX, expectedY)
+
+        animateToEnd = true
+        rule.waitForIdle()
+
+        expectedX = 0.dp
+        expectedY = 0.dp
+
+        // 10.dp is the size of a singular box
+        hGapSize = (rootSize - (10.dp * 4f)) / (boxesCount * 2f)
+        vGapSize = (rootSize - 10.dp) / 2f
+
+        expectedX += hGapSize
+        expectedY += vGapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp;
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX , expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp;
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp;
+        rule.onNodeWithTag("box4").assertPositionInRootIsEqualTo(expectedX, expectedY)
+    }
+
+    @OptIn(ExperimentalMotionApi::class)
+    @Test
+    fun wrapToSpreadGrid() {
+        val rootSize = 200.dp
+        var animateToEnd by mutableStateOf(false)
+        val hGap = 10.dp
+        val vGap = 20.dp
+        val hGapVal = Math.round(hGap.value)
+        val vGapVal = Math.round(vGap.value)
+        rule.setContent {
+            val progress by animateFloatAsState(targetValue = if (animateToEnd) 1f else 0f)
+            
+            MotionLayout(
+                modifier = Modifier
+                    .size(rootSize),
+                motionScene = MotionScene(
+                    """
+            {
+                ConstraintSets: {
+                  start: {
+                    grid1: { 
+                        width: 200,
+                        height: 200,
+                        type: "Grid",
+                        orientation: 0,
+                        rows: 2,
+                        columns: 2,
+                        hGap: 0,
+                        vGap: 0,
+                        contains: ["box1", "box2", "box3", "box4"],
+                      }
+                  },
+                  end: {
+                    grid2: { 
+                        width: 200,
+                        height: 200,
+                        type: "Grid",
+                        orientation: 0,
+                        rows: 2,
+                        columns: 2,
+                        hGap: $hGapVal,
+                        vGap: $vGapVal,
+                        contains: ["box1", "box2", "box3", "box4"],
+                      },
+                      box1: {
+                        width: 'spread',
+                        height: 'spread',
+                      },
+                      box2: {
+                        width: 'spread',
+                        height: 'spread',
+                      },
+                      box3: {
+                        width: 'spread',
+                        height: 'spread',
+                      },
+                      box4: {
+                        width: 'spread',
+                        height: 'spread',
+                      }
+                  }
+                },
+                Transitions: {
+                  default: {
+                    from: 'start', to: 'end',
+                  }
+                }
+            }
+            """
+                ),
+                progress = progress
+            ) {
+                val numArray = arrayOf("box1", "box2", "box3", "box4")
+                for (num in numArray) {
+                    Box(
+                        modifier = Modifier
+                            .size(10.dp)
+                            .layoutId(num)
+                            .testTag(num)
+                            .background(Color.Red)
+                    )
+                }
+            }
+        }
+        rule.waitForIdle()
+
+        val columns = 2
+        var leftX = 0.dp
+        var topY = 0.dp
+        var rightX = 0.dp
+        var bottomY = 0.dp
+
+        // 10.dp is the size of a singular box
+        val gapSize = (rootSize - (10.dp * 2f)) / (columns * 2f)
+        rule.waitForIdle()
+        leftX += gapSize
+        topY += gapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(leftX, topY)
+        rightX = leftX + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(rightX, topY)
+        bottomY = topY + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(leftX, bottomY)
+        rule.onNodeWithTag("box4").assertPositionInRootIsEqualTo(rightX, bottomY)
+
+        animateToEnd = true
+        rule.waitForIdle()
+
+        var expectedLeft = 0.dp
+        var expectedTop = 0.dp
+
+        val boxWidth = (rootSize - hGap) / 2f
+        val boxHeight = (rootSize - vGap) / 2f
+
+        rule.waitForIdle()
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(0.dp, 0.dp)
+        expectedLeft += boxWidth + hGap
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedLeft, 0.dp)
+        expectedTop += boxHeight + vGap
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(0.dp, expectedTop)
+        rule.onNodeWithTag("box4").assertPositionInRootIsEqualTo(expectedLeft, expectedTop)
+    }
+
+    // convert dp to px
+    @Composable
+    private fun dpToPx(dpVal: Dp): Float {
+        val density = LocalDensity.current
+        return with(density) { dpVal.toPx() }
+    }
+}

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintSetParser.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintSetParser.java
@@ -36,6 +36,7 @@ import androidx.constraintlayout.core.state.helpers.BarrierReference;
 import androidx.constraintlayout.core.state.helpers.ChainReference;
 import androidx.constraintlayout.core.state.helpers.FlowReference;
 import androidx.constraintlayout.core.state.helpers.GuidelineReference;
+import androidx.constraintlayout.core.state.helpers.GridReference;
 import androidx.constraintlayout.core.widgets.ConstraintWidget;
 import androidx.constraintlayout.core.widgets.Flow;
 
@@ -538,6 +539,12 @@ public class ConstraintSetParser {
                                                 (CLObject) element
                                         );
                                         break;
+                                    case "Grid":
+                                        parseGridType(state,
+                                                elementName,
+                                                layoutVariables,
+                                                (CLObject) element);
+                                        break;
                                 }
                             } else {
                                 parseWidget(state, layoutVariables,
@@ -850,6 +857,85 @@ public class ConstraintSetParser {
                     }
 
                     break;
+            }
+        }
+    }
+
+    private static void parseGridType(State state,
+                                       String name,
+                                       LayoutVariables layoutVariables,
+                                       CLObject element) throws CLParsingException {
+
+        GridReference grid = state.getGrid(name);
+
+        for (String param : element.names()) {
+            switch (param) {
+                case "contains":
+                    CLArray list = element.getArrayOrNull(param);
+                    if (list != null) {
+                        for (int j = 0; j < list.size(); j++) {
+
+                            String elementNameReference = list.get(j).content();
+                            ConstraintReference elementReference =
+                                    state.constraints(elementNameReference);
+                            if (PARSER_DEBUG) {
+                                System.out.println(
+                                        "Add REFERENCE "
+                                                + "($elementNameReference = $elementReference) "
+                                                + "TO BARRIER "
+                                );
+                            }
+                            grid.add(elementReference);
+                        }
+                    }
+                    break;
+                case "orientation":
+                    int orientation = element.get(param).getInt();
+                    grid.setOrientation(orientation);
+                    break;
+                case "rows":
+                    int rows = element.get(param).getInt();
+                    grid.setRowsSet(rows);
+                    break;
+                case "columns":
+                    int columns = element.get(param).getInt();
+                    grid.setColumnsSet(columns);
+                    break;
+                case "hGap":
+                    float hGap = element.get(param).getFloat();
+                    grid.setHorizontalGaps(toPix(state, hGap));
+                    break;
+                case "vGap":
+                    float vGap = element.get(param).getFloat();
+                    grid.setVerticalGaps(toPix(state, vGap));
+                    break;
+                case "spans":
+                    String spans = element.get(param).content();
+                    if (spans != null && spans.contains("x") && spans.contains(":")) {
+                        grid.setStrSpans(spans);
+                    }
+                    break;
+                case "skips":
+                    String skips = element.get(param).content();
+                    if (skips != null && skips.contains("x") && skips.contains(":")) {
+                        grid.setStrSkips(skips);
+                    }
+                    break;
+                case "rowWeights":
+                    String rowWeights = element.get(param).content();
+                    if (rowWeights != null && rowWeights.contains(",")) {
+                        grid.setStrRowWeights(rowWeights);
+                    }
+                    break;
+                case "columnWeights":
+                    String columnWeights = element.get(param).content();
+                    if (columnWeights != null && columnWeights.contains(",")) {
+                        grid.setStrColumnWeights(columnWeights);
+                    }
+                    break;
+                default:
+                    ConstraintReference reference = state.constraints(name);
+                    applyAttribute(state, layoutVariables, reference, element, param);
             }
         }
     }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/State.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/State.java
@@ -20,13 +20,13 @@ import static androidx.constraintlayout.core.widgets.ConstraintWidget.CHAIN_PACK
 import static androidx.constraintlayout.core.widgets.ConstraintWidget.CHAIN_SPREAD;
 import static androidx.constraintlayout.core.widgets.ConstraintWidget.CHAIN_SPREAD_INSIDE;
 
-import androidx.constraintlayout.core.motion.utils.Utils;
 import androidx.constraintlayout.core.state.helpers.AlignHorizontallyReference;
 import androidx.constraintlayout.core.state.helpers.AlignVerticallyReference;
 import androidx.constraintlayout.core.state.helpers.BarrierReference;
 import androidx.constraintlayout.core.state.helpers.FlowReference;
 import androidx.constraintlayout.core.state.helpers.GuidelineReference;
 import androidx.constraintlayout.core.state.helpers.HorizontalChainReference;
+import androidx.constraintlayout.core.state.helpers.GridReference;
 import androidx.constraintlayout.core.state.helpers.VerticalChainReference;
 import androidx.constraintlayout.core.widgets.ConstraintWidget;
 import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer;
@@ -93,6 +93,7 @@ public class State {
         LAYER,
         HORIZONTAL_FLOW,
         VERTICAL_FLOW,
+        GRID,
         FLOW
     }
 
@@ -324,6 +325,10 @@ public class State {
                     reference = new FlowReference(this, type);
                 }
                 break;
+                case GRID: {
+                    reference = new GridReference(this, type);
+                }
+                break;
                 default: {
                     reference = new HelperReference(this, type);
                 }
@@ -366,6 +371,15 @@ public class State {
             reference.setFacade(barrierReference);
         }
         return (BarrierReference) reference.getFacade();
+    }
+
+    public GridReference getGrid(Object key) {
+        ConstraintReference reference = constraints(key);
+        if (reference.getFacade() == null || !(reference.getFacade() instanceof GridReference)) {
+            GridReference flowReference = new GridReference(this, Helper.GRID);
+            reference.setFacade(flowReference);
+        }
+        return (GridReference) reference.getFacade();
     }
 
     /**

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/GridReference.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/GridReference.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.state.helpers;
+
+import androidx.constraintlayout.core.state.HelperReference;
+import androidx.constraintlayout.core.state.State;
+import androidx.constraintlayout.core.utils.GridCore;
+import androidx.constraintlayout.core.widgets.Flow;
+import androidx.constraintlayout.core.widgets.HelperWidget;
+
+/**
+ * A HelperReference of a Grid Helper that helps enable Grid in Compose
+ */
+public class GridReference extends HelperReference {
+
+    public GridReference(State state, State.Helper type) {
+        super(state, type);
+    }
+
+    /**
+     * The Grid Object
+     */
+    protected GridCore mGrid;
+
+    /**
+     * The orientation of the widgets arrangement horizontally or vertically
+     */
+    protected int mOrientation;
+
+    /**
+     * Number of rows of the Grid
+     */
+    protected int mRowsSet;
+
+    /**
+     * Number of columns of the Grid
+     */
+    protected int mColumnsSet;
+
+    /**
+     * The horizontal gaps between widgets
+     */
+    protected float mHorizontalGaps;
+
+    /**
+     * The vertical gaps between widgets
+     */
+    protected float mVerticalGaps;
+
+    /**
+     * The weight of each widget in a row
+     */
+    protected String mStrRowWeights;
+
+    /**
+     * The weight of each widget in a column
+     */
+    protected String mStrColumnWeights;
+
+    /**
+     * Specify the spanned areas of widgets
+     */
+    protected String mStrSpans;
+
+    /**
+     * Specify the positions to be skipped in a Grid
+     */
+    protected String mStrSkips;
+
+    /**
+     * Get the number of rows
+     * @return the number of rows
+     */
+    public int getRowsSet() {
+        return mRowsSet;
+    }
+
+    /**
+     * Set the number of rows
+     * @param rowsSet the number of rows
+     */
+    public void setRowsSet(int rowsSet) {
+        mRowsSet = rowsSet;
+    }
+
+    /**
+     * Get the number of columns
+     * @return the number of columns
+     */
+    public int getColumnsSet() {
+        return mColumnsSet;
+    }
+
+    /**
+     * Set the number of columns
+     * @param columnsSet the number of columns
+     */
+    public void setColumnsSet(int columnsSet) {
+        mColumnsSet = columnsSet;
+    }
+
+    /**
+     * Get the horizontal gaps
+     * @return the horizontal gaps
+     */
+    public float getHorizontalGaps() {
+        return mHorizontalGaps;
+    }
+
+    /**
+     * Set the horizontal gaps
+     * @param horizontalGaps the horizontal gaps
+     */
+    public void setHorizontalGaps(float horizontalGaps) {
+        mHorizontalGaps = horizontalGaps;
+    }
+
+    /**
+     * Get the vertical gaps
+     * @return the vertical gaps
+     */
+    public float getVerticalGaps() {
+        return mVerticalGaps;
+    }
+
+    /**
+     * Set the vertical gaps
+     * @param verticalGaps  the vertical gaps
+     */
+    public void setVerticalGaps(float verticalGaps) {
+        mVerticalGaps = verticalGaps;
+    }
+
+    /**
+     * Get the row weights
+     * @return the row weights
+     */
+    public String getStrRowWeights() {
+        return mStrRowWeights;
+    }
+
+    /**
+     * Set the row weights
+     * @param strRowWeights the row weights
+     */
+    public void setStrRowWeights(String strRowWeights) {
+        mStrRowWeights = strRowWeights;
+    }
+
+    /**
+     * Get the column weights
+     * @return the column weights
+     */
+    public String getStrColumnWeights() {
+        return mStrColumnWeights;
+    }
+
+    /**
+     * Set the column weights
+     * @param strColumnWeights the column weights
+     */
+    public void setStrColumnWeights(String strColumnWeights) {
+        mStrColumnWeights = strColumnWeights;
+    }
+
+    /**
+     * Get the spans
+     * @return the spans
+     */
+    public String getStrSpans() {
+        return mStrSpans;
+    }
+
+    /**
+     * Set the spans
+     * @param strSpans the spans
+     */
+    public void setStrSpans(String strSpans) {
+        mStrSpans = strSpans;
+    }
+
+    /**
+     * Get the skips
+     * @return the skips
+     */
+    public String getStrSkips() {
+        return mStrSkips;
+    }
+
+    /**
+     * Set the skips
+     * @param strSkips the skips
+     */
+    public void setStrSkips(String strSkips) {
+        mStrSkips = strSkips;
+    }
+
+    /**
+     * Get the helper widget (Grid)
+     * @return the helper widget (Grid)
+     */
+    @Override
+    public HelperWidget getHelperWidget() {
+        if (mGrid == null) {
+            mGrid = new GridCore();
+        }
+        return mGrid;
+    }
+
+    /**
+     * Set the helper widget (Grid)
+     * @param widget the helper widget (Grid)
+     */
+    @Override
+    public void setHelperWidget(HelperWidget widget) {
+        if (widget instanceof Flow) {
+            mGrid = (GridCore) widget;
+        } else {
+            mGrid = null;
+        }
+    }
+
+    /**
+     * Get the Orientation
+     * @return the Orientation
+     */
+    public int getOrientation() {
+        return mOrientation;
+    }
+
+    /**
+     * Set the Orientation
+     * @param orientation the Orientation
+     */
+    public void setOrientation(int orientation) {
+        mOrientation = orientation;
+
+    }
+
+    /**
+     * Apply all the attributes to the helper widget (Grid)
+     */
+    @Override
+    public void apply() {
+        getHelperWidget();
+
+        mGrid.setOrientation(mOrientation);
+
+        if (mRowsSet != 0) {
+            mGrid.setRows(mRowsSet);
+        }
+
+        if (mColumnsSet != 0) {
+            mGrid.setColumns(mColumnsSet);
+        }
+
+        if (mHorizontalGaps != 0) {
+            mGrid.setHorizontalGaps(mHorizontalGaps);
+        }
+
+        if (mVerticalGaps != 0) {
+            mGrid.setVerticalGaps(mVerticalGaps);
+        }
+
+        if (mStrRowWeights != null && !mStrRowWeights.equals("")) {
+            mGrid.setRowWeights(mStrRowWeights);
+        }
+
+        if (mStrColumnWeights != null && !mStrColumnWeights.equals("")) {
+            mGrid.setColumnWeights(mStrColumnWeights);
+        }
+
+        if (mStrSpans != null && !mStrSpans.equals("")) {
+            mGrid.setSpans(mStrSpans);
+        }
+
+        if (mStrSkips != null && !mStrSkips.equals("")) {
+            mGrid.setSkips(mStrSkips);
+        }
+
+        // General attributes of a widget
+        applyBase();
+    }
+}

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/utils/GridCore.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/utils/GridCore.java
@@ -1,0 +1,881 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.core.utils;
+
+import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT;
+
+import androidx.constraintlayout.core.LinearSystem;
+import androidx.constraintlayout.core.widgets.ConstraintWidget;
+import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer;
+import androidx.constraintlayout.core.widgets.VirtualLayout;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * The Grid Helper in the Core library that helps to enable Grid in Compose
+ */
+public class GridCore extends VirtualLayout {
+
+    public static final int VERTICAL = 1;
+    public static final int HORIZONTAL = 0;
+    private static final int MAX_ROWS = 50; // maximum number of rows can be specified.
+    private static final int MAX_COLUMNS = 50; // maximum number of columns can be specified.
+    private static final int DEFAULT_SIZE = 3; // default rows and columns.
+
+    /**
+     * Container for all the ConstraintWidgets
+     */
+    ConstraintWidgetContainer mContainer;
+
+    public ConstraintWidget[] getBoxWidgets() {
+        return mBoxWidgets;
+    }
+
+    /**
+     * boxWidgets were created as anchor points for arranging the associated widgets
+     */
+    private ConstraintWidget[] mBoxWidgets;
+
+    /**
+     * number of rows of the grid
+     */
+    private int mRows;
+
+    /**
+     * number of rows set by the JSON or API
+     */
+    private int mRowsSet;
+
+    /**
+     * number of columns of the grid
+     */
+    private int mColumns;
+
+    /**
+     * number of columns set by the XML or API
+     */
+    private int mColumnsSet;
+
+    /**
+     * Horizontal gaps in Dp
+     */
+    private float mHorizontalGaps;
+
+    /**
+     * Vertical gaps in Dp
+     */
+    private float mVerticalGaps;
+
+    /**
+     * string format of the row weight
+     */
+    private String mStrRowWeights;
+
+    /**
+     * string format of the column weight
+     */
+    private String mStrColumnWeights;
+
+    /**
+     * string format of the input Spans
+     */
+    private String mStrSpans;
+
+    /**
+     * string format of the input Skips
+     */
+    private String mStrSkips;
+
+    /**
+     * orientation of the widget arrangement - vertical or horizontal
+     */
+    private int mOrientation;
+
+    /**
+     * Indicates what is the next available position to place an widget
+     */
+    private int mNextAvailableIndex = 0;
+
+    /**
+     * A boolean matrix that tracks the positions that are occupied by skips and spans
+     * true: available position
+     * false: non-available position
+     */
+    private boolean[][] mPositionMatrix;
+
+    /**
+     * Store the widget ids of handled spans
+     */
+    Set<String> mSpanIds = new HashSet<>();
+
+    /**
+     * A int matrix that contains the positions where a widget would constraint to at each direction
+     * Each row contains 4 values that indicate the position to constraint of a widget.
+     * Example row: [left, top, right, bottom]
+     */
+    private int[][] mConstraintMatrix;
+
+    public GridCore() {
+        updateActualRowsAndColumns();
+        initMatrices();
+    }
+
+    public GridCore(int rows, int columns) {
+        mRowsSet = rows;
+        mColumnsSet = columns;
+        if (rows > MAX_ROWS) {
+            mRowsSet = DEFAULT_SIZE;
+        }
+
+        if (columns > MAX_COLUMNS) {
+            mColumnsSet = DEFAULT_SIZE;
+        }
+
+        updateActualRowsAndColumns();
+        initMatrices();
+    }
+
+    /**
+     * get the parent ConstraintWidgetContainer
+     *
+     * @return the parent ConstraintWidgetContainer
+     */
+    public ConstraintWidgetContainer getContainer() {
+        return mContainer;
+    }
+
+    /**
+     * Set the parent ConstraintWidgetContainer
+     * @param container the parent ConstraintWidgetContainer
+     */
+    public void setContainer(ConstraintWidgetContainer container) {
+        mContainer = container;
+    }
+
+    /**
+     * set new spans value
+     *
+     * @param spans new spans value
+     */
+    public void setSpans(CharSequence spans) {
+        if (mStrSpans != null && mStrSpans.equals(spans.toString())) {
+            return;
+        }
+
+        mStrSpans = spans.toString();
+    }
+
+    /**
+     * set new skips value
+     *
+     * @param skips new spans value
+     */
+    public void setSkips(String skips) {
+        if (mStrSkips != null && mStrSkips.equals(skips)) {
+            return;
+        }
+
+        mStrSkips = skips;
+
+    }
+
+    /**
+     * get the value of horizontalGaps
+     *
+     * @return the value of horizontalGaps
+     */
+    public float getHorizontalGaps() {
+        return mHorizontalGaps;
+    }
+
+    /**
+     * set new horizontalGaps value and also invoke invalidate
+     *
+     * @param horizontalGaps new horizontalGaps value
+     */
+    public void setHorizontalGaps(float horizontalGaps) {
+        if (horizontalGaps < 0) {
+            return;
+        }
+
+        if (mHorizontalGaps == horizontalGaps) {
+            return;
+        }
+
+        mHorizontalGaps = horizontalGaps;
+    }
+
+    /**
+     * get the value of verticalGaps
+     *
+     * @return the value of verticalGaps
+     */
+    public float getVerticalGaps() {
+        return mVerticalGaps;
+    }
+
+    /**
+     * set new verticalGaps value and also invoke invalidate
+     *
+     * @param verticalGaps new verticalGaps value
+     */
+    public void setVerticalGaps(float verticalGaps) {
+        if (verticalGaps < 0) {
+            return;
+        }
+
+        if (mVerticalGaps == verticalGaps) {
+            return;
+        }
+
+        mVerticalGaps = verticalGaps;
+    }
+
+    /**
+     * get the string value of rowWeights
+     *
+     * @return the string value of rowWeights
+     */
+    public String getRowWeights() {
+        return mStrRowWeights;
+    }
+
+    /**
+     * set new rowWeights value and also invoke invalidate
+     *
+     * @param rowWeights new rowWeights value
+     */
+    public void setRowWeights(String rowWeights) {
+        if (mStrRowWeights != null && mStrRowWeights.equals(rowWeights)) {
+            return;
+        }
+
+        mStrRowWeights = rowWeights;
+    }
+
+    /**
+     * get the string value of columnWeights
+     *
+     * @return the string value of columnWeights
+     */
+    public String getColumnWeights() {
+        return mStrColumnWeights;
+    }
+
+    /**
+     * set new columnWeights value and also invoke invalidate
+     *
+     * @param columnWeights new columnWeights value
+     */
+    public void setColumnWeights(String columnWeights) {
+        if (mStrColumnWeights != null && mStrColumnWeights.equals(columnWeights)) {
+            return;
+        }
+
+        mStrColumnWeights = columnWeights;
+    }
+
+    /**
+     * get the value of orientation
+     *
+     * @return the value of orientation
+     */
+    public int getOrientation() {
+        return mOrientation;
+    }
+
+    /**
+     * set new orientation value
+     *
+     * @param orientation new orientation value
+     */
+    public void setOrientation(int orientation) {
+        if (!(orientation == HORIZONTAL || orientation == VERTICAL)) {
+            return;
+        }
+
+        if (mOrientation == orientation) {
+            return;
+        }
+
+        mOrientation = orientation;
+    }
+
+    /**
+     * set new rows value
+     *
+     * @param rows new rows value
+     */
+    public void setRows(int rows) {
+        if (rows > MAX_ROWS) {
+            return;
+        }
+
+        if (mRowsSet == rows) {
+            return;
+        }
+
+        mRowsSet = rows;
+        updateActualRowsAndColumns();
+        initVariables();
+    }
+
+    /**
+     * set new columns value
+     *
+     * @param columns new rows value
+     */
+    public void setColumns(int columns) {
+        if (columns > MAX_COLUMNS) {
+            return;
+        }
+
+        if (mColumnsSet == columns) {
+            return;
+        }
+
+        mColumnsSet = columns;
+        updateActualRowsAndColumns();
+        initVariables();
+    }
+
+    /**
+     * Handle the span use cases
+     *
+     * @param spansMatrix a int matrix that contains span information
+     */
+    private void handleSpans(int[][] spansMatrix) {
+        for (int i = 0; i < spansMatrix.length; i++) {
+            int row = getRowByIndex(spansMatrix[i][0]);
+            int col = getColByIndex(spansMatrix[i][0]);
+            if (!invalidatePositions(row, col,
+                    spansMatrix[i][1], spansMatrix[i][2])) {
+                return;
+            }
+            connectWidget(mWidgets[i], row, col,
+                    spansMatrix[i][1], spansMatrix[i][2]);
+            mSpanIds.add(mWidgets[i].stringId);
+        }
+    }
+
+    /**
+     * Arrange the widgets in the constraint_referenced_ids
+     */
+    private void arrangeWidgets() {
+        int position;
+
+        // @TODO handle RTL
+        for (int i = 0; i < mWidgetsCount; i++) {
+            if (mSpanIds.contains(mWidgets[i].stringId)) {
+                // skip the widget Id that's already handled by handleSpans
+                continue;
+            }
+
+            position = getNextPosition();
+            int row = getRowByIndex(position);
+            int col = getColByIndex(position);
+            if (position == -1) {
+                // no more available position.
+                return;
+            }
+
+            connectWidget(mWidgets[i], row, col, 1, 1);
+        }
+    }
+
+    /**
+     * generate the Grid form based on the input attributes
+     *
+     * @param isUpdate whether to update the existing grid (true) or create a new one (false)
+     */
+    public void setupGrid(boolean isUpdate) {
+        if (mRows < 1 || mColumns < 1) {
+            return;
+        }
+
+        if (isUpdate) {
+            for (int i = 0; i < mPositionMatrix.length; i++) {
+                for (int j = 0; j < mPositionMatrix[0].length; j++) {
+                    mPositionMatrix[i][j] = true;
+                }
+            }
+            mSpanIds.clear();
+        }
+
+        mNextAvailableIndex = 0;
+        createBoxes();
+
+        if (mStrSkips != null && !mStrSkips.trim().isEmpty()) {
+            int[][] mSkips = parseSpans(mStrSkips);
+            if (mSkips != null) {
+                handleSkips(mSkips);
+            }
+        }
+
+        if (mStrSpans != null && !mStrSpans.trim().isEmpty()) {
+            int[][] mSpans = parseSpans(mStrSpans);
+            if (mSpans != null) {
+                handleSpans(mSpans);
+            }
+        }
+    }
+
+    /**
+     * Convert a 1D index to a 2D index that has index for row and index for column
+     *
+     * @param index index in 1D
+     * @return row as its values.
+     */
+    private int getRowByIndex(int index) {
+        if (mOrientation == 1) {
+            return index % mRows;
+
+        } else {
+            return index / mColumns;
+        }
+    }
+
+    /**
+     * Convert a 1D index to a 2D index that has index for row and index for column
+     *
+     * @param index index in 1D
+     * @return column as its values.
+     */
+    private int getColByIndex(int index) {
+        if (mOrientation == 1) {
+            return index / mRows;
+        } else {
+            return index % mColumns;
+        }
+    }
+
+    /**
+     * Make positions in the grid unavailable based on the skips attr
+     *
+     * @param skipsMatrix a int matrix that contains skip information
+     */
+    private void handleSkips(int[][] skipsMatrix) {
+        for (int[] matrix : skipsMatrix) {
+            int row = getRowByIndex(matrix[0]);
+            int col = getColByIndex(matrix[0]);
+            if (!invalidatePositions(row, col,
+                    matrix[1], matrix[2])) {
+                return;
+            }
+        }
+    }
+
+    /**
+     * Make the specified positions in the grid unavailable.
+     *
+     * @param startRow the row of the staring position
+     * @param startColumn the column of the staring position
+     * @param rowSpan how many rows to span
+     * @param columnSpan how many columns to span
+     * @return true if we could properly invalidate the positions else false
+     */
+    private boolean invalidatePositions(int startRow, int startColumn,
+            int rowSpan, int columnSpan) {
+        for (int i = startRow; i < startRow + rowSpan; i++) {
+            for (int j = startColumn; j < startColumn + columnSpan; j++) {
+                if (i >= mPositionMatrix.length || j >= mPositionMatrix[0].length
+                        || !mPositionMatrix[i][j]) {
+                    // the position is already occupied.
+                    return false;
+                }
+                mPositionMatrix[i][j] = false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * parse the weights/pads in the string format into a float array
+     *
+     * @param size size of the return array
+     * @param str  weights/pads in a string format
+     * @return a float array with weights/pads values
+     */
+    private float[] parseWeights(int size, String str) {
+        if (str == null || str.trim().isEmpty()) {
+            return null;
+        }
+
+        String[] values = str.split(",");
+        if (values.length != size) {
+            return null;
+        }
+
+        float[] arr = new float[size];
+        for (int i = 0; i < arr.length; i++) {
+            arr[i] = Float.parseFloat(values[i].trim());
+        }
+        return arr;
+    }
+
+    /**
+     * Get the next available position for widget arrangement.
+     * @return int[] -> [row, column]
+     */
+    private int getNextPosition() {
+        int position = 0;
+        boolean positionFound = false;
+
+        while (!positionFound) {
+            if (mNextAvailableIndex >= mRows * mColumns) {
+                return -1;
+            }
+
+            position = mNextAvailableIndex;
+            int row = getRowByIndex(mNextAvailableIndex);
+            int col = getColByIndex(mNextAvailableIndex);
+            if (mPositionMatrix[row][col]) {
+                mPositionMatrix[row][col] = false;
+                positionFound = true;
+            }
+
+            mNextAvailableIndex++;
+        }
+        return position;
+    }
+
+    /**
+     * Compute the actual rows and columns given what was set
+     * if 0,0 find the most square rows and columns that fits
+     * if 0,n or n,0 scale to fit
+     */
+    private void updateActualRowsAndColumns() {
+        if (mRowsSet == 0 || mColumnsSet == 0) {
+            if (mColumnsSet > 0) {
+                mColumns = mColumnsSet;
+                mRows = (mWidgetsCount + mColumns - 1) / mColumnsSet; // round up
+            } else  if (mRowsSet > 0) {
+                mRows = mRowsSet;
+                mColumns = (mWidgetsCount + mRowsSet - 1) / mRowsSet; // round up
+            } else { // as close to square as possible favoring more rows
+                mRows = (int)  (1.5 + Math.sqrt(mWidgetsCount));
+                mColumns = (mWidgetsCount + mRows - 1) / mRows;
+            }
+        } else {
+            mRows = mRowsSet;
+            mColumns = mColumnsSet;
+        }
+    }
+
+    /**
+     * Create a new boxWidget for constraining widgets
+     * @return the created boxWidget
+     */
+    private ConstraintWidget makeNewWidget() {
+        ConstraintWidget widget = new ConstraintWidget();
+        widget.mListDimensionBehaviors[HORIZONTAL] = MATCH_CONSTRAINT;
+        widget.mListDimensionBehaviors[VERTICAL] = MATCH_CONSTRAINT;
+        widget.stringId = String.valueOf(widget.hashCode());
+        return widget;
+    }
+
+    /**
+     * Connect the widget to the corresponding widgetBoxes based on the input params
+     *
+     * @param widget the widget that we want to add constraints to
+     * @param row    row position to place the widget
+     * @param column column position to place the widget
+     */
+    private void connectWidget(ConstraintWidget widget, int row, int column,
+            int rowSpan, int columnSpan) {
+        // Connect the 4 sides
+        widget.mLeft.connect(mBoxWidgets[column].mLeft, 0);
+        widget.mTop.connect(mBoxWidgets[row].mTop, 0);
+        widget.mRight.connect(mBoxWidgets[column + columnSpan - 1].mRight, 0);
+        widget.mBottom.connect(mBoxWidgets[row + rowSpan - 1].mBottom, 0);
+    }
+
+    /**
+     * Set chain between boxWidget horizontally
+     */
+    private void setBoxWidgetHorizontalChains() {
+        int maxVal = Math.max(mRows, mColumns);
+
+        ConstraintWidget widget = mBoxWidgets[0];
+        float[] columnWeights = parseWeights(mColumns, mStrColumnWeights);
+        // chain all the widgets on the longer side (either horizontal or vertical)
+        if (mColumns == 1) {
+            clearHorizontalAttributes(widget);
+            widget.mLeft.connect(mLeft, 0);
+            widget.mRight.connect(mRight, 0);
+            return;
+        }
+
+        //  chains are grid <- box <-> box <-> box -> grid
+        for (int i = 0; i < mColumns; i++) {
+            widget = mBoxWidgets[i];
+            clearHorizontalAttributes(widget);
+            if (columnWeights != null) {
+                widget.setHorizontalWeight(columnWeights[i]);
+            }
+            if (i > 0) {
+                widget.mLeft.connect(mBoxWidgets[i - 1].mRight, 0);
+            } else {
+                widget.mLeft.connect(mLeft, 0);
+            }
+            if (i < mColumns - 1) {
+                widget.mRight.connect(mBoxWidgets[i + 1].mLeft, 0);
+            } else {
+                widget.mRight.connect(mRight, 0);
+            }
+            if (i > 0) {
+                widget.mLeft.mMargin = (int) mHorizontalGaps;
+            }
+        }
+        // excess boxes are connected to grid those sides are not use
+        // for efficiency they should be connected to parent
+        for (int i = mColumns; i < maxVal; i++) {
+            widget = mBoxWidgets[i];
+            clearHorizontalAttributes(widget);
+            widget.mLeft.connect(mLeft, 0);
+            widget.mRight.connect(mRight, 0);
+        }
+    }
+
+    /**
+     * Set chain between boxWidget vertically
+     */
+    private void setBoxWidgetVerticalChains() {
+        int maxVal = Math.max(mRows, mColumns);
+
+        ConstraintWidget widget = mBoxWidgets[0];
+        float[] rowWeights = parseWeights(mRows, mStrRowWeights);
+        // chain all the widgets on the longer side (either horizontal or vertical)
+        if (mRows == 1) {
+            clearVerticalAttributes(widget);
+            widget.mTop.connect(mTop, 0);
+            widget.mBottom.connect(mBottom, 0);
+            return;
+        }
+
+        // chains are constrained like this: grid <- box <-> box <-> box -> grid
+        for (int i = 0; i < mRows; i++) {
+            widget = mBoxWidgets[i];
+            clearVerticalAttributes(widget);
+            if (rowWeights != null) {
+                widget.setVerticalWeight(rowWeights[i]);
+            }
+            if (i > 0) {
+                widget.mTop.connect(mBoxWidgets[i - 1].mBottom, 0);
+            } else {
+                widget.mTop.connect(mTop, 0);
+            }
+            if (i < mRows - 1) {
+                widget.mBottom.connect(mBoxWidgets[i + 1].mTop, 0);
+            } else {
+                widget.mBottom.connect(mBottom, 0);
+            }
+            if (i > 0) {
+                widget.mTop.mMargin = (int) mVerticalGaps;
+            }
+        }
+
+        // excess boxes are connected to grid those sides are not use
+        // for efficiency they should be connected to parent
+        for (int i = mRows; i < maxVal; i++) {
+            widget = mBoxWidgets[i];
+            clearVerticalAttributes(widget);
+            widget.mTop.connect(mTop, 0);
+            widget.mBottom.connect(mBottom, 0);
+        }
+    }
+
+    /**
+     * Chains the boxWidgets and add constraints to the widgets
+     */
+    public void addConstraints() {
+        setBoxWidgetVerticalChains();
+        setBoxWidgetHorizontalChains();
+        arrangeWidgets();
+    }
+
+    /**
+     * Create all the boxWidgets that will be used to constrain widgets
+     */
+    public void createBoxes() {
+        int boxCount = Math.max(mRows, mColumns);
+        if (mBoxWidgets == null) { // no box widgets build all
+            mBoxWidgets = new ConstraintWidget[boxCount];
+            for (int i = 0; i < mBoxWidgets.length; i++) {
+                mBoxWidgets[i] = makeNewWidget(); // need to remove old Widgets
+            }
+        } else {
+            if (boxCount != mBoxWidgets.length) {
+                ConstraintWidget[] temp = new ConstraintWidget[boxCount];
+                for (int i = 0; i < boxCount; i++) {
+                    if (i < mBoxWidgets.length) { // use old one
+                        temp[i] = mBoxWidgets[i];
+                    } else { // make new one
+                        temp[i] = makeNewWidget();
+                    }
+                }
+                // remove excess
+                for (int j = boxCount; j < mBoxWidgets.length; j++) {
+                    ConstraintWidget widget = mBoxWidgets[j];
+                    mContainer.remove(widget);
+                }
+                mBoxWidgets = temp;
+            }
+        }
+    }
+
+    /**
+     * Clear the vertical related attributes
+     * @param widget widget that has the attributes to be cleared
+     */
+    private void clearVerticalAttributes(ConstraintWidget widget) {
+        widget.setVerticalWeight(UNKNOWN);
+        widget.mTop.reset();
+        widget.mBottom.reset();
+        widget.mBaseline.reset();
+    }
+
+    /**
+     * Clear the horizontal related attributes
+     * @param widget widget that has the attributes to be cleared
+     */
+    private void clearHorizontalAttributes(ConstraintWidget widget) {
+        widget.setHorizontalWeight(UNKNOWN);
+        widget.mLeft.reset();
+        widget.mRight.reset();
+    }
+
+    /**
+     * Initialize the relevant variables
+     */
+    private void initVariables() {
+        mPositionMatrix = new boolean[mRows][mColumns];
+        for (boolean[] row : mPositionMatrix) {
+            Arrays.fill(row, true);
+        }
+
+        if (mWidgetsCount > 0) {
+            mConstraintMatrix = new int[mWidgetsCount][4];
+            for (int[] row : mConstraintMatrix) {
+                Arrays.fill(row, -1);
+            }
+        }
+    }
+
+    /**
+     * parse the skips/spans in the string format into a int matrix
+     * that each row has the information - [index, row_span, col_span]
+     * the format of the input string is index:row_spanxcol_span.
+     * index - the index of the starting position
+     * row_span - the number of rows to span
+     * col_span- the number of columns to span
+     *
+     * @param str string format of skips or spans
+     * @return a int matrix that contains skip information.
+     */
+    private int[][] parseSpans(String str) {
+        try {
+            String[] spans = str.split(",");
+            int[][] spanMatrix = new int[spans.length][3];
+
+            String[] indexAndSpan;
+            String[] rowAndCol;
+            for (int i = 0; i < spans.length; i++) {
+                indexAndSpan = spans[i].trim().split(":");
+                rowAndCol = indexAndSpan[1].split("x");
+                spanMatrix[i][0] = Integer.parseInt(indexAndSpan[0]);
+                spanMatrix[i][1] = Integer.parseInt(rowAndCol[0]);
+                spanMatrix[i][2] = Integer.parseInt(rowAndCol[1]);
+            }
+            return spanMatrix;
+        } catch (Exception e) {
+            return null;
+        }
+
+    }
+
+    /**
+     * fill the constraintMatrix based on the input attributes
+     *
+     * @param isUpdate whether to update the existing grid (true) or create a new one (false)
+     */
+    private void fillConstraintMatrix(boolean isUpdate) {
+        if (isUpdate) {
+            for (int i = 0; i < mPositionMatrix.length; i++) {
+                for (int j = 0; j < mPositionMatrix[0].length; j++) {
+                    mPositionMatrix[i][j] = true;
+                }
+            }
+
+            for (int i = 0; i < mConstraintMatrix.length; i++) {
+                for (int j = 0; j < mConstraintMatrix[0].length; j++) {
+                    mConstraintMatrix[i][j] = -1;
+                }
+            }
+        }
+
+        mNextAvailableIndex = 0;
+
+        if (mStrSkips != null && !mStrSkips.trim().isEmpty()) {
+            int[][] mSkips = parseSpans(mStrSkips);
+            if (mSkips != null) {
+                handleSkips(mSkips);
+            }
+        }
+
+        if (mStrSpans != null && !mStrSpans.trim().isEmpty()) {
+            int[][] mSpans = parseSpans(mStrSpans);
+            if (mSpans != null) {
+                handleSpans(mSpans);
+            }
+        }
+    }
+
+    /**
+     * Set up the Grid engine.
+     */
+    public void initMatrices() {
+        boolean isUpdate = mConstraintMatrix != null
+                && mConstraintMatrix.length == mWidgetsCount
+                && mPositionMatrix != null
+                && mPositionMatrix.length == mRows
+                && mPositionMatrix[0].length == mColumns;
+
+        if (!isUpdate) {
+            initVariables();
+        }
+
+        fillConstraintMatrix(isUpdate);
+    }
+
+
+    @Override
+    public void measure(int widthMode, int widthSize, int heightMode, int heightSize) {
+        super.measure(widthMode, widthSize, heightMode, heightSize);
+        mContainer = (ConstraintWidgetContainer) getParent();
+        setupGrid(false);
+        mContainer.add(mBoxWidgets);
+    }
+
+    @Override
+    public void addToSolver(LinearSystem system, boolean optimize) {
+        super.addToSolver(system, optimize);
+        addConstraints();
+    }
+}

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/GridDemo.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/GridDemo.kt
@@ -1,0 +1,370 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.constraintlayout
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.constraintlayout.compose.*
+
+
+// test adding constraints to parent
+@Preview(group = "grid")
+@Composable
+fun GridDemo1() {
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            grid: { 
+                height: "parent",
+                width: "parent",
+                type: "Grid",
+                margin: 20,
+                orientation: 0,
+                vGap: 25,
+                hGap: 25,
+                rows: 5,
+                columns: 3,
+                spans: "0:1x3",
+                skips: "12:1x1",
+                rowWeights: "3,2,2,2,2",
+                contains: ["box", "btn1", "btn2", "btn3",
+                  "btn4", "btn5", "btn6", "btn7", "btn8", "btn9","btn0"],
+                top: ["parent", "top", 20],
+                bottom: ["parent", "bottom", 20],
+                right: ["parent", "right", 20],
+                left: ["parent", "left", 20],
+              },
+             btn1: {
+              height: "spread",
+              width: "spread",
+             },
+             btn2: {
+              height: "spread",
+              width: "spread",
+             },
+             btn3: {
+              height: "spread",
+              width: "spread",
+             },
+             btn4: {
+              height: "spread",
+              width: "spread",
+             },
+             btn5: {
+              height: "spread",
+              width: "spread",
+             },
+             btn6: {
+              height: "spread",
+              width: "spread",
+             },
+             btn7: {
+              height: "spread",
+              width: "spread",
+             },
+             btn8: {
+              height: "spread",
+              width: "spread",
+             },
+             btn9: {
+              height: "spread",
+              width: "spread",
+             },
+             btn0: {
+              height: "spread",
+              width: "spread",
+             },
+             box: {
+             height: "spread",
+              width: "spread",
+             }
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val numArray = arrayOf("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")
+        for (num in numArray) {
+            Button(
+                modifier = Modifier.layoutId(String.format("btn%s", num)),
+                onClick = {},
+            ) {
+                Text(text = num, fontSize = 45.sp)
+            }
+        }
+        Box(
+            modifier = Modifier.background(Color.Gray).layoutId("box"),
+            Alignment.BottomEnd
+        ) {
+            Text("100", fontSize = 80.sp)
+        }
+
+    }
+}
+
+@Preview(group = "grid2")
+@Composable
+fun GridDemo2() {
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            grid: { 
+                height: "parent",
+                width: "parent",
+                type: "Grid",
+                vGap: 10,
+                hGap: 10,
+                orientation: 0,
+                rows: 1,
+                contains: ["btn1", "btn2", "btn3", "btn4", "btn5"],
+              },
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val numArray = arrayOf("1", "2", "3", "4", "5")
+        for (num in numArray) {
+            Button(
+                modifier = Modifier.layoutId(String.format("btn%s", num)),
+                onClick = {},
+            ) {
+                Text(text = num, fontSize = 35.sp)
+            }
+        }
+    }
+}
+
+@Preview(group = "grid3")
+@Composable
+fun GridDemo3() {
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            grid: { 
+                height: "parent",
+                width: "parent",
+                type: "Grid",
+                vGap: 10,
+                hGap: 10,
+                orientation: 0,
+                columns: 1,
+                contains: ["btn1", "btn2", "btn3", "btn4", "btn5"],
+              },
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val numArray = arrayOf("1", "2", "3", "4", "5")
+        for (num in numArray) {
+            Button(
+                modifier = Modifier.layoutId(String.format("btn%s", num)).width(120.dp),
+                onClick = {},
+            ) {
+                Text(text = num, fontSize = 35.sp)
+            }
+        }
+    }
+}
+
+@Preview(group = "grid4")
+@Composable
+fun GridDemo4() {
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            grid: { 
+                height: "parent",
+                width: "parent",
+                type: "Grid",
+                vGap: 10,
+                hGap: 10,
+                orientation: 0,
+                rows: 1,
+                contains: ["btn1", "btn2", "grid2", "btn3"],
+              },
+              grid2: { 
+                height: "spread",
+                width: "spread",
+                vGap: 10,
+                hGap: 10,
+                type: "Grid",
+                orientation: 1,
+                columns: 1,
+                contains: ["btn4", "grid3", "btn5"],
+              },
+              grid3: { 
+                height: "spread",
+                width: "spread",
+                vGap: 10,
+                hGap: 10,
+                type: "Grid",
+                orientation:0,
+                rows: 1,
+                contains: ["btn6", "btn7"],
+              },
+             btn1: {
+              height: "spread",
+              width: "spread",
+             },
+             btn2: {
+              height: "spread",
+              width: "spread",
+             },
+             btn3: {
+              height: "spread",
+              width: "spread",
+             },
+             btn4: {
+              height: "spread",
+              width: "spread",
+             },
+             btn5: {
+              height: "spread",
+              width: "spread",
+             },
+             btn6: {
+              height: "spread",
+              width: "spread",
+             },
+             btn7: {
+              height: "spread",
+              width: "spread",
+             }
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val numArray = arrayOf("btn1", "btn2", "btn3", "btn4", "btn5", "btn6", "btn7")
+        for (num in numArray) {
+            Button(
+                modifier = Modifier.layoutId(num),
+                onClick = {},
+            ) {
+                Text(text = num)
+            }
+        }
+    }
+}
+
+@Preview(group = "grid5")
+@Composable
+fun GridDemo5() {
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            grid: { 
+                height: "parent",
+                width: "parent",
+                type: "Grid",
+                vGap: 10,
+                hGap: 10,
+                orientation: 0,
+                rows: 0,
+                columns: 1,
+                columnWeights: "",
+                rowWeights: "",
+                contains: ["btn1", "btn2", "btn3", "btn4"],
+                top: ["parent", "top", 10],
+                bottom: ["parent", "bottom", 20],
+                right: ["parent", "right", 30],
+                left: ["parent", "left", 40],
+              },
+             btn1: {
+              height: "spread",
+              width: "spread",
+             },
+             btn2: {
+              height: "spread",
+              width: "spread",
+             },
+             btn3: {
+              height: "spread",
+              width: "spread",
+             },
+             btn4: {
+              height: "spread",
+              width: "spread",
+             }
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val numArray = arrayOf("1", "2", "3", "4")
+        for (num in numArray) {
+            Button(
+                modifier = Modifier.layoutId(String.format("btn%s", num)).width(120.dp),
+                onClick = {},
+            ) {
+                Text(text = num, fontSize = 35.sp)
+            }
+        }
+    }
+}
+
+@Preview(group = "grid6")
+@Composable
+fun GridDemo6() {
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            grid: { 
+                height: "parent",
+                width: "parent",
+                type: "Grid",
+                orientation: 0,
+                skips: "1:1x1,4:1x1,6:1x1",
+                rows: 3,
+                columns: 3,
+                contains: ["grid2", "btn1", "btn2", "btn3", "btn4"],
+              },
+              grid2: { 
+                height: "spread",
+                width: "spread",
+                type: "Grid",
+                skips: "0:1x2,4:1x1,6:1x1",
+                orientation: 0,
+                rows: 3,
+                columns: 3,
+                contains: ["btn5", "btn6", "btn7", "btn8"],     
+              },
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val numArray = arrayOf("1", "2", "3", "4", "5", "6", "7", "8")
+        for (num in numArray) {
+            Button(
+                modifier = Modifier.layoutId(String.format("btn%s", num)).width(50.dp),
+                onClick = {},
+            ) {
+                Text(text = num, fontSize = 20.sp)
+            }
+        }
+    }
+}

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/GridTestDemo.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/GridTestDemo.kt
@@ -1,0 +1,381 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.constraintlayout
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.ConstraintSet
+
+@Preview(group = "testTwoByTwo")
+@Composable
+fun testTwoByTwoDemo() {
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            grid: { 
+                width: 200,
+                height: 200,
+                type: "Grid",
+                boxesCount: 4,
+                orientation: 0,
+                rows: 2,
+                columns: 2,
+                hGap: 0,
+                vGap: 0,
+                spans: "",
+                skips: "",
+                rowWeights: "",
+                columnWeights: "",
+                contains: ["box1", "box2", "box3", "box4"],
+              },
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val numArray = arrayOf("box1", "box2", "box3", "box4")
+        for (num in numArray) {
+            Box(
+                Modifier
+                    .layoutId(num)
+                    .size(30.dp)
+                    .background(Color.Red)
+                    .testTag(num)
+            )
+        }
+    }
+}
+
+@Preview(group = "testOrientation")
+@Composable
+fun testOrientationDemo() {
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            grid: { 
+                width: 200,
+                height: 200,
+                type: "Grid",
+                boxesCount: 4,
+                orientation: 1,
+                rows: 2,
+                columns: 2,
+                hGap: 0,
+                vGap: 0,
+                spans: "",
+                skips: "",
+                rowWeights: "",
+                columnWeights: "",
+                contains: ["box1", "box2", "box3", "box4"],
+              },
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val numArray = arrayOf("box1", "box2", "box3", "box4")
+        for (num in numArray) {
+            Box(
+                Modifier
+                    .layoutId(num)
+                    .size(30.dp)
+                    .background(Color.Red)
+                    .testTag(num)
+            )
+        }
+    }
+}
+
+@Preview(group = "testRows")
+@Composable
+fun testRowsDemo() {
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            grid: { 
+                width: 200,
+                height: 200,
+                type: "Grid",
+                boxesCount: 4,
+                orientation: 0,
+                rows: 0,
+                columns: 1,
+                hGap: 0,
+                vGap: 0,
+                spans: "",
+                skips: "",
+                rowWeights: "",
+                columnWeights: "",
+                contains: ["box1", "box2", "box3", "box4"],
+              },
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val numArray = arrayOf("box1", "box2", "box3", "box4")
+        for (num in numArray) {
+            Box(
+                Modifier
+                    .layoutId(num)
+                    .size(30.dp)
+                    .background(Color.Red)
+                    .testTag(num)
+            )
+        }
+    }
+}
+
+@Preview(group = "testColumns")
+@Composable
+fun testColumnsDemo() {
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            grid: { 
+                width: 200,
+                height: 200,
+                type: "Grid",
+                boxesCount: 4,
+                orientation: 0,
+                rows: 1,
+                columns: 0,
+                hGap: 0,
+                vGap: 0,
+                spans: "",
+                skips: "",
+                rowWeights: "",
+                columnWeights: "",
+                contains: ["box1", "box2", "box3", "box4"],
+              },
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val numArray = arrayOf("box1", "box2", "box3", "box4")
+        for (num in numArray) {
+            Box(
+                Modifier
+                    .layoutId(num)
+                    .size(30.dp)
+                    .background(Color.Red)
+                    .testTag(num)
+            )
+        }
+    }
+}
+
+@Preview(group = "testSpans")
+@Composable
+fun testSpansDemo() {
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            grid: { 
+                height: 200,
+                width: 200,
+                type: "Grid",
+                orientation: 0,
+                rows: 2,
+                columns: 2,
+                skips: "",
+                spans: "0:1x2",
+                rowWeights: "",
+                columnWeights: "",
+                contains: ["box1", "box2", "box3",],
+              },
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val numArray = arrayOf("box1", "box2", "box3")
+        for (num in numArray) {
+            Box(
+                Modifier
+                    .layoutId(num)
+                    .size(30.dp)
+                    .background(Color.Red)
+                    .testTag(num)
+            )
+        }
+    }
+}
+
+@Preview(group = "testSkips")
+@Composable
+fun testSkipsDemo() {
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            grid: { 
+                height: 200,
+                width: 200,
+                type: "Grid",
+                orientation: 0,
+                rows: 2,
+                columns: 2,
+                skips: "0:1x1",
+                spans: "",
+                rowWeights: "",
+                columnWeights: "",
+                contains: ["box1", "box2", "box3",],
+              },
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val numArray = arrayOf("box1", "box2", "box3")
+        for (num in numArray) {
+            Box(
+                Modifier
+                    .layoutId(num)
+                    .size(30.dp)
+                    .background(Color.Red)
+                    .testTag(num)
+            )
+        }
+    }
+}
+
+@Preview(group = "testRowWeights")
+@Composable
+fun testRowWeightsDemo() {
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            grid: { 
+                height: 200,
+                width: 200,
+                type: "Grid",
+                orientation: 0,
+                rows: 0,
+                columns: 1,
+                vGap: 0,
+                hGap: 0,
+                skips: "",
+                spans: "",
+                rowWeights: "1,3",
+                columnWeights: "",
+                contains: ["box1", "box2"],
+              },
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val numArray = arrayOf("box1", "box2")
+        for (num in numArray) {
+            Box(
+                Modifier
+                    .layoutId(num)
+                    .size(30.dp)
+                    .background(Color.Red)
+                    .testTag(num)
+            )
+        }
+    }
+}
+
+@Preview(group = "testColumnWeights")
+@Composable
+fun testColumnWeightsDemo() {
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            grid: { 
+                height: 200,
+                width: 200,
+                type: "Grid",
+                orientation: 0,
+                rows: 1,
+                columns: 0,
+                vGap: 0,
+                hGap: 0,
+                skips: "",
+                spans: "",
+                rowWeights: "",
+                columnWeights: "1,3",
+                contains: ["box1", "box2"],
+              },
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val numArray = arrayOf("box1", "box2")
+        for (num in numArray) {
+            Box(
+                Modifier
+                    .layoutId(num)
+                    .size(30.dp)
+                    .background(Color.Red)
+                    .testTag(num)
+            )
+        }
+    }
+}
+
+@Preview(group = "testGaps")
+@Composable
+fun testGapsDemo() {
+    val density = LocalDensity.current
+    // convert dp to px
+    val vGapPx = with(density) { 20.dp.toPx() }
+    val hGapPx = with(density) { 10.dp.toPx() }
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            grid: { 
+                height: 200,
+                width: 200,
+                type: "Grid",
+                orientation: 0,
+                rows: 2,
+                columns: 2,
+                vGap: $vGapPx,
+                hGap: $hGapPx,
+                contains: ["box1", "box2", "box3", "box4"],
+              },
+              box1: {
+                width: 'spread',
+                height: 'spread',
+              },
+              box2: {
+                width: 'spread',
+                height: 'spread',
+              },
+              box3: {
+                width: 'spread',
+                height: 'spread',
+              },
+              box4: {
+                width: 'spread',
+                height: 'spread',
+              }
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val numArray = arrayOf("box1", "box2", "box3", "box4")
+        for (num in numArray) {
+            Box(
+                Modifier
+                    .layoutId(num)
+                    .size(30.dp)
+                    .background(Color.Red)
+                    .testTag(num)
+            )
+        }
+    }
+}

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/MotionGridDemo.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/MotionGridDemo.kt
@@ -1,0 +1,280 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.constraintlayout
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.constraintlayout.compose.MotionLayout
+import androidx.constraintlayout.compose.MotionScene
+
+
+@Preview(group = "grid1")
+@Composable
+public fun MotionGridDemo() {
+    var animateToEnd by remember { mutableStateOf(false) }
+
+    val progress = remember { Animatable(0f) }
+
+    LaunchedEffect(animateToEnd) {
+        progress.animateTo(if (animateToEnd) 1f else 0f,
+            animationSpec = tween(3000))
+    }
+
+    Column(modifier = Modifier.background(Color.White)) {
+
+        val scene1 = MotionScene("""
+            {
+                Header: {
+                  name: 'splitDemo1'
+                },
+                
+                ConstraintSets: {
+                  start: {
+                    split: { 
+                        height: 'parent',
+                        width: 'parent',
+                        type: 'Grid',
+                        orientation: 0,
+                        vGap: 10,
+                        hGap: 15,
+                        rows: 2,
+                        columns: 3,
+                        contains: ["btn1", "btn2", "btn3", "btn4", "btn5", "btn6"],
+                      },
+                  },
+                  
+                  end: {
+                    split: { 
+                        height: 'parent',
+                        width: 'parent',
+                        type: 'Grid',
+                        orientation: 1,
+                        rows: 3,
+                        columns: 2,
+                        contains: ["btn1", "btn2", "btn3", "btn4", "btn5", "btn6"],
+                      },
+                  }
+                },
+                
+                Transitions: {
+                  default: {
+                    from: 'start', to: 'end',
+                  }
+                }
+            }
+            """)
+
+        MotionLayout(
+            modifier    = Modifier
+                .fillMaxWidth()
+                .height(400.dp),
+            motionScene = scene1,
+            progress = progress.value) {
+            val numArray = arrayOf("1", "2", "3", "4", "5", "6")
+            for (num in numArray) {
+                Button(
+                    modifier = Modifier.layoutId(String.format("btn%s", num)),
+                    onClick = {},
+                ) {
+                    Text(text = num, fontSize = 35.sp)
+                }
+            }
+        }
+
+        Button(onClick = { animateToEnd = !animateToEnd },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(3.dp)) {
+            Text(text = "Run")
+        }
+    }
+}
+
+@Preview(group = "grid2")
+@Composable
+public fun MotionGridDemo2() {
+    var animateToEnd by remember { mutableStateOf(false) }
+
+    val progress = remember { Animatable(0f) }
+
+    LaunchedEffect(animateToEnd) {
+        progress.animateTo(if (animateToEnd) 1f else 0f,
+            animationSpec = tween(3000))
+    }
+
+    Column(modifier = Modifier.background(Color.White)) {
+
+        val scene1 = MotionScene("""
+            {
+                Header: {
+                  name: 'splitDemo1'
+                },
+                
+                ConstraintSets: {
+                  start: {
+                    split1: { 
+                        height: 'parent',
+                        width: 'parent',
+                        type: 'Grid',
+                        orientation: 0,
+                        hGap: 10,
+                        columns: 1,
+                        contains: ["btn1", "btn2", "split2", "btn3", "btn4"],
+                      },
+                      split2: { 
+                        height: 'spread',
+                        width: 'spread',
+                        type: 'Grid',
+                        orientation: 0,
+                        hGap: 15,
+                        rows: 1,
+                        contains: ["btn5", "btn6", "btn7"],
+                      },
+                      btn1: {
+                        width: "spread",
+                        height: "spread",
+                      },
+                      btn2: {
+                        width: "spread",
+                        height: "spread",
+                      },
+                      btn3: {
+                        width: "spread",
+                        height: "spread",
+                      },
+                      btn4: {
+                        width: "spread",
+                        height: "spread",
+                      },
+                      btn5: {
+                        width: "spread",
+                        height: "spread",
+                      },
+                      btn6: {
+                        width: "spread",
+                        height: "spread",
+                      },
+                      btn7: {
+                        width: "spread",
+                        height: "spread",
+                      }
+                  },
+                  
+                  end: {
+                    split1: { 
+                        height: 'parent',
+                        width: 'parent',
+                        type: 'Grid',
+                        orientation: 0,
+                        vGap: 10,
+                        hGap: 15,
+                        rows: 1,
+                        contains: ["btn1", "btn2", "split2", "btn3", "btn4"],
+                      },
+                      split2: { 
+                        height: 'spread',
+                        width: 'spread',
+                        type: 'Grid',
+                        orientation: 0,
+                        hGap: 15,
+                        columns: 1,
+                        contains: ["btn5", "btn6", "btn7"],
+                      },
+                      btn1: {
+                        width: "spread",
+                        height: "spread",
+                      },
+                      btn2: {
+                        width: "spread",
+                        height: "spread",
+                      },
+                      btn3: {
+                        width: "spread",
+                        height: "spread",
+                      },
+                      btn4: {
+                        width: "spread",
+                        height: "spread",
+                      },
+                      btn5: {
+                        width: "spread",
+                        height: "spread",
+                      },
+                      btn6: {
+                        width: "spread",
+                        height: "spread",
+                      },
+                      btn7: {
+                        width: "spread",
+                        height: "spread",
+                      }
+                  }
+                },
+                
+                Transitions: {
+                  default: {
+                    from: 'start', to: 'end',
+                  }
+                }
+            }
+            """)
+
+        MotionLayout(
+            modifier    = Modifier
+                .fillMaxWidth()
+                .height(400.dp),
+            motionScene = scene1,
+            progress = progress.value) {
+            val numArray = arrayOf("1", "2", "3", "4", "5", "6", "7")
+            for (num in numArray) {
+                Button(
+                    modifier = Modifier.layoutId(String.format("btn%s", num)),
+                    colors = ButtonDefaults.buttonColors(
+                        backgroundColor = Color.Gray.copy(
+                            alpha = 0.1F,
+                        ),
+                    ),
+                    onClick = {},
+                ) {
+                    Text(text = num, fontSize = 35.sp)
+                }
+            }
+        }
+
+        Button(onClick = { animateToEnd = !animateToEnd },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(3.dp)) {
+            Text(text = "Run")
+        }
+    }
+}

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/MotionGridTestDemo.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/MotionGridTestDemo.kt
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.constraintlayout
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.constraintlayout.compose.MotionLayout
+import androidx.constraintlayout.compose.MotionScene
+
+
+@Preview(group = "rowToColumnGrid")
+@Composable
+public fun rowToColumnGridDemo() {
+    var animateToEnd by remember { mutableStateOf(false) }
+
+    val progress = remember { Animatable(0f) }
+
+    LaunchedEffect(animateToEnd) {
+        progress.animateTo(if (animateToEnd) 1f else 0f,
+            animationSpec = tween(3000))
+    }
+
+    Column(modifier = Modifier.background(Color.White)) {
+
+        val scene1 = MotionScene("""
+            {
+                ConstraintSets: {
+                  start: {
+                    grid1: { 
+                        width: 200,
+                        height: 200,
+                        type: "Grid",
+                        orientation: 0,
+                        rows: 0,
+                        columns: 1,
+                        hGap: 0,
+                        vGap: 0,
+                        spans: "",
+                        skips: "",
+                        rowWeights: "",
+                        columnWeights: "",
+                        contains: ["box1", "box2", "box3", "box4"],
+                      }
+                  },
+                  end: {
+                    grid2: { 
+                        width: 200,
+                        height: 200,
+                        type: "Grid",
+                        orientation: 0,
+                        rows: 1,
+                        columns: 0,
+                        hGap: 0,
+                        vGap: 0,
+                        spans: "",
+                        skips: "",
+                        rowWeights: "",
+                        columnWeights: "",
+                        contains: ["box1", "box2", "box3", "box4"],
+                      }
+                  }
+                },
+                Transitions: {
+                  default: {
+                    from: 'start', to: 'end',
+                  }
+                }
+            }
+            """)
+
+        MotionLayout(
+            modifier    = Modifier
+                .fillMaxWidth()
+                .height(400.dp),
+            motionScene = scene1,
+            progress = progress.value) {
+            val numArray = arrayOf("box1", "box2", "box3", "box4")
+            for (num in numArray) {
+                Box(
+                    modifier = Modifier
+                        .size(10.dp)
+                        .layoutId(num)
+                        .testTag(num)
+                        .background(Color.Red)
+                )
+            }
+        }
+
+        Button(onClick = { animateToEnd = !animateToEnd },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(3.dp)) {
+            Text(text = "Run")
+        }
+    }
+}
+
+@Preview(group = "wrapToSpreadGrid")
+@Composable
+public fun wrapToSpreadGridDemo() {
+    var animateToEnd by remember { mutableStateOf(false) }
+
+    val progress = remember { Animatable(0f) }
+    val hGapVal = 10
+    val vGapVal = 20
+
+    LaunchedEffect(animateToEnd) {
+        progress.animateTo(if (animateToEnd) 1f else 0f,
+            animationSpec = tween(3000))
+    }
+
+    Column(modifier = Modifier.background(Color.White)) {
+
+        val scene1 = MotionScene("""
+            {
+                ConstraintSets: {
+                  start: {
+                    grid1: { 
+                        width: 200,
+                        height: 200,
+                        type: "Grid",
+                        orientation: 0,
+                        rows: 2,
+                        columns: 2,
+                        hGap: 0,
+                        vGap: 0,
+                        spans: "",
+                        skips: "",
+                        rowWeights: "",
+                        columnWeights: "",
+                        contains: ["box1", "box2", "box3", "box4"],
+                      }
+                  },
+                  end: {
+                    grid2: { 
+                        width: 200,
+                        height: 200,
+                        type: "Grid",
+                        orientation: 0,
+                        rows: 2,
+                        columns: 2,
+                        hGap: $hGapVal,
+                        vGap: $vGapVal,
+                        spans: "",
+                        skips: "",
+                        rowWeights: "",
+                        columnWeights: "",
+                        contains: ["box1", "box2", "box3", "box4"],
+                      },
+                      box1: {
+                        width: 'spread',
+                        height: 'spread',
+                      },
+                      box2: {
+                        width: 'spread',
+                        height: 'spread',
+                      },
+                      box3: {
+                        width: 'spread',
+                        height: 'spread',
+                      },
+                      box4: {
+                        width: 'spread',
+                        height: 'spread',
+                      }
+                  }
+                },
+                Transitions: {
+                  default: {
+                    from: 'start', to: 'end',
+                  }
+                }
+            }
+            """)
+
+        MotionLayout(
+            modifier    = Modifier
+                .fillMaxWidth()
+                .height(400.dp),
+            motionScene = scene1,
+            progress = progress.value) {
+            val numArray = arrayOf("box1", "box2", "box3", "box4")
+            for (num in numArray) {
+                Box(
+                    modifier = Modifier
+                        .size(10.dp)
+                        .layoutId(num)
+                        .testTag(num)
+                        .background(Color.Red)
+                )
+            }
+        }
+
+        Button(onClick = { animateToEnd = !animateToEnd },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(3.dp)) {
+            Text(text = "Run")
+        }
+    }
+}


### PR DESCRIPTION
### Enable the Grid Helper in Compose using JSON representation.

- Moves the whole logic of Grid to core (**GridCore.java**)
- Adds a reference object for Grid (**GridReference.kt**)
- Updates **Stata.java** and **ConstraintSetParser.java** to parse Grid helper and create a reference object proper.
- Adds ConstraintLayout and MotionLayout demos (**GridDemo.kt**, **MotionGridDemo.kt**)
- Adds tests with ConstraintLayout and MotionLayout (**GridTest.kt**, **MotionGridTest.kt**)
- Adds corresponding demos for the tests to better visualize the tests (**GridTestDemo.kt**, **MotionGridDemo.kt**) 

Todo: Test setters when working on DSL.

Sample Demos:
GridDemo1:
![image](https://user-images.githubusercontent.com/20599348/204392435-d643c4cf-8b92-40f0-bcc3-f4b54c5b6798.png)


GridDemo6
![image](https://user-images.githubusercontent.com/20599348/204392341-2062ea33-526c-44ee-b989-919e463beb08.png)

Sample Motions:
MotionGridDemo
![Screen Recording 2022-11-28 at 2 17 44 PM](https://user-images.githubusercontent.com/20599348/204393230-473063b8-f0c9-4b68-8fa1-9a1d4f58aa66.gif)

MotionGridDemo2
![Screen Recording 2022-11-28 at 2 18 55 PM](https://user-images.githubusercontent.com/20599348/204393247-7d071c8e-937c-46f3-b971-a6c96e44ea0b.gif)

