### PR TITLE
[Grid] Add Row and Column Type for GridReference

### DIFF
--- a/constraintlayout/.idea/androidTestResultsUserPreferences.xml
+++ b/constraintlayout/.idea/androidTestResultsUserPreferences.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidTestResultsUserPreferences">
+    <option name="androidTestResultsTableState">
+      <map>
+        <entry key="-508597275">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Copy_of_Pixel_3_API_30" value="120" />
+                  <entry key="Duration" value="90" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/RowColumnTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/RowColumnTest.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.compose
+
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.platform.isDebugInspectorInfoEnabled
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertPositionInRootIsEqualTo
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@MediumTest
+@RunWith(AndroidJUnit4::class)
+class RowColumnTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Before
+    fun setup() {
+        isDebugInspectorInfoEnabled = true
+    }
+
+    @After
+    fun tearDown() {
+        isDebugInspectorInfoEnabled = false
+    }
+
+    @Test
+    fun testRows() {
+        val rootSize = 200.dp
+        val boxesCount = 4
+        val rows = 0
+        val columns = 1
+        rule.setContent {
+            RowColumnComposableTest(
+                modifier = Modifier.size(rootSize),
+                type = "'Row'",
+                width = "'parent'",
+                height = "'parent'",
+                boxesCount = boxesCount,
+                orientation = 0,
+                hGap = 0,
+                vGap = 0,
+                spans = "''",
+                skips = "''",
+                rowWeights = "''",
+                columnWeights = "''"
+            )
+        }
+        var expectedX = 0.dp
+        var expectedY = 0.dp
+
+        // 10.dp is the size of a singular box
+        val hGapSize = (rootSize - 10.dp) / 2f
+        val vGapSize = (rootSize - (10.dp * 4f)) / (boxesCount * 2f)
+        rule.waitForIdle()
+        expectedX += hGapSize
+        expectedY += vGapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp;
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX , expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp;
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp;
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
+    }
+
+    @Test
+    fun testColumns() {
+        val rootSize = 200.dp
+        val boxesCount = 4
+        val rows = 1
+        val columns = 0
+        rule.setContent {
+            RowColumnComposableTest(
+                modifier = Modifier.size(rootSize),
+                type = "'Column'",
+                width = "'parent'",
+                height = "'parent'",
+                boxesCount = boxesCount,
+                orientation = 0,
+                hGap = 0,
+                vGap = 0,
+                spans = "''",
+                skips = "''",
+                rowWeights = "''",
+                columnWeights = "''"
+            )
+        }
+        var expectedX = 0.dp
+        var expectedY = 0.dp
+
+        // 10.dp is the size of a singular box
+        val hGapSize = (rootSize - (10.dp * 4f)) / (boxesCount * 2f)
+        val vGapSize = (rootSize - 10.dp) / 2f
+        rule.waitForIdle()
+        expectedX += hGapSize
+        expectedY += vGapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp;
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX , expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp;
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp;
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
+    }
+
+    @Composable
+    private fun RowColumnComposableTest(
+        modifier: Modifier = Modifier,
+        type: String,
+        width: String,
+        height: String,
+        spans: String,
+        skips: String,
+        rowWeights: String,
+        columnWeights: String,
+        boxesCount: Int,
+        orientation: Int,
+        vGap: Int,
+        hGap: Int,
+    ) {
+        val ids = (0 until boxesCount).map { "box$it" }.toTypedArray()
+        val gridContains = ids.joinToString(separator = ", ") { "'$it'" }
+        ConstraintLayout(
+            modifier = modifier,
+            constraintSet = ConstraintSet(
+                """
+        {
+            grid: {
+                width: $width,
+                height: $height,
+                type: $type,
+                vGap: $vGap,
+                hGap: $hGap,
+                spans: $spans,
+                skips: $skips,
+                rowWeights: $rowWeights,
+                columnWeights: $columnWeights
+                orientation: $orientation,
+                contains: [$gridContains],
+              }
+        }
+        """.trimIndent()
+            )
+        ) {
+            ids.forEach { id ->
+                Box(
+                    Modifier
+                        .layoutId(id)
+                        .size(10.dp)
+                        .background(Color.Red)
+                        .testTag(id)
+                )
+            }
+        }
+    }
+}

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintSetParser.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintSetParser.java
@@ -540,7 +540,10 @@ public class ConstraintSetParser {
                                         );
                                         break;
                                     case "Grid":
-                                        parseGridType(state,
+                                    case "Row":
+                                    case "Column":
+                                        parseGridType(type,
+                                                state,
                                                 elementName,
                                                 layoutVariables,
                                                 (CLObject) element);
@@ -861,12 +864,13 @@ public class ConstraintSetParser {
         }
     }
 
-    private static void parseGridType(State state,
+    private static void parseGridType(String gridType,
+                                       State state,
                                        String name,
                                        LayoutVariables layoutVariables,
                                        CLObject element) throws CLParsingException {
 
-        GridReference grid = state.getGrid(name);
+        GridReference grid = state.getGrid(name, gridType);
 
         for (String param : element.names()) {
             switch (param) {

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/State.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/State.java
@@ -94,6 +94,8 @@ public class State {
         HORIZONTAL_FLOW,
         VERTICAL_FLOW,
         GRID,
+        ROW,
+        COLUMN,
         FLOW
     }
 
@@ -325,7 +327,9 @@ public class State {
                     reference = new FlowReference(this, type);
                 }
                 break;
-                case GRID: {
+                case GRID:
+                case ROW:
+                case COLUMN: {
                     reference = new GridReference(this, type);
                 }
                 break;
@@ -373,11 +377,17 @@ public class State {
         return (BarrierReference) reference.getFacade();
     }
 
-    public GridReference getGrid(Object key) {
+    public GridReference getGrid(Object key, String gridType) {
         ConstraintReference reference = constraints(key);
         if (reference.getFacade() == null || !(reference.getFacade() instanceof GridReference)) {
-            GridReference flowReference = new GridReference(this, Helper.GRID);
-            reference.setFacade(flowReference);
+            State.Helper Type = Helper.GRID;
+            if (gridType.charAt(0) == 'R') {
+                Type = Helper.ROW;
+            } else if (gridType.charAt(0) == 'C') {
+                Type = Helper.COLUMN;
+            }
+            GridReference gridReference = new GridReference(this, Type);
+            reference.setFacade(gridReference);
         }
         return (GridReference) reference.getFacade();
     }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/GridReference.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/GridReference.java
@@ -29,6 +29,11 @@ public class GridReference extends HelperReference {
 
     public GridReference(State state, State.Helper type) {
         super(state, type);
+        if (type == State.Helper.ROW) {
+            this.mColumnsSet = 1;
+        } else if (type == State.Helper.COLUMN) {
+            this.mRowsSet = 1;
+        }
     }
 
     /**
@@ -94,6 +99,9 @@ public class GridReference extends HelperReference {
      * @param rowsSet the number of rows
      */
     public void setRowsSet(int rowsSet) {
+        if (super.getType() == State.Helper.COLUMN) {
+            return;
+        }
         mRowsSet = rowsSet;
     }
 
@@ -110,6 +118,9 @@ public class GridReference extends HelperReference {
      * @param columnsSet the number of columns
      */
     public void setColumnsSet(int columnsSet) {
+        if (super.getType() == State.Helper.ROW) {
+            return;
+        }
         mColumnsSet = columnsSet;
     }
 

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/RowColumnDemo.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/RowColumnDemo.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.constraintlayout
+
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.sp
+import androidx.constraintlayout.compose.*
+
+@Preview(group = "row")
+@Composable
+fun RowDemo() {
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            grid: { 
+                height: "parent",
+                width: "parent",
+                type: "Row",
+                vGap: 10,
+                hGap: 10,
+                orientation: 0,
+                contains: ["btn1", "btn2", "btn3", "btn4", "btn5"],
+              },
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val numArray = arrayOf("1", "2", "3", "4", "5")
+        for (num in numArray) {
+            Button(
+                modifier = Modifier.layoutId(String.format("btn%s", num)),
+                onClick = {},
+            ) {
+                Text(text = num, fontSize = 35.sp)
+            }
+        }
+    }
+}
+
+@Preview(group = "column")
+@Composable
+fun ColumnDemo() {
+    ConstraintLayout(
+        ConstraintSet("""
+        {
+            grid: { 
+                height: "parent",
+                width: "parent",
+                type: "Column",
+                vGap: 10,
+                hGap: 10,
+                orientation: 0,
+                contains: ["btn1", "btn2", "btn3", "btn4", "btn5"],
+              },
+        }
+        """.trimIndent()),
+        modifier = Modifier.fillMaxSize()) {
+        val numArray = arrayOf("1", "2", "3", "4", "5")
+        for (num in numArray) {
+            Button(
+                modifier = Modifier.layoutId(String.format("btn%s", num)),
+                onClick = {},
+            ) {
+                Text(text = num, fontSize = 35.sp)
+            }
+        }
+    }
+}

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/RowColumnDemo.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/RowColumnDemo.kt
@@ -39,7 +39,6 @@ fun RowDemo() {
                 type: "Row",
                 vGap: 10,
                 hGap: 10,
-                orientation: 0,
                 contains: ["btn1", "btn2", "btn3", "btn4", "btn5"],
               },
         }
@@ -69,7 +68,6 @@ fun ColumnDemo() {
                 type: "Column",
                 vGap: 10,
                 hGap: 10,
-                orientation: 0,
                 contains: ["btn1", "btn2", "btn3", "btn4", "btn5"],
               },
         }


### PR DESCRIPTION
Add Row and Column type for Grid Helper to help users to create a Row or a Column Layout.

Row type
<img width="919" alt="image" src="https://user-images.githubusercontent.com/20599348/206756362-c9294b83-cc54-46a3-ab9a-4232040ef9ec.png">

Column Type
<img width="919" alt="image" src="https://user-images.githubusercontent.com/20599348/206756459-3cd9ae2b-0267-47ae-9941-b5eccf4ccf95.png">
