### PR TITLE
AndroidX Sync 01-06-2023

### DIFF
--- a/constraintlayout/build-logic/build.gradle
+++ b/constraintlayout/build-logic/build.gradle
@@ -1,4 +1,3 @@
 plugins {
     id 'groovy-gradle-plugin'
 }
-

--- a/constraintlayout/compose/build.gradle
+++ b/constraintlayout/compose/build.gradle
@@ -20,7 +20,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-
     buildFeatures {
         compose true
         buildConfig false
@@ -28,6 +27,7 @@ android {
 
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
+        freeCompilerArgs = ['-Xjvm-default=all']
     }
 
     composeOptions {

--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/ChainsTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/ChainsTest.kt
@@ -1,0 +1,463 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.assertHeightIsEqualTo
+import androidx.compose.ui.test.assertPositionInRootIsEqualTo
+import androidx.compose.ui.test.assertWidthIsEqualTo
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@MediumTest
+@RunWith(AndroidJUnit4::class)
+class ChainsTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Test
+    fun testHorizontalPacked_withConstraintSet() {
+        val rootSize = 100.dp
+        val boxSizes = arrayOf(10.dp, 20.dp, 30.dp)
+        val margin = 10.dp
+        val constraintSet = ConstraintSet {
+            val box0 = createRefFor("box0")
+            val box1 = createRefFor("box1")
+            val box2 = createRefFor("box2")
+            val chain0 = createHorizontalChain(box0, box1, chainStyle = ChainStyle.Packed)
+
+            constrain(box0) {
+                width = Dimension.value(boxSizes[0])
+                height = Dimension.value(boxSizes[0])
+                centerVerticallyTo(parent)
+            }
+            constrain(box1) {
+                width = Dimension.value(boxSizes[1])
+                height = Dimension.value(boxSizes[1])
+                centerVerticallyTo(box0)
+            }
+            constrain(box2) {
+                width = Dimension.value(boxSizes[2])
+                height = Dimension.value(boxSizes[2])
+                top.linkTo(parent.top, margin)
+                start.linkTo(parent.start, margin)
+            }
+            constrain(chain0) {
+                start.linkTo(box2.end, margin)
+            }
+        }
+        rule.setContent {
+            ConstraintLayout(
+                modifier = Modifier.size(rootSize),
+                constraintSet = constraintSet
+            ) {
+                Box(
+                    modifier = Modifier
+                        .background(Color.Red)
+                        .layoutTestId("box0")
+                )
+                Box(
+                    modifier = Modifier
+                        .background(Color.Blue)
+                        .layoutTestId("box1")
+                )
+                Box(
+                    modifier = Modifier
+                        .background(Color.Green)
+                        .layoutTestId("box2")
+                )
+            }
+        }
+        rule.waitForIdle()
+
+        val spaceForChain = rootSize - boxSizes[2] - (margin * 2)
+        val spaceAroundChain = spaceForChain - boxSizes[0] - boxSizes[1]
+        val spaceAtLeftOfChain = spaceAroundChain * 0.5f
+        val offsetFromBox2 = margin + boxSizes[2] + margin
+
+        val box0Left = offsetFromBox2 + spaceAtLeftOfChain
+        val box0Top = (rootSize - boxSizes[0]) * 0.5f
+
+        val box1Left = box0Left + boxSizes[0] + 0.5.dp // 0.5dp, compensate for a small solver error
+        val box1Top = box0Top - ((boxSizes[1] - boxSizes[0]) * 0.5f)
+
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(box0Left, box0Top)
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(box1Left, box1Top)
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(margin, margin)
+    }
+
+    @Test
+    fun testHorizontalPacked_withModifier() {
+        val rootSize = 100.dp
+        val boxSizes = arrayOf(10.dp, 20.dp, 30.dp)
+        val margin = 10.dp
+        rule.setContent {
+            ConstraintLayout(
+                Modifier
+                    .background(Color.LightGray)
+                    .size(rootSize)
+            ) {
+                val (box0, box1, box2) = createRefs()
+                val chain0 = createHorizontalChain(box0, box1, chainStyle = ChainStyle.Packed)
+                constrain(chain0) {
+                    start.linkTo(box2.end, margin)
+                }
+                Box(
+                    modifier = Modifier
+                        .background(Color.Red)
+                        .constrainAs(box0) {
+                            width = Dimension.value(boxSizes[0])
+                            height = Dimension.value(boxSizes[0])
+                            centerVerticallyTo(parent)
+                        }
+                        .layoutTestId("box0")
+                )
+                Box(
+                    modifier = Modifier
+                        .background(Color.Blue)
+                        .constrainAs(box1) {
+                            width = Dimension.value(boxSizes[1])
+                            height = Dimension.value(boxSizes[1])
+                            centerVerticallyTo(box0)
+                        }
+                        .layoutTestId("box1")
+                )
+                Box(
+                    modifier = Modifier
+                        .background(Color.Green)
+                        .constrainAs(box2) {
+                            width = Dimension.value(boxSizes[2])
+                            height = Dimension.value(boxSizes[2])
+                            top.linkTo(parent.top, margin)
+                            start.linkTo(parent.start, margin)
+                        }
+                        .layoutTestId("box2")
+                )
+            }
+        }
+        rule.waitForIdle()
+
+        val spaceForChain = rootSize - boxSizes[2] - (margin * 2)
+        val spaceAroundChain = spaceForChain - boxSizes[0] - boxSizes[1]
+        val spaceAtLeftOfChain = spaceAroundChain * 0.5f
+        val offsetFromBox2 = margin + boxSizes[2] + margin
+
+        val box0Left = offsetFromBox2 + spaceAtLeftOfChain
+        val box0Top = (rootSize - boxSizes[0]) * 0.5f
+
+        val box1Left = box0Left + boxSizes[0] + 0.5.dp // 0.5dp, compensate for a small solver error
+        val box1Top = box0Top - ((boxSizes[1] - boxSizes[0]) * 0.5f)
+
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(box0Left, box0Top)
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(box1Left, box1Top)
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(margin, margin)
+    }
+
+    @Test
+    fun testHorizontalPacked_withMargins() {
+        val rootSize = 100.dp
+        val boxSizes = arrayOf(10.dp, 20.dp, 30.dp)
+        val boxMargin = 5.dp
+        val boxGoneMargin = 7.dp
+        val constraintSet = ConstraintSet {
+            val box0 = createRefFor("box0")
+            val boxGone = createRefFor("boxGone")
+            val box1 = createRefFor("box1")
+            val box2 = createRefFor("box2")
+
+            createHorizontalChain(
+                box0.withChainParams(
+                    startMargin = 0.dp,
+                    endMargin = boxMargin, // Not applied since the next box is Gone
+                    endGoneMargin = boxGoneMargin
+                ),
+                boxGone.withChainParams(
+                    // None of these margins should apply since it's Gone
+                    startMargin = 100.dp,
+                    endMargin = 100.dp,
+                    startGoneMargin = 100.dp,
+                    endGoneMargin = 100.dp
+                ),
+                box1,
+                box2.withHorizontalChainParams(startMargin = boxMargin, endMargin = 0.dp),
+                chainStyle = ChainStyle.Packed
+            )
+
+            constrain(box0) {
+                width = Dimension.value(boxSizes[0])
+                height = Dimension.value(boxSizes[0])
+                centerVerticallyTo(parent)
+            }
+            constrain(boxGone) {
+                width = Dimension.value(boxSizes[1])
+                height = Dimension.value(boxSizes[1])
+                centerVerticallyTo(box0)
+
+                visibility = Visibility.Gone
+            }
+            constrain(box1) {
+                width = Dimension.value(boxSizes[1])
+                height = Dimension.value(boxSizes[1])
+                centerVerticallyTo(box0)
+            }
+            constrain(box2) {
+                width = Dimension.value(boxSizes[2])
+                height = Dimension.value(boxSizes[2])
+                centerVerticallyTo(box0)
+            }
+        }
+        rule.setContent {
+            ConstraintLayout(
+                modifier = Modifier
+                    .background(Color.LightGray)
+                    .size(rootSize),
+                constraintSet = constraintSet
+            ) {
+                Box(
+                    modifier = Modifier
+                        .background(Color.Red)
+                        .layoutTestId("box0")
+                )
+                Box(
+                    modifier = Modifier
+                        .background(Color.Blue)
+                        .layoutTestId("box1")
+                )
+                Box(
+                    modifier = Modifier
+                        .background(Color.Green)
+                        .layoutTestId("box2")
+                )
+            }
+        }
+        rule.waitForIdle()
+
+        val totalMargins = boxMargin + boxGoneMargin
+        val totalChainSpace = boxSizes[0] + boxSizes[1] + boxSizes[2] + totalMargins
+
+        val box0Left = (rootSize - totalChainSpace) * 0.5f
+        val box0Top = (rootSize - boxSizes[0]) * 0.5f
+
+        val box1Left = box0Left + boxSizes[0] + boxGoneMargin
+        val box1Top = (rootSize - boxSizes[1]) * 0.5f
+
+        val box2Left = box1Left + boxSizes[1] + boxMargin
+        val box2Top = (rootSize - boxSizes[2]) * 0.5f
+
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(box0Left, box0Top)
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(box1Left, box1Top)
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(box2Left, box2Top)
+    }
+
+    @Test
+    fun testVerticalPacked_withMargins() {
+        val rootSize = 100.dp
+        val boxSizes = arrayOf(10.dp, 20.dp, 30.dp)
+        val boxMargin = 5.dp
+        val boxGoneMargin = 7.dp
+        val constraintSet = ConstraintSet {
+            val box0 = createRefFor("box0")
+            val boxGone = createRefFor("boxGone")
+            val box1 = createRefFor("box1")
+            val box2 = createRefFor("box2")
+
+            createVerticalChain(
+                box0.withChainParams(
+                    topMargin = 0.dp,
+                    bottomMargin = boxMargin, // Not applied since the next box is Gone
+                    bottomGoneMargin = boxGoneMargin
+                ),
+                boxGone.withChainParams(
+                    // None of these margins should apply since it's Gone
+                    topMargin = 100.dp,
+                    bottomMargin = 100.dp,
+                    topGoneMargin = 100.dp,
+                    bottomGoneMargin = 100.dp
+                ),
+                box1,
+                box2.withVerticalChainParams(topMargin = boxMargin, bottomMargin = 0.dp),
+                chainStyle = ChainStyle.Packed
+            )
+
+            constrain(box0) {
+                width = Dimension.value(boxSizes[0])
+                height = Dimension.value(boxSizes[0])
+                centerHorizontallyTo(parent)
+            }
+            constrain(boxGone) {
+                width = Dimension.value(100.dp) // Dimensions won't matter since it's Gone
+                height = Dimension.value(100.dp) // Dimensions won't matter since it's Gone
+                centerHorizontallyTo(box0)
+
+                visibility = Visibility.Gone
+            }
+            constrain(box1) {
+                width = Dimension.value(boxSizes[1])
+                height = Dimension.value(boxSizes[1])
+                centerHorizontallyTo(box0)
+            }
+            constrain(box2) {
+                width = Dimension.value(boxSizes[2])
+                height = Dimension.value(boxSizes[2])
+                centerHorizontallyTo(box0)
+            }
+        }
+        rule.setContent {
+            ConstraintLayout(
+                modifier = Modifier
+                    .background(Color.LightGray)
+                    .size(rootSize),
+                constraintSet = constraintSet
+            ) {
+                Box(
+                    modifier = Modifier
+                        .background(Color.Red)
+                        .layoutTestId("box0")
+                )
+                Box(
+                    modifier = Modifier
+                        .background(Color.Blue)
+                        .layoutTestId("box1")
+                )
+                Box(
+                    modifier = Modifier
+                        .background(Color.Green)
+                        .layoutTestId("box2")
+                )
+            }
+        }
+        rule.waitForIdle()
+
+        val totalMargins = boxMargin + boxGoneMargin
+        val totalChainSpace = boxSizes[0] + boxSizes[1] + boxSizes[2] + totalMargins
+
+        val box0Left = (rootSize - boxSizes[0]) * 0.5f
+        val box0Top = (rootSize - totalChainSpace) * 0.5f
+
+        val box1Left = (rootSize - boxSizes[1]) * 0.5f
+        val box1Top = box0Top + boxSizes[0] + boxGoneMargin
+
+        val box2Left = (rootSize - boxSizes[2]) * 0.5f
+        val box2Top = box1Top + boxSizes[1] + boxMargin
+
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(box0Left, box0Top)
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(box1Left, box1Top)
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(box2Left, box2Top)
+    }
+
+    @Test
+    fun testHorizontalWeight_withConstraintSet() {
+        val rootSize = 100.dp
+        val boxSize = 10.dp
+
+        rule.setContent {
+            ConstraintLayout(
+                modifier = Modifier
+                    .background(Color.LightGray)
+                    .size(rootSize),
+                constraintSet = ConstraintSet {
+                    val box0 = createRefFor("box0")
+                    val box1 = createRefFor("box1")
+
+                    constrain(box0) {
+                        width = Dimension.fillToConstraints
+                        height = Dimension.value(boxSize)
+
+                        horizontalChainWeight = 1.0f
+                        verticalChainWeight = 2.0f // Ignored in horizontal chain
+                    }
+                    constrain(box1) {
+                        width = Dimension.fillToConstraints
+                        height = Dimension.value(boxSize)
+                    }
+                    createHorizontalChain(box0, box1.withChainParams(weight = 0.5f))
+                }
+            ) {
+                Box(
+                    modifier = Modifier
+                        .background(Color.Red)
+                        .layoutTestId("box0")
+                )
+                Box(
+                    modifier = Modifier
+                        .background(Color.Blue)
+                        .layoutTestId("box1")
+                )
+            }
+        }
+        rule.waitForIdle()
+        rule.onNodeWithTag("box0").assertWidthIsEqualTo(rootSize * 0.667f)
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(rootSize * 0.667f, 0.dp)
+        rule.onNodeWithTag("box1").assertWidthIsEqualTo(rootSize * 0.334f)
+    }
+
+    @Test
+    fun testVerticalWeight_withConstraintSet() {
+        val rootSize = 100.dp
+        val boxSize = 10.dp
+
+        rule.setContent {
+            ConstraintLayout(
+                modifier = Modifier
+                    .background(Color.LightGray)
+                    .size(rootSize),
+                constraintSet = ConstraintSet {
+                    val box0 = createRefFor("box0")
+                    val box1 = createRefFor("box1")
+
+                    constrain(box0) {
+                        width = Dimension.value(boxSize)
+                        height = Dimension.fillToConstraints
+
+                        horizontalChainWeight = 2.0f // Ignored in vertical chain
+                        verticalChainWeight = 1.0f
+                    }
+                    constrain(box1) {
+                        width = Dimension.value(boxSize)
+                        height = Dimension.fillToConstraints
+                    }
+                    createVerticalChain(box0, box1.withChainParams(weight = 0.5f))
+                }
+            ) {
+                Box(
+                    modifier = Modifier
+                        .background(Color.Red)
+                        .layoutTestId("box0")
+                )
+                Box(
+                    modifier = Modifier
+                        .background(Color.Blue)
+                        .layoutTestId("box1")
+                )
+            }
+        }
+        rule.waitForIdle()
+        rule.onNodeWithTag("box0").assertHeightIsEqualTo(rootSize * 0.667f)
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(0.dp, rootSize * 0.667f)
+        rule.onNodeWithTag("box1").assertHeightIsEqualTo(rootSize * 0.334f)
+    }
+}

--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/ConstraintLayoutTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/ConstraintLayoutTest.kt
@@ -136,12 +136,12 @@ class ConstraintLayoutTest {
         rule.runOnIdle {
             // The aspect ratio could not wrap and it is wrap suggested, so it respects constraints.
             assertEquals(
-                (displaySize.width / 2),
+                (displaySize.width / 2f).roundToInt(),
                 aspectRatioBoxSize.value!!.width
             )
             // Aspect ratio is preserved.
             assertEquals(
-                (displaySize.width / 2 / 2),
+                (displaySize.width / 2f / 2f).roundToInt(),
                 aspectRatioBoxSize.value!!.height
             )
             // Divider has fixed width 1.dp in constraint set.
@@ -197,12 +197,12 @@ class ConstraintLayoutTest {
         rule.runOnIdle {
             // The aspect ratio could not wrap and it is wrap suggested, so it respects constraints.
             assertEquals(
-                (displaySize.width / 2),
+                (displaySize.width / 2f).roundToInt(),
                 aspectRatioBoxSize.value!!.width
             )
             // Aspect ratio is preserved.
             assertEquals(
-                (displaySize.width / 2 / 2),
+                (displaySize.width / 2f / 2f).roundToInt(),
                 aspectRatioBoxSize.value!!.height
             )
             // Divider has fixed width 1.dp in constraint set.
@@ -258,12 +258,12 @@ class ConstraintLayoutTest {
         rule.runOnIdle {
             // The aspect ratio could not wrap and it is wrap suggested, so it respects constraints.
             assertEquals(
-                (displaySize.width / 2),
+                (displaySize.width / 2f).roundToInt(),
                 aspectRatioBoxSize.value!!.width
             )
             // Aspect ratio is preserved.
             assertEquals(
-                (displaySize.width / 2 / 2),
+                (displaySize.width / 2f / 2f).roundToInt(),
                 aspectRatioBoxSize.value!!.height
             )
             // Divider has fixed width 1.dp in constraint set.
@@ -424,7 +424,7 @@ class ConstraintLayoutTest {
         val boxSize = 100
         val offset = 150
 
-        val position = Array(3) { Ref<Offset>() }
+        val position: Array<IntOffset> = Array(3) { IntOffset.Zero }
 
         rule.setContent {
             ConstraintLayout(
@@ -441,7 +441,9 @@ class ConstraintLayoutTest {
                         }
                         .size(boxSize.toDp(), boxSize.toDp())
                         .onGloballyPositioned {
-                            position[0].value = it.positionInRoot()
+                            position[0] = it
+                                .positionInRoot()
+                                .round()
                         }
                 )
                 val half = createGuidelineFromAbsoluteLeft(fraction = 0.5f)
@@ -453,7 +455,9 @@ class ConstraintLayoutTest {
                         }
                         .size(boxSize.toDp(), boxSize.toDp())
                         .onGloballyPositioned {
-                            position[1].value = it.positionInRoot()
+                            position[1] = it
+                                .positionInRoot()
+                                .round()
                         }
                 )
                 Box(
@@ -464,7 +468,9 @@ class ConstraintLayoutTest {
                         }
                         .size(boxSize.toDp(), boxSize.toDp())
                         .onGloballyPositioned {
-                            position[2].value = it.positionInRoot()
+                            position[2] = it
+                                .positionInRoot()
+                                .round()
                         }
                 )
             }
@@ -476,24 +482,24 @@ class ConstraintLayoutTest {
         rule.runOnIdle {
             assertEquals(
                 Offset(
-                    ((displayWidth - boxSize) / 2).toFloat(),
-                    ((displayHeight - boxSize) / 2).toFloat()
-                ),
-                position[0].value
+                    ((displayWidth - boxSize) / 2f),
+                    ((displayHeight - boxSize) / 2f)
+                ).round(),
+                position[0]
             )
             assertEquals(
                 Offset(
-                    (displayWidth / 2 + offset).toFloat(),
-                    ((displayHeight - boxSize) / 2 - boxSize).toFloat()
-                ),
-                position[1].value
+                    (displayWidth / 2f + offset),
+                    ((displayHeight - boxSize) / 2f - boxSize)
+                ).round(),
+                position[1]
             )
             assertEquals(
-                Offset(
-                    offset.toFloat(),
-                    (displayHeight - boxSize - offset).toFloat()
+                IntOffset(
+                    offset,
+                    (displayHeight - boxSize - offset)
                 ),
-                position[2].value
+                position[2]
             )
         }
     }
@@ -504,7 +510,7 @@ class ConstraintLayoutTest {
         val boxSize = 100
         val offset = 150
 
-        val position = Array(3) { Ref<Offset>() }
+        val position: Array<IntOffset> = Array(3) { IntOffset.Zero }
 
         rule.setContent {
             ConstraintLayout(
@@ -540,7 +546,9 @@ class ConstraintLayoutTest {
                             .layoutId("box$i")
                             .size(boxSize.toDp(), boxSize.toDp())
                             .onGloballyPositioned {
-                                position[i].value = it.positionInRoot()
+                                position[i] = it
+                                    .positionInRoot()
+                                    .round()
                             }
                     )
                 }
@@ -555,22 +563,22 @@ class ConstraintLayoutTest {
                 Offset(
                     (displayWidth - boxSize) / 2f,
                     (displayHeight - boxSize) / 2f
-                ),
-                position[0].value
+                ).round(),
+                position[0]
             )
             assertEquals(
                 Offset(
                     (displayWidth / 2f + offset),
-                    ((displayHeight - boxSize) / 2 - boxSize).toFloat()
-                ),
-                position[1].value
+                    ((displayHeight - boxSize) / 2f - boxSize)
+                ).round(),
+                position[1]
             )
             assertEquals(
-                Offset(
-                    offset.toFloat(),
-                    (displayHeight - boxSize - offset).toFloat()
+                IntOffset(
+                    offset,
+                    (displayHeight - boxSize - offset)
                 ),
-                position[2].value
+                position[2]
             )
         }
     }
@@ -653,7 +661,7 @@ class ConstraintLayoutTest {
     }
 
     @Test
-    fun testConstraintLayout_helpers_ltr() = with(rule.density) {
+    fun testConstraintLayout_guidelines_ltr() = with(rule.density) {
         val size = 200.toDp()
         val offset = 50.toDp()
 
@@ -687,20 +695,38 @@ class ConstraintLayoutTest {
             }
         }
 
-        rule.runOnIdle {
-            assertEquals(50f, position[0])
-            assertEquals(50f, position[1])
-            assertEquals(150f, position[2])
-            assertEquals(150f, position[3])
-            assertEquals(50f, position[4])
-            assertEquals(50f, position[5])
-            assertEquals(150f, position[6])
-            assertEquals(150f, position[7])
-        }
+        assertGuidelinesLtrPositions(position)
     }
 
     @Test
-    fun testConstraintLayout_helpers_rtl() = with(rule.density) {
+    fun testConstraintLayout_json_guidelines_ltr() = with(rule.density) {
+        val size = 200.toDp()
+        val offset = 50.toDp()
+
+        val position = Array(8) { 0f }
+        rule.setContent {
+            ConstraintLayout(
+                constraintSet = ConstraintSet(getJsonGuidelinesContent(offset.value)),
+                Modifier.size(size)
+            ) {
+                position.forEachIndexed { index, _ ->
+                    Box(
+                        Modifier
+                            .size(1.dp)
+                            .layoutId("box$index")
+                            .onGloballyPositioned {
+                                position[index] = it.positionInParent().x
+                            }
+                    )
+                }
+            }
+        }
+
+        assertGuidelinesLtrPositions(position)
+    }
+
+    @Test
+    fun testConstraintLayout_guidelines_rtl() = with(rule.density) {
         val size = 200.toDp()
         val offset = 50.toDp()
 
@@ -736,16 +762,36 @@ class ConstraintLayoutTest {
             }
         }
 
-        rule.runOnIdle {
-            assertEquals(150f, position[0])
-            assertEquals(50f, position[1])
-            assertEquals(50f, position[2])
-            assertEquals(150f, position[3])
-            assertEquals(150f, position[4])
-            assertEquals(50f, position[5])
-            assertEquals(50f, position[6])
-            assertEquals(150f, position[7])
+        assertGuidelinesRtlPositions(position)
+    }
+
+    @Test
+    fun testConstraintLayout_json_guidelines_rtl() = with(rule.density) {
+        val size = 200.toDp()
+        val offset = 50.toDp()
+
+        val position = Array(8) { 0f }
+        rule.setContent {
+            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+                ConstraintLayout(
+                    constraintSet = ConstraintSet(getJsonGuidelinesContent(offset.value)),
+                    Modifier.size(size)
+                ) {
+                    position.forEachIndexed { index, _ ->
+                        Box(
+                            Modifier
+                                .size(1.dp)
+                                .layoutId("box$index")
+                                .onGloballyPositioned {
+                                    position[index] = it.positionInParent().x
+                                }
+                        )
+                    }
+                }
+            }
         }
+
+        assertGuidelinesRtlPositions(position)
     }
 
     @Test
@@ -797,12 +843,44 @@ class ConstraintLayoutTest {
             }
         }
 
-        rule.runOnIdle {
-            assertEquals(50f, position[0])
-            assertEquals(50f, position[1])
-            assertEquals(151f, position[2])
-            assertEquals(151f, position[3])
+        assertBarriersLtrPositions(position)
+    }
+
+    @Test
+    fun testConstraintLayout_json_barriers_ltr() = with(rule.density) {
+        val size = 200.toDp()
+        val offset = 50.toDp()
+
+        val position = Array(4) { 0f }
+        rule.setContent {
+            ConstraintLayout(
+                constraintSet = ConstraintSet(getJsonBarriersContent(offset.value)),
+                Modifier.size(size)
+            ) {
+                Box(
+                    Modifier
+                        .size(1.toDp())
+                        .layoutId("boxA")
+                )
+                Box(
+                    Modifier
+                        .size(1.toDp())
+                        .layoutId("boxB")
+                )
+                position.forEachIndexed { index, _ ->
+                    Box(
+                        Modifier
+                            .size(1.dp)
+                            .layoutId("box$index")
+                            .onGloballyPositioned {
+                                position[index] = it.positionInParent().x
+                            }
+                    )
+                }
+            }
         }
+
+        assertBarriersLtrPositions(position)
     }
 
     @Test
@@ -856,34 +934,46 @@ class ConstraintLayoutTest {
             }
         }
 
-        rule.runOnIdle {
-            assertEquals(151f, position[0])
-            assertEquals(50f, position[1])
-            assertEquals(50f, position[2])
-            assertEquals(151f, position[3])
-        }
+        assertBarriersRtlPositions(position)
     }
 
-    fun listAnchors(box: ConstrainedLayoutReference): List<ConstrainScope.() -> Unit> {
-        // TODO(172055763) directly construct an immutable list when Lint supports it
-        val anchors = mutableListOf<ConstrainScope.() -> Unit>()
-        anchors.add({ start.linkTo(box.start) })
-        anchors.add({ absoluteLeft.linkTo(box.start) })
-        anchors.add({ start.linkTo(box.absoluteLeft) })
-        anchors.add({ absoluteLeft.linkTo(box.absoluteLeft) })
-        anchors.add({ end.linkTo(box.start) })
-        anchors.add({ absoluteRight.linkTo(box.start) })
-        anchors.add({ end.linkTo(box.absoluteLeft) })
-        anchors.add({ absoluteRight.linkTo(box.absoluteLeft) })
-        anchors.add({ start.linkTo(box.end) })
-        anchors.add({ absoluteLeft.linkTo(box.end) })
-        anchors.add({ start.linkTo(box.absoluteRight) })
-        anchors.add({ absoluteLeft.linkTo(box.absoluteRight) })
-        anchors.add({ end.linkTo(box.end) })
-        anchors.add({ absoluteRight.linkTo(box.end) })
-        anchors.add({ end.linkTo(box.absoluteRight) })
-        anchors.add({ absoluteRight.linkTo(box.absoluteRight) })
-        return anchors
+    @Test
+    fun testConstraintLayout_json_barriers_rtl() = with(rule.density) {
+        val size = 200.toDp()
+        val offset = 50.toDp()
+
+        val position = Array(4) { 0f }
+        rule.setContent {
+            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+                ConstraintLayout(
+                    constraintSet = ConstraintSet(getJsonBarriersContent(offset.value)),
+                    Modifier.size(size)
+                ) {
+                    Box(
+                        Modifier
+                            .size(1.toDp())
+                            .layoutId("boxA")
+                    )
+                    Box(
+                        Modifier
+                            .size(1.toDp())
+                            .layoutId("boxB")
+                    )
+                    position.forEachIndexed { index, _ ->
+                        Box(
+                            Modifier
+                                .size(1.dp)
+                                .layoutId("box$index")
+                                .onGloballyPositioned {
+                                    position[index] = it.positionInParent().x
+                                }
+                        )
+                    }
+                }
+            }
+        }
+
+        assertBarriersRtlPositions(position)
     }
 
     @Test
@@ -922,24 +1012,39 @@ class ConstraintLayoutTest {
             }
         }
 
-        rule.runOnIdle {
-            assertEquals(50f, position[0])
-            assertEquals(50f, position[1])
-            assertEquals(50f, position[2])
-            assertEquals(50f, position[3])
-            assertEquals(49f, position[4])
-            assertEquals(49f, position[5])
-            assertEquals(49f, position[6])
-            assertEquals(49f, position[7])
-            assertEquals(51f, position[8])
-            assertEquals(51f, position[9])
-            assertEquals(51f, position[10])
-            assertEquals(51f, position[11])
-            assertEquals(50f, position[12])
-            assertEquals(50f, position[13])
-            assertEquals(50f, position[14])
-            assertEquals(50f, position[15])
+        assertAnchorsLtrPositions(position)
+    }
+
+    @Test
+    fun testConstraintLayout_json_anchors_ltr() = with(rule.density) {
+        val size = 200.toDp()
+        val offset = 50.toDp()
+
+        val position = Array(16) { 0f }
+        rule.setContent {
+            ConstraintLayout(
+                constraintSet = ConstraintSet(getJsonAnchorsContent(offset.value)),
+                Modifier.size(size)
+            ) {
+                Box(
+                    Modifier
+                        .size(1.toDp())
+                        .layoutId("box")
+                )
+                position.forEachIndexed { index, _ ->
+                    Box(
+                        Modifier
+                            .size(1.toDp())
+                            .layoutId("box$index")
+                            .onGloballyPositioned {
+                                position[index] = it.positionInParent().x
+                            }
+                    )
+                }
+            }
         }
+
+        assertAnchorsLtrPositions(position)
     }
 
     @Test
@@ -980,24 +1085,41 @@ class ConstraintLayoutTest {
             }
         }
 
-        rule.runOnIdle {
-            assertEquals(50f, position[0])
-            assertEquals(51f, position[1])
-            assertEquals(49f, position[2])
-            assertEquals(50f, position[3])
-            assertEquals(51f, position[4])
-            assertEquals(50f, position[5])
-            assertEquals(50f, position[6])
-            assertEquals(49f, position[7])
-            assertEquals(49f, position[8])
-            assertEquals(50f, position[9])
-            assertEquals(50f, position[10])
-            assertEquals(51f, position[11])
-            assertEquals(50f, position[12])
-            assertEquals(49f, position[13])
-            assertEquals(51f, position[14])
-            assertEquals(50f, position[15])
+        assertAnchorsRtlPositions(position)
+    }
+
+    @Test
+    fun testConstraintLayout_json_anchors_rtl() = with(rule.density) {
+        val size = 200.toDp()
+        val offset = 50.toDp()
+
+        val position = Array(16) { 0f }
+        rule.setContent {
+            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+                ConstraintLayout(
+                    constraintSet = ConstraintSet(getJsonAnchorsContent(offset.value)),
+                    Modifier.size(size)
+                ) {
+                    Box(
+                        Modifier
+                            .size(1.toDp())
+                            .layoutId("box")
+                    )
+                    position.forEachIndexed { index, _ ->
+                        Box(
+                            Modifier
+                                .size(1.toDp())
+                                .layoutId("box$index")
+                                .onGloballyPositioned {
+                                    position[index] = it.positionInParent().x
+                                }
+                        )
+                    }
+                }
+            }
         }
+
+        assertAnchorsRtlPositions(position)
     }
 
     @Test
@@ -1200,8 +1322,8 @@ class ConstraintLayoutTest {
         rule.setContent {
             Box {
                 ConstraintLayout {
-                    val (box1, box2) = createRefs()
-                    val barrier = createBottomBarrier(box1)
+                    val (box1, _) = createRefs()
+                    createBottomBarrier(box1)
                     Box(
                         Modifier
                             .height(if (smallSize) 30.dp else 40.dp)
@@ -1247,6 +1369,7 @@ class ConstraintLayoutTest {
                 val barrier = createAbsoluteLeftBarrier(box1)
 
                 // Make sure the content is reexecuted when first changes.
+                @Suppress("UNUSED_EXPRESSION")
                 first
 
                 // If the reference changed, we would remeasure and reexecute the DSL.
@@ -1463,6 +1586,34 @@ class ConstraintLayoutTest {
     }
 
     @Test
+    fun testConstraintLayout_doesNotRecomposeAgain_whenHelpersChange() = with(rule.density) {
+        var offset by mutableStateOf(10.dp)
+        var compositions = 0
+        rule.setContent {
+            ConstraintLayout {
+                ++compositions
+                val box = createRef()
+                val g = createGuidelineFromStart(offset)
+                Box(
+                    Modifier
+                        .constrainAs(box) {
+                            start.linkTo(g)
+                        }
+                )
+            }
+        }
+
+        rule.runOnIdle {
+            offset = 20.dp
+            assertEquals(1, compositions)
+        }
+
+        rule.runOnIdle {
+            assertEquals(2, compositions)
+        }
+    }
+
+    @Test
     fun testConstraintLayout_rebuilds_whenLambdaChanges() = with(rule.density) {
         var first by mutableStateOf(true)
         var obtainedX = 0f
@@ -1498,16 +1649,16 @@ class ConstraintLayoutTest {
     fun testConstraintLayout_updates_whenConstraintSetChangesConstraints() = with(rule.density) {
         val box1Size = 20
         var first by mutableStateOf(true)
-        val constraintSet = ConstraintSet {
-            val box1 = createRefFor("box1")
-            val box2 = createRefFor("box2")
-            constrain(box2) {
-                if (first) start.linkTo(box1.end) else top.linkTo(box1.bottom)
-            }
-        }
 
         var box2Position = IntOffset.Zero
         rule.setContent {
+            val constraintSet = ConstraintSet {
+                val box1 = createRefFor("box1")
+                val box2 = createRefFor("box2")
+                constrain(box2) {
+                    if (first) start.linkTo(box1.end) else top.linkTo(box1.bottom)
+                }
+            }
             ConstraintLayout(constraintSet) {
                 Box(
                     Modifier
@@ -1533,6 +1684,55 @@ class ConstraintLayoutTest {
 
         rule.runOnIdle {
             assertEquals(IntOffset(0, box1Size), box2Position)
+        }
+    }
+
+    @Test
+    fun testConstraintLayout_doesNotUpdate_withRememberConstraintSet() = with(rule.density) {
+        val box1Size = 20
+        var first by mutableStateOf(true)
+        var compCount = 0
+
+        var box2Position = IntOffset.Zero
+        rule.setContent {
+            // ConstraintSet should be immutable and shouldn't recompose if "remembered"
+            val constraintSet = remember {
+                ConstraintSet {
+                    val box1 = createRefFor("box1")
+                    val box2 = createRefFor("box2")
+                    constrain(box2) {
+                        if (first) start.linkTo(box1.end) else top.linkTo(box1.bottom)
+                    }
+                }
+            }
+            compCount++
+            ConstraintLayout(constraintSet) {
+                Box(
+                    Modifier
+                        .size(box1Size.toDp())
+                        .layoutId("box1")
+                )
+                Box(
+                    Modifier
+                        .layoutId("box2")
+                        .onGloballyPositioned {
+                            box2Position = it
+                                .positionInRoot()
+                                .round()
+                        }
+                )
+            }
+        }
+
+        rule.runOnIdle {
+            assertEquals(IntOffset(box1Size, 0), box2Position)
+            assertEquals(1, compCount)
+            first = false
+        }
+
+        rule.runOnIdle {
+            assertEquals(IntOffset(box1Size, 0), box2Position)
+            assertEquals(2, compCount)
         }
     }
 
@@ -1581,6 +1781,7 @@ class ConstraintLayoutTest {
         rule.onNodeWithTag(boxTag).assertPositionInRootIsEqualTo(175.dp, 5.dp)
     }
 
+    @Ignore("Fails with online devices, expects 30.47dp instead of 29.5dp")
     @Test
     fun testLayoutReference_withConstraintSet() {
         val boxTag1 = "box1"
@@ -1626,6 +1827,7 @@ class ConstraintLayoutTest {
         rule.onNodeWithTag(boxTag2).assertPositionInRootIsEqualTo(60.dp, 0.dp)
     }
 
+    @Ignore("Fails with online devices, expects 30.47dp instead of 29.5dp")
     @Test
     fun testLayoutReference_withInlineDsl() {
         val boxTag1 = "box1"
@@ -1659,5 +1861,323 @@ class ConstraintLayoutTest {
         // TODO: Investigate, Left position should be 30.dp
         rule.onNodeWithTag(boxTag1).assertPositionInRootIsEqualTo(29.5.dp, 0.dp)
         rule.onNodeWithTag(boxTag2).assertPositionInRootIsEqualTo(60.dp, 0.dp)
+    }
+
+    @Test
+    fun testBias_withConstraintSet() {
+        val rootSize = 100.dp
+        val boxSize = 10.dp
+        val horBias = 0.2f
+        val verBias = 1f - horBias
+        rule.setContent {
+            ConstraintLayout(
+                modifier = Modifier.size(rootSize),
+                constraintSet = ConstraintSet {
+                    constrain(createRefFor("box")) {
+                        width = Dimension.value(boxSize)
+                        height = Dimension.value(boxSize)
+
+                        centerTo(parent)
+                        horizontalBias = horBias
+                        verticalBias = verBias
+                    }
+                }) {
+                Box(
+                    modifier = Modifier
+                        .background(Color.Red)
+                        .layoutTestId("box")
+                )
+            }
+        }
+        rule.waitForIdle()
+        rule.onNodeWithTag("box").assertPositionInRootIsEqualTo(
+            (rootSize - boxSize) * 0.2f,
+            (rootSize - boxSize) * 0.8f
+        )
+    }
+
+    @Test
+    fun testBias_withInlineDsl() {
+        val rootSize = 100.dp
+        val boxSize = 10.dp
+        val horBias = 0.2f
+        val verBias = 1f - horBias
+        rule.setContent {
+            ConstraintLayout(Modifier.size(rootSize)) {
+                val box = createRef()
+                Box(
+                    modifier = Modifier
+                        .background(Color.Red)
+                        .constrainAs(box) {
+                            width = Dimension.value(boxSize)
+                            height = Dimension.value(boxSize)
+
+                            centerTo(parent)
+                            horizontalBias = horBias
+                            verticalBias = verBias
+                        }
+                        .layoutTestId("box")
+                )
+            }
+        }
+        rule.waitForIdle()
+        rule.onNodeWithTag("box").assertPositionInRootIsEqualTo(
+            (rootSize - boxSize) * 0.2f,
+            (rootSize - boxSize) * 0.8f
+        )
+    }
+
+    @Test
+    fun testLinkToBias_withInlineDsl_rtl() = with(rule.density) {
+        val rootSize = 200
+        val boxSize = 20
+        val box1Bias = 0.2f
+        val box2Bias = 0.2f
+
+        var box1Position = IntOffset.Zero
+        var box2Position = IntOffset.Zero
+        rule.setContent {
+            CompositionLocalProvider(LocalLayoutDirection.provides(LayoutDirection.Rtl)) {
+                ConstraintLayout(Modifier.size(rootSize.toDp())) {
+                    val (box1Ref, box2Ref) = createRefs()
+
+                    Box(
+                        modifier = Modifier
+                            .background(Color.Red)
+                            .constrainAs(box1Ref) {
+                                width = Dimension.value(boxSize.toDp())
+                                height = Dimension.value(boxSize.toDp())
+
+                                centerTo(parent)
+                                horizontalBias = box1Bias // unaffected by Rtl
+                            }
+                            .onGloballyPositioned {
+                                box1Position = it
+                                    .positionInRoot()
+                                    .round()
+                            }
+                    )
+                    Box(
+                        modifier = Modifier
+                            .background(Color.Blue)
+                            .constrainAs(box2Ref) {
+                                width = Dimension.value(boxSize.toDp())
+                                height = Dimension.value(boxSize.toDp())
+
+                                top.linkTo(box1Ref.bottom)
+                                linkTo(
+                                    start = parent.start,
+                                    end = box1Ref.start,
+                                    startMargin = 0.dp,
+                                    endMargin = 0.dp,
+                                    startGoneMargin = 0.dp,
+                                    endGoneMargin = 0.dp,
+                                    bias = box2Bias // affected by Rtl
+                                )
+                            }
+                            .onGloballyPositioned {
+                                box2Position = it
+                                    .positionInRoot()
+                                    .round()
+                            }
+                    )
+                }
+            }
+        }
+
+        rule.runOnIdle {
+            val expectedBox1X = (rootSize - boxSize) * box1Bias
+            val expectedBox1Y = (rootSize * 0.5f) - (boxSize * 0.5f)
+            assertEquals(Offset(expectedBox1X, expectedBox1Y).round(), box1Position)
+
+            val expectedBox1End = expectedBox1X + boxSize
+            val expectedBox2X =
+                (rootSize - expectedBox1End - boxSize) * (1f - box2Bias) + expectedBox1End
+            assertEquals(Offset(expectedBox2X, expectedBox1Y + boxSize).round(), box2Position)
+        }
+    }
+
+    private fun listAnchors(box: ConstrainedLayoutReference): List<ConstrainScope.() -> Unit> {
+        // TODO(172055763) directly construct an immutable list when Lint supports it
+        val anchors = mutableListOf<ConstrainScope.() -> Unit>()
+        anchors.add({ start.linkTo(box.start) })
+        anchors.add({ absoluteLeft.linkTo(box.start) })
+        anchors.add({ start.linkTo(box.absoluteLeft) })
+        anchors.add({ absoluteLeft.linkTo(box.absoluteLeft) })
+        anchors.add({ end.linkTo(box.start) })
+        anchors.add({ absoluteRight.linkTo(box.start) })
+        anchors.add({ end.linkTo(box.absoluteLeft) })
+        anchors.add({ absoluteRight.linkTo(box.absoluteLeft) })
+        anchors.add({ start.linkTo(box.end) })
+        anchors.add({ absoluteLeft.linkTo(box.end) })
+        anchors.add({ start.linkTo(box.absoluteRight) })
+        anchors.add({ absoluteLeft.linkTo(box.absoluteRight) })
+        anchors.add({ end.linkTo(box.end) })
+        anchors.add({ absoluteRight.linkTo(box.end) })
+        anchors.add({ end.linkTo(box.absoluteRight) })
+        anchors.add({ absoluteRight.linkTo(box.absoluteRight) })
+        return anchors
+    }
+
+    private fun getJsonAnchorsContent(guidelineOffset: Float): String =
+        //language=json5
+        """
+            {
+              g1: { type: 'vGuideline', left: $guidelineOffset },
+              box: { left: ['g1', 'left', 0] },
+              box0: { start: ['box','start',0] },
+              box1: { left: ['box','start',0] },
+              box2: { start: ['box','left',0] },
+              box3: { left: ['box','left',0] },
+              box4: { end: ['box','start',0] },
+              box5: { right: ['box','start',0] },
+              box6: { end: ['box','left',0] },
+              box7: { right: ['box','left',0] },
+              box8: { start: ['box','end',0] },
+              box9: { left: ['box','end',0] },
+              box10: { start: ['box','right',0] },
+              box11: { left: ['box','right',0] },
+              box12: { end: ['box','end',0] },
+              box13: { right: ['box','end',0] },
+              box14: { end: ['box','right',0] },
+              box15: { right: ['box','right',0] }
+            }
+        """.trimIndent()
+
+    private fun assertAnchorsLtrPositions(position: Array<Float>) {
+        rule.runOnIdle {
+            assertEquals(16, position.size)
+            assertEquals(50f, position[0])
+            assertEquals(50f, position[1])
+            assertEquals(50f, position[2])
+            assertEquals(50f, position[3])
+            assertEquals(49f, position[4])
+            assertEquals(49f, position[5])
+            assertEquals(49f, position[6])
+            assertEquals(49f, position[7])
+            assertEquals(51f, position[8])
+            assertEquals(51f, position[9])
+            assertEquals(51f, position[10])
+            assertEquals(51f, position[11])
+            assertEquals(50f, position[12])
+            assertEquals(50f, position[13])
+            assertEquals(50f, position[14])
+            assertEquals(50f, position[15])
+        }
+    }
+
+    private fun assertAnchorsRtlPositions(position: Array<Float>) {
+        rule.runOnIdle {
+            assertEquals(16, position.size)
+            assertEquals(50f, position[0])
+            assertEquals(51f, position[1])
+            assertEquals(49f, position[2])
+            assertEquals(50f, position[3])
+            assertEquals(51f, position[4])
+            assertEquals(50f, position[5])
+            assertEquals(50f, position[6])
+            assertEquals(49f, position[7])
+            assertEquals(49f, position[8])
+            assertEquals(50f, position[9])
+            assertEquals(50f, position[10])
+            assertEquals(51f, position[11])
+            assertEquals(50f, position[12])
+            assertEquals(49f, position[13])
+            assertEquals(51f, position[14])
+            assertEquals(50f, position[15])
+        }
+    }
+
+    private fun getJsonGuidelinesContent(guidelineOffset: Float): String =
+        //language=json5
+        """
+            {
+              g0: { type: 'vGuideline', start: $guidelineOffset },
+              g1: { type: 'vGuideline', left: $guidelineOffset },
+              g2: { type: 'vGuideline', end: $guidelineOffset },
+              g3: { type: 'vGuideline', right: $guidelineOffset },
+              g4: { type: 'vGuideline', percent: ["start", 0.25] },
+              g5: { type: 'vGuideline', percent: ["left", 0.25] },
+              g6: { type: 'vGuideline', percent: ["end", 0.25] },
+              g7: { type: 'vGuideline', percent: ["right", 0.25] },
+              box0: { left: ['g0', 'start', 0] },
+              box1: { left: ['g1', 'start', 0] },
+              box2: { left: ['g2', 'start', 0] },
+              box3: { left: ['g3', 'start', 0] },
+              box4: { left: ['g4', 'start', 0] },
+              box5: { left: ['g5', 'start', 0] },
+              box6: { left: ['g6', 'start', 0] },
+              box7: { left: ['g7', 'start', 0] }
+            }
+        """.trimIndent()
+
+    private fun assertGuidelinesLtrPositions(position: Array<Float>) {
+        rule.runOnIdle {
+            assertEquals(8, position.size)
+            assertEquals(50f, position[0])
+            assertEquals(50f, position[1])
+            assertEquals(150f, position[2])
+            assertEquals(150f, position[3])
+            assertEquals(50f, position[4])
+            assertEquals(50f, position[5])
+            assertEquals(150f, position[6])
+            assertEquals(150f, position[7])
+        }
+    }
+
+    private fun assertGuidelinesRtlPositions(position: Array<Float>) {
+        rule.runOnIdle {
+            assertEquals(8, position.size)
+            assertEquals(150f, position[0])
+            assertEquals(50f, position[1])
+            assertEquals(50f, position[2])
+            assertEquals(150f, position[3])
+            assertEquals(150f, position[4])
+            assertEquals(50f, position[5])
+            assertEquals(50f, position[6])
+            assertEquals(150f, position[7])
+        }
+    }
+
+    private fun getJsonBarriersContent(guidelineOffset: Float): String =
+        //language=json5
+        """
+            {
+              g0: { type: 'vGuideline', left: $guidelineOffset },
+              g1: { type: 'vGuideline', right: $guidelineOffset },
+
+              boxA: { left: ['g0', 'start', 0] },
+              boxB: { left: ['g1', 'start', 0] },
+
+              b0: { type: 'barrier', direction: 'start', contains: ['boxA','boxB'] },
+              b1: { type: 'barrier', direction: 'left', contains: ['boxA','boxB'] },
+              b2: { type: 'barrier', direction: 'end', contains: ['boxA','boxB'] },
+              b3: { type: 'barrier', direction: 'right', contains: ['boxA','boxB'] },
+
+              box0: { left: ['b0', 'start', 0] },
+              box1: { left: ['b1', 'start', 0] },
+              box2: { left: ['b2', 'start', 0] },
+              box3: { left: ['b3', 'start', 0] },
+            }
+        """.trimIndent()
+
+    private fun assertBarriersLtrPositions(position: Array<Float>) {
+        rule.runOnIdle {
+            assertEquals(4, position.size)
+            assertEquals(50f, position[0])
+            assertEquals(50f, position[1])
+            assertEquals(151f, position[2])
+            assertEquals(151f, position[3])
+        }
+    }
+
+    private fun assertBarriersRtlPositions(position: Array<Float>) {
+        rule.runOnIdle {
+            assertEquals(4, position.size)
+            assertEquals(151f, position[0])
+            assertEquals(50f, position[1])
+            assertEquals(50f, position[2])
+            assertEquals(151f, position[3])
+        }
     }
 }

--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/ConstraintSetParserKtTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/ConstraintSetParserKtTest.kt
@@ -25,7 +25,7 @@ internal class ConstraintSetParserKtTest {
 
     @Test
     fun parseCustomColor() {
-        val coreTransition = Transition()
+        val coreTransition = Transition { dp -> dp }
 
         @Language("JSON5")
         val content = """

--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/GridTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/GridTest.kt
@@ -16,7 +16,6 @@
 
 package androidx.constraintlayout.compose
 
-import android.content.Context
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
@@ -29,6 +28,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertPositionInRootIsEqualTo
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
@@ -38,6 +38,9 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+/**
+ * Tests for the Grid Helper
+ */
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class GridTest {
@@ -79,8 +82,8 @@ class GridTest {
         }
         var leftX = 0.dp
         var topY = 0.dp
-        var rightX = 0.dp
-        var bottomY = 0.dp
+        var rightX: Dp
+        var bottomY: Dp
 
         // 10.dp is the size of a singular box
         val gapSize = (rootSize - (10.dp * 2f)) / (columns * 2f)
@@ -120,8 +123,8 @@ class GridTest {
         }
         var leftX = 0.dp
         var topY = 0.dp
-        var rightX = 0.dp
-        var bottomY = 0.dp
+        var rightX: Dp
+        var bottomY: Dp
 
         // 10.dp is the size of a singular box
         val gapSize = (rootSize - (10.dp * 2f)) / (columns * 2f)
@@ -135,7 +138,6 @@ class GridTest {
         rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(leftX, bottomY)
         rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(rightX, bottomY)
     }
-
 
     @Test
     fun testRows() {
@@ -170,11 +172,11 @@ class GridTest {
         expectedX += hGapSize
         expectedY += vGapSize
         rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedX, expectedY)
-        expectedY += vGapSize + vGapSize + 10.dp;
-        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX , expectedY)
-        expectedY += vGapSize + vGapSize + 10.dp;
+        expectedY += vGapSize + vGapSize + 10.dp
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp
         rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX, expectedY)
-        expectedY += vGapSize + vGapSize + 10.dp;
+        expectedY += vGapSize + vGapSize + 10.dp
         rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
     }
 
@@ -211,11 +213,11 @@ class GridTest {
         expectedX += hGapSize
         expectedY += vGapSize
         rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedX, expectedY)
-        expectedX += hGapSize + hGapSize + 10.dp;
-        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX , expectedY)
-        expectedX += hGapSize + hGapSize + 10.dp;
+        expectedX += hGapSize + hGapSize + 10.dp
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp
         rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX, expectedY)
-        expectedX += hGapSize + hGapSize + 10.dp;
+        expectedX += hGapSize + hGapSize + 10.dp
         rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
     }
 
@@ -244,8 +246,8 @@ class GridTest {
         }
         var leftX = 0.dp
         var topY = 0.dp
-        var rightX = 0.dp
-        var bottomY = 0.dp
+        var rightX: Dp
+        var bottomY: Dp
 
         // 10.dp is the size of a singular box
         val gapSize = (rootSize - (10.dp * 2f)) / (columns * 2f)
@@ -284,8 +286,8 @@ class GridTest {
         }
         var leftX = 0.dp
         var topY = 0.dp
-        var rightX = 0.dp
-        var bottomY = 0.dp
+        var rightX: Dp
+        var bottomY: Dp
 
         // 10.dp is the size of a singular box
         var spanLeft = (rootSize - 10.dp) / 2f
@@ -336,7 +338,6 @@ class GridTest {
         rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedLeft, expectedTop)
         expectedTop += 10.dp + firstGapSize + secondGapSize
         rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedLeft, expectedTop)
-
     }
 
     @Test
@@ -433,7 +434,7 @@ class GridTest {
             grid: {
                 width: $width,
                 height: $height,
-                type: 'Grid',
+                type: 'grid',
                 rows: $rows,
                 columns $columns,
                 vGap: $vGap,
@@ -480,7 +481,7 @@ class GridTest {
             grid: {
                 width: $width,
                 height: $height,
-                type: 'Grid',
+                type: 'grid',
                 rows: 2,
                 columns: 2,
                 vGap: $vGap,

--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/MotionGridTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/MotionGridTest.kt
@@ -45,6 +45,9 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+/**
+ * Tests for motions using the Grid Helper
+ */
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class MotionGridTest {
@@ -76,10 +79,10 @@ class MotionGridTest {
             {
                 ConstraintSets: {
                   start: {
-                    grid1: { 
+                    grid1: {
                         width: 200,
                         height: 200,
-                        type: "Grid",
+                        type: "grid",
                         orientation: 0,
                         rows: 0,
                         columns: 1,
@@ -93,10 +96,10 @@ class MotionGridTest {
                       }
                   },
                   end: {
-                    grid2: { 
+                    grid2: {
                         width: 200,
                         height: 200,
-                        type: "Grid",
+                        type: "grid",
                         orientation: 0,
                         rows: 1,
                         columns: 0,
@@ -145,11 +148,11 @@ class MotionGridTest {
         expectedX += hGapSize
         expectedY += vGapSize
         rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX, expectedY)
-        expectedY += vGapSize + vGapSize + 10.dp;
-        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX , expectedY)
-        expectedY += vGapSize + vGapSize + 10.dp;
+        expectedY += vGapSize + vGapSize + 10.dp
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp
         rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
-        expectedY += vGapSize + vGapSize + 10.dp;
+        expectedY += vGapSize + vGapSize + 10.dp
         rule.onNodeWithTag("box4").assertPositionInRootIsEqualTo(expectedX, expectedY)
 
         animateToEnd = true
@@ -165,11 +168,11 @@ class MotionGridTest {
         expectedX += hGapSize
         expectedY += vGapSize
         rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX, expectedY)
-        expectedX += hGapSize + hGapSize + 10.dp;
-        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX , expectedY)
-        expectedX += hGapSize + hGapSize + 10.dp;
+        expectedX += hGapSize + hGapSize + 10.dp
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp
         rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
-        expectedX += hGapSize + hGapSize + 10.dp;
+        expectedX += hGapSize + hGapSize + 10.dp
         rule.onNodeWithTag("box4").assertPositionInRootIsEqualTo(expectedX, expectedY)
     }
 
@@ -184,7 +187,7 @@ class MotionGridTest {
         val vGapVal = Math.round(vGap.value)
         rule.setContent {
             val progress by animateFloatAsState(targetValue = if (animateToEnd) 1f else 0f)
-            
+
             MotionLayout(
                 modifier = Modifier
                     .size(rootSize),
@@ -193,10 +196,10 @@ class MotionGridTest {
             {
                 ConstraintSets: {
                   start: {
-                    grid1: { 
+                    grid1: {
                         width: 200,
                         height: 200,
-                        type: "Grid",
+                        type: "grid",
                         orientation: 0,
                         rows: 2,
                         columns: 2,
@@ -206,10 +209,10 @@ class MotionGridTest {
                       }
                   },
                   end: {
-                    grid2: { 
+                    grid2: {
                         width: 200,
                         height: 200,
-                        type: "Grid",
+                        type: "grid",
                         orientation: 0,
                         rows: 2,
                         columns: 2,
@@ -262,8 +265,8 @@ class MotionGridTest {
         val columns = 2
         var leftX = 0.dp
         var topY = 0.dp
-        var rightX = 0.dp
-        var bottomY = 0.dp
+        var rightX: Dp
+        var bottomY: Dp
 
         // 10.dp is the size of a singular box
         val gapSize = (rootSize - (10.dp * 2f)) / (columns * 2f)

--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/MotionParserTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/MotionParserTest.kt
@@ -66,7 +66,7 @@ internal class MotionParserTest {
     @Test
     fun testTransitionParseFailsSilently() {
         // We don't want applications to hard-crash when the parser sees an error
-        var coreTransition = androidx.constraintlayout.core.state.Transition()
+        var coreTransition = androidx.constraintlayout.core.state.Transition { dp -> dp }
         val transitionContent = """
             {
               from: "start",
@@ -82,9 +82,9 @@ internal class MotionParserTest {
         """.trimIndent()
         // Parsing transition throws an exception but the Composable should not crash the app
         assertFailsWith<CLParsingException> {
-            TransitionParser.parse(CLParser.parse(transitionContent), coreTransition) { dp -> dp }
+            TransitionParser.parse(CLParser.parse(transitionContent), coreTransition)
         }
-        coreTransition = androidx.constraintlayout.core.state.Transition()
+        coreTransition = androidx.constraintlayout.core.state.Transition { dp -> dp }
         rule.setContent {
             val transition = Transition(content = transitionContent)
             MotionLayout(

--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/OnSwipeTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/OnSwipeTest.kt
@@ -39,6 +39,7 @@ import androidx.test.filters.MediumTest
 import kotlin.math.roundToInt
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -59,11 +60,13 @@ class OnSwipeTest {
         isDebugInspectorInfoEnabled = false
     }
 
+    @Ignore("Fails on online devices, box left position is 48 instead of 51.6")
     @Test
     fun simpleCornerToCornerRightSwipe_Json() {
         testMotionLayoutSwipe { OnSwipeTestJson() }
     }
 
+    @Ignore("Fails on online devices, box left position is 48 instead of 51.6")
     @Test
     fun simpleCornerToCornerRightSwipe_Dsl() {
         testMotionLayoutSwipe { OnSwipeTestDsl() }

--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/RowColumnTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/RowColumnTest.kt
@@ -16,7 +16,6 @@
 
 package androidx.constraintlayout.compose
 
-import android.content.Context
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
@@ -38,6 +37,9 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+/**
+ * Tests for the Grid Helper (Row / Column)
+ */
 @MediumTest
 @RunWith(AndroidJUnit4::class)
 class RowColumnTest {
@@ -58,12 +60,10 @@ class RowColumnTest {
     fun testRows() {
         val rootSize = 200.dp
         val boxesCount = 4
-        val rows = 0
-        val columns = 1
         rule.setContent {
             RowColumnComposableTest(
                 modifier = Modifier.size(rootSize),
-                type = "'Row'",
+                type = "'row'",
                 width = "'parent'",
                 height = "'parent'",
                 boxesCount = boxesCount,
@@ -86,11 +86,11 @@ class RowColumnTest {
         expectedX += hGapSize
         expectedY += vGapSize
         rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedX, expectedY)
-        expectedY += vGapSize + vGapSize + 10.dp;
-        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX , expectedY)
-        expectedY += vGapSize + vGapSize + 10.dp;
+        expectedY += vGapSize + vGapSize + 10.dp
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp
         rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX, expectedY)
-        expectedY += vGapSize + vGapSize + 10.dp;
+        expectedY += vGapSize + vGapSize + 10.dp
         rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
     }
 
@@ -98,12 +98,10 @@ class RowColumnTest {
     fun testColumns() {
         val rootSize = 200.dp
         val boxesCount = 4
-        val rows = 1
-        val columns = 0
         rule.setContent {
             RowColumnComposableTest(
                 modifier = Modifier.size(rootSize),
-                type = "'Column'",
+                type = "'column'",
                 width = "'parent'",
                 height = "'parent'",
                 boxesCount = boxesCount,
@@ -126,11 +124,11 @@ class RowColumnTest {
         expectedX += hGapSize
         expectedY += vGapSize
         rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedX, expectedY)
-        expectedX += hGapSize + hGapSize + 10.dp;
-        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX , expectedY)
-        expectedX += hGapSize + hGapSize + 10.dp;
+        expectedX += hGapSize + hGapSize + 10.dp
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp
         rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX, expectedY)
-        expectedX += hGapSize + hGapSize + 10.dp;
+        expectedX += hGapSize + hGapSize + 10.dp
         rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
     }
 

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ChainConstrainScope.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ChainConstrainScope.kt
@@ -18,76 +18,70 @@ package androidx.constraintlayout.compose
 
 import androidx.compose.foundation.layout.LayoutScopeMarker
 import androidx.compose.runtime.Stable
-import androidx.constraintlayout.core.state.ConstraintReference
+import androidx.constraintlayout.core.parser.CLObject
 
 @LayoutScopeMarker
 @Stable
-class HorizontalChainScope internal constructor(internal val id: Any) {
-    internal val tasks = mutableListOf<(State) -> Unit>()
-
+class HorizontalChainScope internal constructor(
+    internal val id: Any,
+    containerObject: CLObject
+) {
     /**
      * Reference to the [ConstraintLayout] itself, which can be used to specify constraints
      * between itself and its children.
      */
-    val parent = ConstrainedLayoutReference(SolverState.PARENT)
+    val parent = ConstrainedLayoutReference("parent")
 
     /**
      * The start anchor of the chain - can be constrained using [VerticalAnchorable.linkTo].
      */
-    val start: VerticalAnchorable = ChainVerticalAnchorable(tasks, id, -2)
+    val start: VerticalAnchorable = ChainVerticalAnchorable(containerObject, -2)
 
     /**
      * The left anchor of the chain - can be constrained using [VerticalAnchorable.linkTo].
      */
-    val absoluteLeft: VerticalAnchorable = ChainVerticalAnchorable(tasks, id, 0)
+    val absoluteLeft: VerticalAnchorable = ChainVerticalAnchorable(containerObject, 0)
 
     /**
      * The end anchor of the chain - can be constrained using [VerticalAnchorable.linkTo].
      */
-    val end: VerticalAnchorable = ChainVerticalAnchorable(tasks, id, -1)
+    val end: VerticalAnchorable = ChainVerticalAnchorable(containerObject, -1)
 
     /**
      * The right anchor of the chain - can be constrained using [VerticalAnchorable.linkTo].
      */
-    val absoluteRight: VerticalAnchorable = ChainVerticalAnchorable(tasks, id, 1)
+    val absoluteRight: VerticalAnchorable = ChainVerticalAnchorable(containerObject, 1)
 }
 
 @LayoutScopeMarker
 @Stable
-class VerticalChainScope internal constructor(internal val id: Any) {
-    internal val tasks = mutableListOf<(State) -> Unit>()
-
+class VerticalChainScope internal constructor(
+    internal val id: Any,
+    containerObject: CLObject
+) {
     /**
      * Reference to the [ConstraintLayout] itself, which can be used to specify constraints
      * between itself and its children.
      */
-    val parent = ConstrainedLayoutReference(SolverState.PARENT)
+    val parent = ConstrainedLayoutReference("parent")
 
     /**
      * The top anchor of the chain - can be constrained using [HorizontalAnchorable.linkTo].
      */
-    val top: HorizontalAnchorable = ChainHorizontalAnchorable(tasks, id, 0)
+    val top: HorizontalAnchorable = ChainHorizontalAnchorable(containerObject, 0)
 
     /**
      * The bottom anchor of the chain - can be constrained using [HorizontalAnchorable.linkTo].
      */
-    val bottom: HorizontalAnchorable = ChainHorizontalAnchorable(tasks, id, 1)
+    val bottom: HorizontalAnchorable = ChainHorizontalAnchorable(containerObject, 1)
 }
 
 private class ChainVerticalAnchorable constructor(
-    tasks: MutableList<(State) -> Unit>,
-    private val id: Any,
+    containerObject: CLObject,
     index: Int
-) : BaseVerticalAnchorable(tasks, index) {
-    override fun getConstraintReference(state: State): ConstraintReference =
-        state.helper(id, androidx.constraintlayout.core.state.State.Helper.HORIZONTAL_CHAIN)
-}
+) : BaseVerticalAnchorable(containerObject, index)
 
 private class ChainHorizontalAnchorable constructor(
-    tasks: MutableList<(State) -> Unit>,
-    private val id: Any,
+    containerObject: CLObject,
     index: Int
-) : BaseHorizontalAnchorable(tasks, index) {
-    override fun getConstraintReference(state: State): ConstraintReference =
-        state.helper(id, androidx.constraintlayout.core.state.State.Helper.VERTICAL_CHAIN)
-}
+) : BaseHorizontalAnchorable(containerObject, index)

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstrainScope.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstrainScope.kt
@@ -22,10 +22,13 @@ import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.layout.FirstBaseline
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import androidx.constraintlayout.compose.AnchorFunctions.baselineAnchorFunction
-import androidx.constraintlayout.core.state.ConstraintReference
+import androidx.constraintlayout.core.parser.CLArray
+import androidx.constraintlayout.core.parser.CLNumber
+import androidx.constraintlayout.core.parser.CLObject
+import androidx.constraintlayout.core.parser.CLString
+import kotlin.properties.ObservableProperty
+import kotlin.reflect.KProperty
 
 /**
  * Scope that can be used to constrain a layout.
@@ -35,96 +38,75 @@ import androidx.constraintlayout.core.state.ConstraintReference
  */
 @LayoutScopeMarker
 @Stable
-class ConstrainScope internal constructor(internal val id: Any) {
-    internal val tasks = mutableListOf<(State) -> Unit>()
-    internal fun applyTo(state: State) = tasks.forEach { it(state) }
-
+class ConstrainScope internal constructor(
+    internal val id: Any,
+    internal val containerObject: CLObject
+) {
     /**
      * Reference to the [ConstraintLayout] itself, which can be used to specify constraints
      * between itself and its children.
      */
-    val parent = ConstrainedLayoutReference(SolverState.PARENT)
+    val parent = ConstrainedLayoutReference("parent")
 
     /**
      * The start anchor of the layout - can be constrained using [VerticalAnchorable.linkTo].
      */
-    val start: VerticalAnchorable = ConstraintVerticalAnchorable(id, -2, tasks)
+    val start: VerticalAnchorable = ConstraintVerticalAnchorable(-2, containerObject)
 
     /**
      * The left anchor of the layout - can be constrained using [VerticalAnchorable.linkTo].
      */
-    val absoluteLeft: VerticalAnchorable = ConstraintVerticalAnchorable(id, 0, tasks)
+    val absoluteLeft: VerticalAnchorable = ConstraintVerticalAnchorable(0, containerObject)
 
     /**
      * The top anchor of the layout - can be constrained using [HorizontalAnchorable.linkTo].
      */
-    val top: HorizontalAnchorable = ConstraintHorizontalAnchorable(id, 0, tasks)
+    val top: HorizontalAnchorable = ConstraintHorizontalAnchorable(0, containerObject)
 
     /**
      * The end anchor of the layout - can be constrained using [VerticalAnchorable.linkTo].
      */
-    val end: VerticalAnchorable = ConstraintVerticalAnchorable(id, -1, tasks)
+    val end: VerticalAnchorable = ConstraintVerticalAnchorable(-1, containerObject)
 
     /**
      * The right anchor of the layout - can be constrained using [VerticalAnchorable.linkTo].
      */
-    val absoluteRight: VerticalAnchorable = ConstraintVerticalAnchorable(id, 1, tasks)
+    val absoluteRight: VerticalAnchorable = ConstraintVerticalAnchorable(1, containerObject)
 
     /**
      * The bottom anchor of the layout - can be constrained using [HorizontalAnchorable.linkTo].
      */
-    val bottom: HorizontalAnchorable = ConstraintHorizontalAnchorable(id, 1, tasks)
+    val bottom: HorizontalAnchorable = ConstraintHorizontalAnchorable(1, containerObject)
 
     /**
      * The [FirstBaseline] of the layout - can be constrained using [BaselineAnchorable.linkTo].
      */
-    val baseline: BaselineAnchorable = ConstraintBaselineAnchorable(id, tasks)
+    val baseline: BaselineAnchorable = ConstraintBaselineAnchorable(containerObject)
 
     /**
      * The width of the [ConstraintLayout] child.
      */
-    var width: Dimension = Dimension.wrapContent
-        set(value) {
-            field = value
-            tasks.add { state ->
-                state.constraints(id).width(
-                    (value as DimensionDescription).toSolverDimension(state)
-                )
-            }
-        }
+    var width: Dimension by DimensionProperty(Dimension.wrapContent)
 
     /**
      * The height of the [ConstraintLayout] child.
      */
-    var height: Dimension = Dimension.wrapContent
-        set(value) {
-            field = value
-            tasks.add { state ->
-                state.constraints(id).height(
-                    (value as DimensionDescription).toSolverDimension(state)
-                )
-            }
-        }
+    var height: Dimension by DimensionProperty(Dimension.wrapContent)
 
     /**
      * The overall visibility of the [ConstraintLayout] child.
      *
      * [Visibility.Visible] by default.
      */
-    var visibility: Visibility = Visibility.Visible
-        set(value) {
-            field = value
-            tasks.add { state ->
-                with(state.constraints(id)) {
-                    visibility(value.solverValue)
-                    if (value == Visibility.Invisible) {
-                        // A bit of a hack, this behavior is not defined in :core
-                        // Invisible should override alpha
-                        alpha(0f)
-                    }
-                }
-            }
+    var visibility: Visibility by object : ObservableProperty<Visibility>(Visibility.Visible) {
+        override fun afterChange(
+            property: KProperty<*>,
+            oldValue: Visibility,
+            newValue: Visibility
+        ) {
+            containerObject.putString(property.name, newValue.name)
         }
+    }
 
     /**
      * The transparency value when rendering the content.
@@ -132,12 +114,11 @@ class ConstrainScope internal constructor(internal val id: Any) {
     @FloatRange(from = 0.0, to = 1.0)
     var alpha: Float = 1.0f
         set(value) {
-            field = value
-            addTransform {
-                if (visibility != Visibility.Invisible) {
-                    // A bit of a hack, this behavior is not defined in :core
-                    // Invisible should override alpha
-                    alpha(value)
+            // Not using delegate to support FloatRange annotation
+            if (value != field) {
+                field = value
+                if (!value.isNaN()) {
+                    containerObject.putNumber("alpha", value)
                 }
             }
         }
@@ -145,128 +126,110 @@ class ConstrainScope internal constructor(internal val id: Any) {
     /**
      * The percent scaling value on the horizontal axis. Where 1 is 100%.
      */
-    var scaleX: Float = 1.0f
-        set(value) {
-            field = value
-            addTransform { scaleX(value) }
-        }
+    var scaleX: Float by FloatProperty(1.0f)
 
     /**
      * The percent scaling value on the vertical axis. Where 1 is 100%.
      */
-    var scaleY: Float = 1.0f
-        set(value) {
-            field = value
-            addTransform { scaleY(value) }
-        }
+    var scaleY: Float by FloatProperty(1.0f)
 
     /**
      * The degrees to rotate the content over the horizontal axis.
      */
-    var rotationX: Float = 0.0f
-        set(value) {
-            field = value
-            addTransform { rotationX(value) }
-        }
+    var rotationX: Float by FloatProperty(0.0f)
 
     /**
      * The degrees to rotate the content over the vertical axis.
      */
-    var rotationY: Float = 0.0f
-        set(value) {
-            field = value
-            addTransform { rotationY(value) }
-        }
+    var rotationY: Float by FloatProperty(0.0f)
 
     /**
      * The degrees to rotate the content on the screen plane.
      */
-    var rotationZ: Float = 0.0f
-        set(value) {
-            field = value
-            addTransform { rotationZ(value) }
-        }
+    var rotationZ: Float by FloatProperty(0.0f)
 
     /**
      * The distance to offset the content over the X axis.
      */
-    var translationX: Dp = 0.dp
-        set(value) {
-            field = value
-            addFloatTransformFromDp(value) { floatValue -> translationX(floatValue) }
-        }
+    var translationX: Dp by DpProperty(0.dp)
 
     /**
      * The distance to offset the content over the Y axis.
      */
-    var translationY: Dp = 0.dp
-        set(value) {
-            field = value
-            addFloatTransformFromDp(value) { floatValue -> translationY(floatValue) }
-        }
+    var translationY: Dp by DpProperty(0.dp)
 
     /**
      * The distance to offset the content over the Z axis.
      */
-    var translationZ: Dp = 0.dp
-        set(value) {
-            field = value
-            addFloatTransformFromDp(value) { floatValue -> translationZ(floatValue) }
-        }
+    var translationZ: Dp by DpProperty(0.dp)
 
     /**
      * The X axis offset percent where the content is rotated and scaled.
      *
      * @see [TransformOrigin]
      */
-    var pivotX: Float = 0.5f
-        set(value) {
-            field = value
-            addTransform { pivotX(value) }
-        }
+    var pivotX: Float by FloatProperty(0.5f)
 
     /**
      * The Y axis offset percent where the content is rotated and scaled.
      *
      * @see [TransformOrigin]
      */
-    var pivotY: Float = 0.5f
-        set(value) {
-            field = value
-            addTransform { pivotY(value) }
-        }
+    var pivotY: Float by FloatProperty(0.5f)
 
     /**
      * Whenever the width is not fixed, this weight may be used by an horizontal Chain to decide how
      * much space assign to this widget.
      */
-    var horizontalChainWeight: Float = Float.NaN
-        set(value) {
-            field = value
-            tasks.add { state ->
-                state.constraints(id).horizontalChainWeight = value
-            }
-        }
+    var horizontalChainWeight: Float by FloatProperty(Float.NaN, "hWeight")
 
     /**
      * Whenever the height is not fixed, this weight may be used by a vertical Chain to decide how
      * much space assign to this widget.
      */
-    var verticalChainWeight: Float = Float.NaN
+    var verticalChainWeight: Float by FloatProperty(Float.NaN, "vWeight")
+
+    /**
+     * Applied when the widget has constraints on the [start] and [end] anchors. It defines the
+     * position of the widget relative to the space within the constraints, where `0f` is the
+     * left-most position and `1f` is the right-most position.
+     *
+     * &nbsp;
+     *
+     * When layout direction is RTL, the value of the bias is effectively inverted.
+     *
+     * E.g.: For `horizontalBias = 0.3f`, `0.7f` is used for RTL.
+     *
+     * &nbsp;
+     *
+     * Note that the bias may also be applied with calls such as [linkTo].
+     */
+    @FloatRange(from = 0.0, to = 1.0)
+    var horizontalBias: Float = 0.5f
         set(value) {
-            field = value
-            tasks.add { state ->
-                state.constraints(id).verticalChainWeight = value
+            // Not using delegate to support FloatRange annotation
+            if (value != field) {
+                field = value
+                if (!value.isNaN()) {
+                    containerObject.putNumber("hBias", value)
+                }
             }
         }
 
-    private fun addTransform(change: ConstraintReference.() -> Unit) =
-        tasks.add { state -> change(state.constraints(id)) }
-
-    private fun addFloatTransformFromDp(dpValue: Dp, change: ConstraintReference.(Float) -> Unit) =
-        tasks.add { state ->
-            (state as? State)?.also {
-                state.constraints(id).change(state.convertDimension(dpValue).toFloat())
+    /**
+     * Applied when the widget has constraints on the [top] and [bottom] anchors. It defines the
+     * position of the widget relative to the space within the constraints, where `0f` is the
+     * top-most position and `1f` is the bottom-most position.
+     */
+    @FloatRange(from = 0.0, to = 1.0)
+    var verticalBias: Float = 0.5f
+        set(value) {
+            // Not using delegate to support FloatRange annotation
+            if (value != field) {
+                field = value
+                if (!value.isNaN()) {
+                    containerObject.putNumber("vBias", value)
+                }
             }
         }
 
@@ -287,11 +250,12 @@ class ConstrainScope internal constructor(internal val id: Any) {
             margin = startMargin,
             goneMargin = startGoneMargin
         )
-        this@ConstrainScope.end.linkTo(anchor = end, margin = endMargin, goneMargin = endGoneMargin)
-        tasks.add { state ->
-            val resolvedBias = if (state.layoutDirection == LayoutDirection.Rtl) 1 - bias else bias
-            state.constraints(id).horizontalBias(resolvedBias)
-        }
+        this@ConstrainScope.end.linkTo(
+            anchor = end,
+            margin = endMargin,
+            goneMargin = endGoneMargin
+        )
+        containerObject.putNumber("hRtlBias", bias)
     }
 
     /**
@@ -306,15 +270,17 @@ class ConstrainScope internal constructor(internal val id: Any) {
         bottomGoneMargin: Dp = 0.dp,
         @FloatRange(from = 0.0, to = 1.0) bias: Float = 0.5f
     ) {
-        this@ConstrainScope.top.linkTo(anchor = top, margin = topMargin, goneMargin = topGoneMargin)
+        this@ConstrainScope.top.linkTo(
+            anchor = top,
+            margin = topMargin,
+            goneMargin = topGoneMargin
+        )
         this@ConstrainScope.bottom.linkTo(
             anchor = bottom,
             margin = bottomMargin,
             goneMargin = bottomGoneMargin
         )
-        tasks.add { state ->
-            state.constraints(id).verticalBias(bias)
-        }
+        containerObject.putNumber("vBias", bias)
     }
 
     /**
@@ -410,10 +376,12 @@ class ConstrainScope internal constructor(internal val id: Any) {
      * This will position the current widget at a relative angle and distance from [other].
      */
     fun circular(other: ConstrainedLayoutReference, angle: Float, distance: Dp) {
-        tasks.add { state ->
-            state.constraints(id)
-                .circularConstraint(other.id, angle, state.convertDimension(distance).toFloat())
+        val circularParams = CLArray(charArrayOf()).apply {
+            add(CLString.from(other.id.toString()))
+            add(CLNumber(angle))
+            add(CLNumber(distance.value))
         }
+        containerObject.put("circular", circularParams)
     }
 
     /**
@@ -422,9 +390,10 @@ class ConstrainScope internal constructor(internal val id: Any) {
      * Useful when extending another [ConstraintSet] with unwanted constraints on this axis.
      */
     fun clearHorizontal() {
-        tasks.add { state ->
-            state.constraints(id).clearHorizontal()
-        }
+        containerObject.remove("left")
+        containerObject.remove("right")
+        containerObject.remove("start")
+        containerObject.remove("end")
     }
 
     /**
@@ -433,9 +402,9 @@ class ConstrainScope internal constructor(internal val id: Any) {
      * Useful when extending another [ConstraintSet] with unwanted constraints on this axis.
      */
     fun clearVertical() {
-        tasks.add { state ->
-            state.constraints(id).clearVertical()
-        }
+        containerObject.remove("top")
+        containerObject.remove("bottom")
+        containerObject.remove("baseline")
     }
 
     /**
@@ -444,9 +413,9 @@ class ConstrainScope internal constructor(internal val id: Any) {
      * Useful when extending another [ConstraintSet] with unwanted constraints applied.
      */
     fun clearConstraints() {
-        tasks.add { state ->
-            state.constraints(id).clearAll()
-        }
+        clearHorizontal()
+        clearVertical()
+        containerObject.remove("circular")
     }
 
     /**
@@ -455,13 +424,8 @@ class ConstrainScope internal constructor(internal val id: Any) {
      * Useful when extending another [ConstraintSet] with unwanted dimensions.
      */
     fun resetDimensions() {
-        tasks.add { state ->
-            val defaultDimension =
-                (Dimension.wrapContent as DimensionDescription).toSolverDimension(state)
-            state.constraints(id)
-                .width(defaultDimension)
-                .height(defaultDimension)
-        }
+        width = Dimension.wrapContent
+        height = Dimension.wrapContent
     }
 
     /**
@@ -472,19 +436,45 @@ class ConstrainScope internal constructor(internal val id: Any) {
      * Useful when extending another [ConstraintSet] with unwanted transforms applied.
      */
     fun resetTransforms() {
-        tasks.add { state ->
-            state.constraints(id)
-                .alpha(Float.NaN)
-                .scaleX(Float.NaN)
-                .scaleY(Float.NaN)
-                .rotationX(Float.NaN)
-                .rotationY(Float.NaN)
-                .rotationZ(Float.NaN)
-                .translationX(Float.NaN)
-                .translationY(Float.NaN)
-                .translationZ(Float.NaN)
-                .pivotX(Float.NaN)
-                .pivotY(Float.NaN)
+        containerObject.remove("alpha")
+        containerObject.remove("scaleX")
+        containerObject.remove("scaleY")
+        containerObject.remove("rotationX")
+        containerObject.remove("rotationY")
+        containerObject.remove("rotationZ")
+        containerObject.remove("translationX")
+        containerObject.remove("translationY")
+        containerObject.remove("translationZ")
+        containerObject.remove("pivotX")
+        containerObject.remove("pivotY")
+    }
+
+    private inner class DimensionProperty(initialValue: Dimension) :
+        ObservableProperty<Dimension>(initialValue) {
+        override fun afterChange(property: KProperty<*>, oldValue: Dimension, newValue: Dimension) {
+            containerObject.put(property.name, (newValue as DimensionDescription).asCLElement())
+        }
+    }
+
+    private inner class FloatProperty(
+        initialValue: Float,
+        private val nameOverride: String? = null
+    ) : ObservableProperty<Float>(initialValue) {
+        override fun afterChange(property: KProperty<*>, oldValue: Float, newValue: Float) {
+            if (!newValue.isNaN()) {
+                containerObject.putNumber(nameOverride ?: property.name, newValue)
+            }
+        }
+    }
+
+    private inner class DpProperty(
+        initialValue: Dp,
+        private val nameOverride: String? = null
+    ) : ObservableProperty<Dp>(initialValue) {
+        override fun afterChange(property: KProperty<*>, oldValue: Dp, newValue: Dp) {
+            if (!newValue.value.isNaN()) {
+                containerObject.putNumber(nameOverride ?: property.name, newValue.value)
+            }
         }
     }
 }
@@ -494,34 +484,25 @@ class ConstrainScope internal constructor(internal val id: Any) {
  * [linkTo] in their `Modifier.constrainAs` blocks.
  */
 private class ConstraintVerticalAnchorable constructor(
-    val id: Any,
     index: Int,
-    tasks: MutableList<(State) -> Unit>
-) : BaseVerticalAnchorable(tasks, index) {
-    override fun getConstraintReference(state: State): ConstraintReference =
-        state.constraints(id)
-}
+    containerObject: CLObject
+) : BaseVerticalAnchorable(containerObject, index)
 
 /**
  * Represents a horizontal side of a layout (i.e top and bottom) that can be anchored using
  * [linkTo] in their `Modifier.constrainAs` blocks.
  */
 private class ConstraintHorizontalAnchorable constructor(
-    val id: Any,
     index: Int,
-    tasks: MutableList<(State) -> Unit>
-) : BaseHorizontalAnchorable(tasks, index) {
-    override fun getConstraintReference(state: State): ConstraintReference =
-        state.constraints(id)
-}
+    containerObject: CLObject
+) : BaseHorizontalAnchorable(containerObject, index)
 
 /**
  * Represents the [FirstBaseline] of a layout that can be anchored
  * using [linkTo] in their `Modifier.constrainAs` blocks.
  */
 private class ConstraintBaselineAnchorable constructor(
-    val id: Any,
-    val tasks: MutableList<(State) -> Unit>
+    private val containerObject: CLObject
 ) : BaselineAnchorable {
     /**
      * Adds a link towards a [ConstraintLayoutBaseScope.BaselineAnchor].
@@ -531,14 +512,12 @@ private class ConstraintBaselineAnchorable constructor(
         margin: Dp,
         goneMargin: Dp
     ) {
-        tasks.add { state ->
-            (state as? State)?.let {
-                it.baselineNeededFor(id)
-                it.baselineNeededFor(anchor.id)
-            }
-            with(state.constraints(id)) {
-                baselineAnchorFunction.invoke(this, anchor.id).margin(margin).marginGone(goneMargin)
-            }
+        val constraintArray = CLArray(charArrayOf()).apply {
+            add(CLString.from(anchor.id.toString()))
+            add(CLString.from("baseline"))
+            add(CLNumber(margin.value))
+            add(CLNumber(goneMargin.value))
         }
+        containerObject.put("baseline", constraintArray)
     }
 }

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayout.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayout.kt
@@ -57,12 +57,12 @@ import androidx.compose.ui.layout.FirstBaseline
 import androidx.compose.ui.layout.LayoutIdParentData
 import androidx.compose.ui.layout.Measurable
 import androidx.compose.ui.layout.MeasurePolicy
-import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.layout.MultiMeasureLayout
 import androidx.compose.ui.layout.ParentDataModifier
 import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.platform.InspectorValueInfo
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.debugInspectorInfo
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.semantics
@@ -78,11 +78,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastForEachIndexed
+import androidx.constraintlayout.core.parser.CLElement
+import androidx.constraintlayout.core.parser.CLNumber
 import androidx.constraintlayout.core.parser.CLObject
 import androidx.constraintlayout.core.parser.CLParser
 import androidx.constraintlayout.core.parser.CLParsingException
+import androidx.constraintlayout.core.parser.CLString
 import androidx.constraintlayout.core.state.ConstraintSetParser
-import androidx.constraintlayout.core.state.Dimension.SPREAD_DIMENSION
 import androidx.constraintlayout.core.state.Dimension.WRAP_DIMENSION
 import androidx.constraintlayout.core.state.Registry
 import androidx.constraintlayout.core.state.RegistryCallback
@@ -114,7 +116,8 @@ inline fun ConstraintLayout(
     optimizationLevel: Int = Optimizer.OPTIMIZATION_STANDARD,
     crossinline content: @Composable ConstraintLayoutScope.() -> Unit
 ) {
-    val measurer = remember { Measurer() }
+    val density = LocalDensity.current
+    val measurer = remember { Measurer(density) }
     val scope = remember { ConstraintLayoutScope() }
     val remeasureRequesterState = remember { mutableStateOf(false) }
     val (measurePolicy, onHelpersChanged) = rememberConstraintLayoutMeasurePolicy(
@@ -131,7 +134,12 @@ inline fun ConstraintLayout(
             val previousHelpersHashCode = scope.helpersHashCode
             scope.reset()
             scope.content()
-            if (scope.helpersHashCode != previousHelpersHashCode) onHelpersChanged()
+            if (scope.helpersHashCode != previousHelpersHashCode) {
+                // onHelpersChanged writes non-snapshot state so it can't be called directly from
+                // composition. It also reads snapshot state, so calling it from composition causes
+                // an extra recomposition.
+                SideEffect(onHelpersChanged)
+            }
         }
     )
 }
@@ -153,8 +161,7 @@ internal fun rememberConstraintLayoutMeasurePolicy(
                 layoutDirection,
                 constraintSet,
                 measurables,
-                optimizationLevel,
-                this
+                optimizationLevel
             )
             // We read the remeasurement requester state, to request remeasure when the value
             // changes. This will happen when the scope helpers are changing at recomposition.
@@ -190,19 +197,20 @@ private class ConstraintSetForInlineDsl(
     }
 
     override fun applyTo(state: State, measurables: List<Measurable>) {
-        scope.applyTo(state)
         previousDatas.clear()
         observer.observeReads(Unit, onCommitAffectingConstrainLambdas) {
             measurables.fastForEach { measurable ->
                 val parentData = measurable.parentData as? ConstraintLayoutParentData
                 // Run the constrainAs block of the child, to obtain its constraints.
                 if (parentData != null) {
-                    val constrainScope = ConstrainScope(parentData.ref.id)
+                    val ref = parentData.ref
+                    val container = with(scope) { ref.asCLContainer() }
+                    val constrainScope = ConstrainScope(ref.id, container)
                     parentData.constrain(constrainScope)
-                    constrainScope.applyTo(state)
                 }
                 previousDatas.add(parentData)
             }
+            scope.applyTo(state)
         }
         knownDirty = false
     }
@@ -296,7 +304,8 @@ inline fun ConstraintLayout(
             mutableStateOf(0L)
         }
 
-        val measurer = remember { Measurer() }
+        val density = LocalDensity.current
+        val measurer = remember { Measurer(density) }
         val measurePolicy = rememberConstraintLayoutMeasurePolicy(
             optimizationLevel,
             needsUpdate,
@@ -354,8 +363,7 @@ internal fun rememberConstraintLayoutMeasurePolicy(
             layoutDirection,
             constraintSet,
             measurables,
-            optimizationLevel,
-            this
+            optimizationLevel
         )
         layout(layoutSize.width, layoutSize.height) {
             with(measurer) { performLayout(measurables) }
@@ -367,7 +375,7 @@ internal fun rememberConstraintLayoutMeasurePolicy(
  * Scope used by the inline DSL of [ConstraintLayout].
  */
 @LayoutScopeMarker
-class ConstraintLayoutScope @PublishedApi internal constructor() : ConstraintLayoutBaseScope() {
+class ConstraintLayoutScope @PublishedApi internal constructor() : ConstraintLayoutBaseScope(null) {
     /**
      * Creates one [ConstrainedLayoutReference], which needs to be assigned to a layout within the
      * [ConstraintLayout] as part of [Modifier.constrainAs]. To create more references at the
@@ -452,7 +460,8 @@ class ConstraintLayoutScope @PublishedApi internal constructor() : ConstraintLay
  * Scope used by the [ConstraintSet] DSL.
  */
 @LayoutScopeMarker
-class ConstraintSetScope internal constructor() : ConstraintLayoutBaseScope() {
+class ConstraintSetScope internal constructor(extendFrom: CLObject?) :
+    ConstraintLayoutBaseScope(extendFrom) {
     /**
      * Creates one [ConstrainedLayoutReference] corresponding to the [ConstraintLayout] element
      * with [id].
@@ -520,9 +529,8 @@ interface Dimension {
          * be used instead.
          */
         fun preferredValue(dp: Dp): Dimension.MinCoercible =
-            DimensionDescription { state ->
-                SolverDimension.createSuggested(state.convertDimension(dp))
-                    .suggested(SPREAD_DIMENSION)
+            DimensionDescription("spread").apply {
+                max.update(dp)
             }
 
         /**
@@ -530,9 +538,7 @@ interface Dimension {
          * according to the constraints in the [ConstraintSet].
          */
         fun value(dp: Dp): Dimension =
-            DimensionDescription { state ->
-                SolverDimension.createFixed(state.convertDimension(dp))
-            }
+            DimensionDescription(dp)
 
         /**
          * Sets the dimensions to be defined as a ratio of the width and height. The assigned
@@ -546,7 +552,7 @@ interface Dimension {
          * Note that only one dimension should be defined as a ratio.
          */
         fun ratio(ratio: String): Dimension =
-            DimensionDescription { SolverDimension.createRatio(ratio).suggested(SPREAD_DIMENSION) }
+            DimensionDescription(ratio)
 
         /**
          * Links should be specified from both sides corresponding to this dimension, in order for
@@ -558,21 +564,21 @@ interface Dimension {
          * should be used instead.
          */
         val preferredWrapContent: Dimension.Coercible
-            get() = DimensionDescription { SolverDimension.createSuggested(WRAP_DIMENSION) }
+            get() = DimensionDescription("preferWrap")
 
         /**
          * A fixed [Dimension] with wrap content behavior. The size will not change
          * according to the constraints in the [ConstraintSet].
          */
         val wrapContent: Dimension
-            get() = DimensionDescription { SolverDimension.createFixed(WRAP_DIMENSION) }
+            get() = DimensionDescription("wrap")
 
         /**
          * A fixed [Dimension] that matches the dimensions of the root ConstraintLayout. The size
          * will not change accoring to the constraints in the [ConstraintSet].
          */
         val matchParent: Dimension
-            get() = DimensionDescription { SolverDimension.createParent() }
+            get() = DimensionDescription("parent")
 
         /**
          * Links should be specified from both sides corresponding to this dimension, in order for
@@ -581,14 +587,15 @@ interface Dimension {
          * A [Dimension] that spreads to match constraints.
          */
         val fillToConstraints: Dimension.Coercible
-            get() = DimensionDescription { SolverDimension.createSuggested(SPREAD_DIMENSION) }
+            get() = DimensionDescription("spread")
 
         /**
          * A [Dimension] that is a percent of the parent in the corresponding direction.
+         *
+         * Where 1f is 100% and 0f is 0%.
          */
         fun percent(percent: Float): Dimension =
-            // TODO(popam, b/157880732): make this nicer when possible in future solver releases
-            DimensionDescription { SolverDimension.createPercent(0, percent).suggested(0) }
+            DimensionDescription("${percent * 100f}%")
     }
 }
 
@@ -596,25 +603,25 @@ interface Dimension {
  * Sets the lower bound of the current [Dimension] to be the wrap content size of the child.
  */
 val Dimension.Coercible.atLeastWrapContent: Dimension.MaxCoercible
-    get() = (this as DimensionDescription).also { it.minSymbol = WRAP_DIMENSION }
+    get() = (this as DimensionDescription).also { it.min.update("wrap") }
 
 /**
  * Sets the lower bound of the current [Dimension] to a fixed [dp] value.
  */
 fun Dimension.Coercible.atLeast(dp: Dp): Dimension.MaxCoercible =
-    (this as DimensionDescription).also { it.min = dp }
+    (this as DimensionDescription).also { it.min.update(dp) }
 
 /**
  * Sets the upper bound of the current [Dimension] to a fixed [dp] value.
  */
 fun Dimension.Coercible.atMost(dp: Dp): Dimension.MinCoercible =
-    (this as DimensionDescription).also { it.max = dp }
+    (this as DimensionDescription).also { it.max.update(dp) }
 
 /**
  * Sets the upper bound of the current [Dimension] to be the wrap content size of the child.
  */
 val Dimension.Coercible.atMostWrapContent: Dimension.MinCoercible
-    get() = (this as DimensionDescription).also { it.maxSymbol = WRAP_DIMENSION }
+    get() = (this as DimensionDescription).also { it.max.update("wrap") }
 
 /**
  * Sets the lower bound of the current [Dimension] to a fixed [dp] value.
@@ -627,55 +634,106 @@ val Dimension.Coercible.atMostWrapContent: Dimension.MinCoercible
     )
 )
 fun Dimension.MinCoercible.atLeastWrapContent(dp: Dp): Dimension =
-    (this as DimensionDescription).also { it.min = dp }
+    (this as DimensionDescription).also { it.min.update(dp) }
 
 /**
  * Sets the lower bound of the current [Dimension] to a fixed [dp] value.
  */
 fun Dimension.MinCoercible.atLeast(dp: Dp): Dimension =
-    (this as DimensionDescription).also { it.min = dp }
+    (this as DimensionDescription).also { it.min.update(dp) }
 
 /**
  * Sets the lower bound of the current [Dimension] to be the wrap content size of the child.
  */
 val Dimension.MinCoercible.atLeastWrapContent: Dimension
-    get() = (this as DimensionDescription).also { it.minSymbol = WRAP_DIMENSION }
+    get() = (this as DimensionDescription).also { it.min.update("wrap") }
 
 /**
  * Sets the upper bound of the current [Dimension] to a fixed [dp] value.
  */
 fun Dimension.MaxCoercible.atMost(dp: Dp): Dimension =
-    (this as DimensionDescription).also { it.max = dp }
+    (this as DimensionDescription).also { it.max.update(dp) }
 
 /**
  * Sets the upper bound of the current [Dimension] to be the [WRAP_DIMENSION] size of the child.
  */
 val Dimension.MaxCoercible.atMostWrapContent: Dimension
-    get() = (this as DimensionDescription).also { it.maxSymbol = WRAP_DIMENSION }
+    get() = (this as DimensionDescription).also { it.max.update("wrap") }
 
 /**
  * Describes a sizing behavior that can be applied to the width or height of a
  * [ConstraintLayout] child. The content of this class should not be instantiated
  * directly; helpers available in the [Dimension]'s companion object should be used.
  */
-internal class DimensionDescription internal constructor(
-    private val baseDimension: (State) -> SolverDimension
+internal class DimensionDescription private constructor(
+    value: Dp?,
+    valueSymbol: String?
 ) : Dimension.Coercible, Dimension.MinCoercible, Dimension.MaxCoercible, Dimension {
-    var min: Dp? = null
-    var minSymbol: Any? = null
-    var max: Dp? = null
-    var maxSymbol: Any? = null
-    internal fun toSolverDimension(state: State) = baseDimension(state).also {
-        if (minSymbol != null) {
-            it.min(minSymbol)
-        } else if (min != null) {
-            it.min(state.convertDimension(min!!))
+    constructor(value: Dp) : this(value, null)
+
+    constructor(valueSymbol: String) : this(null, valueSymbol)
+
+    private val valueSymbol = DimensionSymbol(value, valueSymbol, "base")
+    internal val min = DimensionSymbol(null, null, "min")
+    internal val max = DimensionSymbol(null, null, "max")
+
+    /**
+     * Returns the [DimensionDescription] as a [CLElement].
+     *
+     * The specific implementation of the element depends on the properties. If only the base value
+     * is provided, the resulting element will be either [CLString] or [CLNumber], but, if either
+     * the [max] or [min] were defined, it'll return a [CLObject] with the defined properties.
+     */
+    internal fun asCLElement(): CLElement =
+        if (min.isUndefined() && max.isUndefined()) {
+            valueSymbol.asCLElement()
+        } else {
+            CLObject(charArrayOf()).apply {
+                if (!min.isUndefined()) {
+                    put("min", min.asCLElement())
+                }
+                if (!max.isUndefined()) {
+                    put("max", max.asCLElement())
+                }
+                put("value", valueSymbol.asCLElement())
+            }
         }
-        if (maxSymbol != null) {
-            it.max(maxSymbol)
-        } else if (max != null) {
-            it.max(state.convertDimension(max!!))
+}
+
+/**
+ * Dimension that may be represented by either a fixed [Dp] value or a symbol of a specific
+ * behavior (such as "wrap", "spread", "parent", etc).
+ *
+ * [asCLElement] may be used to parse the symbol into it's corresponding [CLElement], depending if
+ * the dimension is represented by a value ([CLNumber]) or a symbol ([CLString]).
+ */
+internal class DimensionSymbol(
+    private var value: Dp?,
+    private var symbol: String?,
+    private val debugName: String
+) {
+    fun update(dp: Dp) {
+        value = dp
+        symbol = null
+    }
+
+    fun update(symbol: String) {
+        value = null
+        this.symbol = symbol
+    }
+
+    fun isUndefined() = value == null && symbol == null
+
+    fun asCLElement(): CLElement {
+        value?.let {
+            return CLNumber(it.value)
         }
+        symbol?.let {
+            return CLString.from(it)
+        }
+        // No valid element to return, default to wrapContent
+        Log.e("CCL", "DimensionDescription: Null value & symbol for $debugName. Using WrapContent.")
+        return CLString.from("wrap")
     }
 }
 
@@ -917,7 +975,8 @@ fun ConstraintSet(
  */
 class State(val density: Density) : SolverState() {
     var rootIncomingConstraints: Constraints = Constraints()
-    lateinit var layoutDirection: LayoutDirection
+    @Deprecated("Use #isLtr instead")
+    var layoutDirection: LayoutDirection = LayoutDirection.Ltr
 
     init {
         setDpToPixel { dp -> density.density * dp }
@@ -929,10 +988,6 @@ class State(val density: Density) : SolverState() {
         } else {
             super.convertDimension(value)
         }
-    }
-
-    override fun reset() {
-        super.reset()
     }
 
     internal fun getKeyId(helperWidget: HelperWidget): Any? {
@@ -962,7 +1017,9 @@ interface LayoutInformationReceiver {
 }
 
 @PublishedApi
-internal open class Measurer : BasicMeasure.Measurer, DesignInfoProvider {
+internal open class Measurer(
+    density: Density // TODO: Change to a variable since density may change
+) : BasicMeasure.Measurer, DesignInfoProvider {
     private var computedLayoutResult: String = ""
     protected var layoutInformationReceiver: LayoutInformationReceiver? = null
     protected val root = ConstraintWidgetContainer(0, 0).also { it.measurer = this }
@@ -970,9 +1027,7 @@ internal open class Measurer : BasicMeasure.Measurer, DesignInfoProvider {
     private val lastMeasures = mutableMapOf<String, Array<Int>>()
     protected val frameCache = mutableMapOf<Measurable, WidgetFrame>()
 
-    protected lateinit var density: Density
-    protected lateinit var measureScope: MeasureScope
-    protected val state by lazy(LazyThreadSafetyMode.NONE) { State(density) }
+    protected val state = State(density)
 
     private val widthConstraintsHolder = IntArray(2)
     private val heightConstraintsHolder = IntArray(2)
@@ -1226,11 +1281,8 @@ internal open class Measurer : BasicMeasure.Measurer, DesignInfoProvider {
         layoutDirection: LayoutDirection,
         constraintSet: ConstraintSet,
         measurables: List<Measurable>,
-        optimizationLevel: Int,
-        measureScope: MeasureScope
+        optimizationLevel: Int
     ): IntSize {
-        this.density = measureScope
-        this.measureScope = measureScope
         // Define the size of the ConstraintLayout.
         state.width(
             if (constraints.hasFixedWidth) {
@@ -1248,7 +1300,7 @@ internal open class Measurer : BasicMeasure.Measurer, DesignInfoProvider {
         )
         // Build constraint set and apply it to the state.
         state.rootIncomingConstraints = constraints
-        state.layoutDirection = layoutDirection
+        state.isLtr = layoutDirection == LayoutDirection.Ltr
         resetMeasureState()
         if (constraintSet.isDirty(measurables)) {
             state.reset()
@@ -1367,7 +1419,8 @@ internal open class Measurer : BasicMeasure.Measurer, DesignInfoProvider {
                 //   the placeable should be a result of the given measurable
                 placeWithFrameTransform(
                     measurable.measure(Constraints.fixed(placeable.width, placeable.height)),
-                    frame)
+                    frame
+                )
             } else {
                 placeWithFrameTransform(placeable, frame)
             }
@@ -1555,7 +1608,7 @@ internal fun Placeable.PlacementScope.placeWithFrameTransform(
     placeable: Placeable,
     frame: WidgetFrame,
     offset: IntOffset = IntOffset.Zero
-    ) {
+) {
     if (frame.isDefaultTransform) {
         val x = frame.left - offset.x
         val y = frame.top - offset.y
@@ -1627,7 +1680,7 @@ internal fun buildMapping(state: State, measurables: List<Measurable>) {
     measurables.fastForEach { measurable ->
         val id = measurable.layoutId ?: measurable.constraintLayoutId ?: createId()
         // Map the id and the measurable, to be retrieved later during measurement.
-        state.map(id, measurable)
+        state.map(id.toString(), measurable)
         val tag = measurable.constraintLayoutTag
         if (tag != null && tag is String && id is String) {
             state.setTag(id, tag)
@@ -1637,8 +1690,6 @@ internal fun buildMapping(state: State, measurables: List<Measurable>) {
 
 internal typealias SolverDimension = androidx.constraintlayout.core.state.Dimension
 internal typealias SolverState = androidx.constraintlayout.core.state.State
-internal typealias SolverDirection = androidx.constraintlayout.core.state.State.Direction
-internal typealias SolverChain = androidx.constraintlayout.core.state.State.Chain
 
 private val DEBUG = false
 private fun ConstraintWidget.toDebugString() =

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayoutBaseScope.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayoutBaseScope.kt
@@ -20,21 +20,37 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.layout.FirstBaseline
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import androidx.constraintlayout.core.widgets.ConstraintWidget
+import androidx.constraintlayout.core.parser.CLArray
+import androidx.constraintlayout.core.parser.CLElement
+import androidx.constraintlayout.core.parser.CLNumber
+import androidx.constraintlayout.core.parser.CLObject
+import androidx.constraintlayout.core.parser.CLString
+import androidx.constraintlayout.core.state.ConstraintSetParser
 
 /**
  * Common scope for [ConstraintLayoutScope] and [ConstraintSetScope], the content being shared
  * between the inline DSL API and the ConstraintSet-based API.
  */
-abstract class ConstraintLayoutBaseScope {
+abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObject?) {
+    @Suppress("unused") // Needed to maintain binary compatibility
+    constructor() : this(null)
+
+    @Deprecated("Tasks is unused, it breaks the immutability promise.")
     protected val tasks = mutableListOf<(State) -> Unit>()
 
-    fun applyTo(state: State): Unit = tasks.forEach { it(state) }
+    internal val containerObject: CLObject = extendFrom?.clone() ?: CLObject(charArrayOf())
+
+    fun applyTo(state: State) {
+        ConstraintSetParser.populateState(
+            containerObject,
+            state,
+            ConstraintSetParser.LayoutVariables()
+        )
+    }
 
     open fun reset() {
-        tasks.clear()
+        containerObject.clear()
         helperId = HelpersStartId
         helpersHashCode = 0
     }
@@ -95,10 +111,8 @@ abstract class ConstraintLayoutBaseScope {
     fun constrain(
         ref: HorizontalChainReference,
         constrainBlock: HorizontalChainScope.() -> Unit
-    ): HorizontalChainScope = HorizontalChainScope(ref.id).apply {
-        constrainBlock()
-        this@ConstraintLayoutBaseScope.tasks.addAll(this.tasks)
-    }
+    ): HorizontalChainScope =
+        HorizontalChainScope(ref.id, ref.asCLContainer()).apply(constrainBlock)
 
     /**
      * Specifies additional constraints associated to the vertical chain identified with [ref].
@@ -106,10 +120,7 @@ abstract class ConstraintLayoutBaseScope {
     fun constrain(
         ref: VerticalChainReference,
         constrainBlock: VerticalChainScope.() -> Unit
-    ): VerticalChainScope = VerticalChainScope(ref.id).apply {
-        constrainBlock()
-        this@ConstraintLayoutBaseScope.tasks.addAll(this.tasks)
-    }
+    ): VerticalChainScope = VerticalChainScope(ref.id, ref.asCLContainer()).apply(constrainBlock)
 
     /**
      * Specifies the constraints associated to the layout identified with [ref].
@@ -117,35 +128,38 @@ abstract class ConstraintLayoutBaseScope {
     fun constrain(
         ref: ConstrainedLayoutReference,
         constrainBlock: ConstrainScope.() -> Unit
-    ): ConstrainScope = ConstrainScope(ref.id).apply {
-        constrainBlock()
-        this@ConstraintLayoutBaseScope.tasks.addAll(this.tasks)
-    }
+    ): ConstrainScope = ConstrainScope(ref.id, ref.asCLContainer()).apply(constrainBlock)
 
     /**
      * Creates a guideline at a specific offset from the start of the [ConstraintLayout].
      */
     fun createGuidelineFromStart(offset: Dp): VerticalAnchor {
-        val id = createHelperId()
-        tasks.add { state ->
-            state.verticalGuideline(id).apply {
-                if (state.layoutDirection == LayoutDirection.Ltr) start(offset) else end(offset)
-            }
+        val ref = LayoutReferenceImpl(createHelperId())
+
+        ref.asCLContainer().apply {
+            putString("type", "vGuideline")
+            putNumber("start", offset.value)
         }
+
         updateHelpersHashCode(1)
         updateHelpersHashCode(offset.hashCode())
-        return VerticalAnchor(id, 0, LayoutReferenceImpl(id))
+        return VerticalAnchor(ref.id, 0, ref)
     }
 
     /**
      * Creates a guideline at a specific offset from the left of the [ConstraintLayout].
      */
     fun createGuidelineFromAbsoluteLeft(offset: Dp): VerticalAnchor {
-        val id = createHelperId()
-        tasks.add { state -> state.verticalGuideline(id).apply { start(offset) } }
+        val ref = LayoutReferenceImpl(createHelperId())
+
+        ref.asCLContainer().apply {
+            putString("type", "vGuideline")
+            putNumber("left", offset.value)
+        }
+
         updateHelpersHashCode(2)
         updateHelpersHashCode(offset.hashCode())
-        return VerticalAnchor(id, 0, LayoutReferenceImpl(id))
+        return VerticalAnchor(ref.id, 0, ref)
     }
 
     /**
@@ -154,19 +168,21 @@ abstract class ConstraintLayoutBaseScope {
      * correspond to the end.
      */
     fun createGuidelineFromStart(fraction: Float): VerticalAnchor {
-        val id = createHelperId()
-        tasks.add { state ->
-            state.verticalGuideline(id).apply {
-                if (state.layoutDirection == LayoutDirection.Ltr) {
-                    percent(fraction)
-                } else {
-                    percent(1f - fraction)
-                }
-            }
+        val ref = LayoutReferenceImpl(createHelperId())
+
+        val percentParams = CLArray(charArrayOf()).apply {
+            add(CLString.from("start"))
+            add(CLNumber(fraction))
         }
+
+        ref.asCLContainer().apply {
+            putString("type", "vGuideline")
+            put("percent", percentParams)
+        }
+
         updateHelpersHashCode(3)
         updateHelpersHashCode(fraction.hashCode())
-        return VerticalAnchor(id, 0, LayoutReferenceImpl(id))
+        return VerticalAnchor(ref.id, 0, ref)
     }
 
     /**
@@ -174,39 +190,49 @@ abstract class ConstraintLayoutBaseScope {
      * A [fraction] of 0f will correspond to the left of the [ConstraintLayout], while 1f will
      * correspond to the right.
      */
-    // TODO(popam, b/157781990): this is not really percenide
     fun createGuidelineFromAbsoluteLeft(fraction: Float): VerticalAnchor {
-        val id = createHelperId()
-        tasks.add { state -> state.verticalGuideline(id).apply { percent(fraction) } }
+        val ref = LayoutReferenceImpl(createHelperId())
+
+        ref.asCLContainer().apply {
+            putString("type", "vGuideline")
+            putNumber("percent", fraction)
+        }
+
         updateHelpersHashCode(4)
         updateHelpersHashCode(fraction.hashCode())
-        return VerticalAnchor(id, 0, LayoutReferenceImpl(id))
+        return VerticalAnchor(ref.id, 0, ref)
     }
 
     /**
      * Creates a guideline at a specific offset from the end of the [ConstraintLayout].
      */
     fun createGuidelineFromEnd(offset: Dp): VerticalAnchor {
-        val id = createHelperId()
-        tasks.add { state ->
-            state.verticalGuideline(id).apply {
-                if (state.layoutDirection == LayoutDirection.Ltr) end(offset) else start(offset)
-            }
+        val ref = LayoutReferenceImpl(createHelperId())
+
+        ref.asCLContainer().apply {
+            putString("type", "vGuideline")
+            putNumber("end", offset.value)
         }
+
         updateHelpersHashCode(5)
         updateHelpersHashCode(offset.hashCode())
-        return VerticalAnchor(id, 0, LayoutReferenceImpl(id))
+        return VerticalAnchor(ref.id, 0, ref)
     }
 
     /**
      * Creates a guideline at a specific offset from the right of the [ConstraintLayout].
      */
     fun createGuidelineFromAbsoluteRight(offset: Dp): VerticalAnchor {
-        val id = createHelperId()
-        tasks.add { state -> state.verticalGuideline(id).apply { end(offset) } }
+        val ref = LayoutReferenceImpl(createHelperId())
+
+        ref.asCLContainer().apply {
+            putString("type", "vGuideline")
+            putNumber("right", offset.value)
+        }
+
         updateHelpersHashCode(6)
         updateHelpersHashCode(offset.hashCode())
-        return VerticalAnchor(id, 0, LayoutReferenceImpl(id))
+        return VerticalAnchor(ref.id, 0, ref)
     }
 
     /**
@@ -215,7 +241,21 @@ abstract class ConstraintLayoutBaseScope {
      * correspond to the start.
      */
     fun createGuidelineFromEnd(fraction: Float): VerticalAnchor {
-        return createGuidelineFromStart(1f - fraction)
+        val ref = LayoutReferenceImpl(createHelperId())
+
+        val percentParams = CLArray(charArrayOf()).apply {
+            add(CLString.from("end"))
+            add(CLNumber(fraction))
+        }
+
+        ref.asCLContainer().apply {
+            putString("type", "vGuideline")
+            put("percent", percentParams)
+        }
+
+        updateHelpersHashCode(3)
+        updateHelpersHashCode(fraction.hashCode())
+        return VerticalAnchor(ref.id, 0, ref)
     }
 
     /**
@@ -231,35 +271,50 @@ abstract class ConstraintLayoutBaseScope {
      * Creates a guideline at a specific offset from the top of the [ConstraintLayout].
      */
     fun createGuidelineFromTop(offset: Dp): HorizontalAnchor {
-        val id = createHelperId()
-        tasks.add { state -> state.horizontalGuideline(id).apply { start(offset) } }
+        val ref = LayoutReferenceImpl(createHelperId())
+
+        ref.asCLContainer().apply {
+            putString("type", "hGuideline")
+            putNumber("start", offset.value)
+        }
+
         updateHelpersHashCode(7)
         updateHelpersHashCode(offset.hashCode())
-        return HorizontalAnchor(id, 0, LayoutReferenceImpl(id))
+        return HorizontalAnchor(ref.id, 0, ref)
     }
 
     /**
-     * Creates a guideline at a height percenide from the top of the [ConstraintLayout].
+     * Creates a guideline at a height fraction from the top of the [ConstraintLayout].
      * A [fraction] of 0f will correspond to the top of the [ConstraintLayout], while 1f will
      * correspond to the bottom.
      */
     fun createGuidelineFromTop(fraction: Float): HorizontalAnchor {
-        val id = createHelperId()
-        tasks.add { state -> state.horizontalGuideline(id).apply { percent(fraction) } }
+        val ref = LayoutReferenceImpl(createHelperId())
+
+        ref.asCLContainer().apply {
+            putString("type", "hGuideline")
+            putNumber("percent", fraction)
+        }
+
         updateHelpersHashCode(8)
         updateHelpersHashCode(fraction.hashCode())
-        return HorizontalAnchor(id, 0, LayoutReferenceImpl(id))
+        return HorizontalAnchor(ref.id, 0, ref)
     }
 
     /**
      * Creates a guideline at a specific offset from the bottom of the [ConstraintLayout].
      */
     fun createGuidelineFromBottom(offset: Dp): HorizontalAnchor {
-        val id = createHelperId()
-        tasks.add { state -> state.horizontalGuideline(id).apply { end(offset) } }
+        val ref = LayoutReferenceImpl(createHelperId())
+
+        ref.asCLContainer().apply {
+            putString("type", "hGuideline")
+            putNumber("end", offset.value)
+        }
+
         updateHelpersHashCode(9)
         updateHelpersHashCode(offset.hashCode())
-        return HorizontalAnchor(id, 0, LayoutReferenceImpl(id))
+        return HorizontalAnchor(ref.id, 0, ref)
     }
 
     /**
@@ -278,21 +333,24 @@ abstract class ConstraintLayoutBaseScope {
         vararg elements: LayoutReference,
         margin: Dp = 0.dp
     ): VerticalAnchor {
-        val id = createHelperId()
-        tasks.add { state ->
-            val direction = if (state.layoutDirection == LayoutDirection.Ltr) {
-                SolverDirection.LEFT
-            } else {
-                SolverDirection.RIGHT
-            }
-            state.barrier(id, direction).apply {
-                add(*(elements.map { it.id }.toTypedArray()))
-            }.margin(state.convertDimension(margin))
+        val ref = LayoutReferenceImpl(createHelperId())
+
+        val elementArray = CLArray(charArrayOf())
+        elements.forEach {
+            elementArray.add(CLString.from(it.id.toString()))
         }
+
+        ref.asCLContainer().apply {
+            putString("type", "barrier")
+            putString("direction", "start")
+            putNumber("margin", margin.value)
+            put("contains", elementArray)
+        }
+
         updateHelpersHashCode(10)
         elements.forEach { updateHelpersHashCode(it.hashCode()) }
         updateHelpersHashCode(margin.hashCode())
-        return VerticalAnchor(id, 0, LayoutReferenceImpl(id))
+        return VerticalAnchor(ref.id, 0, ref)
     }
 
     /**
@@ -302,16 +360,24 @@ abstract class ConstraintLayoutBaseScope {
         vararg elements: LayoutReference,
         margin: Dp = 0.dp
     ): VerticalAnchor {
-        val id = createHelperId()
-        tasks.add { state ->
-            state.barrier(id, SolverDirection.LEFT).apply {
-                add(*(elements.map { it.id }.toTypedArray()))
-            }.margin(state.convertDimension(margin))
+        val ref = LayoutReferenceImpl(createHelperId())
+
+        val elementArray = CLArray(charArrayOf())
+        elements.forEach {
+            elementArray.add(CLString.from(it.id.toString()))
         }
+
+        ref.asCLContainer().apply {
+            putString("type", "barrier")
+            putString("direction", "left")
+            putNumber("margin", margin.value)
+            put("contains", elementArray)
+        }
+
         updateHelpersHashCode(11)
         elements.forEach { updateHelpersHashCode(it.hashCode()) }
         updateHelpersHashCode(margin.hashCode())
-        return VerticalAnchor(id, 0, LayoutReferenceImpl(id))
+        return VerticalAnchor(ref.id, 0, ref)
     }
 
     /**
@@ -321,16 +387,24 @@ abstract class ConstraintLayoutBaseScope {
         vararg elements: LayoutReference,
         margin: Dp = 0.dp
     ): HorizontalAnchor {
-        val id = createHelperId()
-        tasks.add { state ->
-            state.barrier(id, SolverDirection.TOP).apply {
-                add(*(elements.map { it.id }.toTypedArray()))
-            }.margin(state.convertDimension(margin))
+        val ref = LayoutReferenceImpl(createHelperId())
+
+        val elementArray = CLArray(charArrayOf())
+        elements.forEach {
+            elementArray.add(CLString.from(it.id.toString()))
         }
+
+        ref.asCLContainer().apply {
+            putString("type", "barrier")
+            putString("direction", "top")
+            putNumber("margin", margin.value)
+            put("contains", elementArray)
+        }
+
         updateHelpersHashCode(12)
         elements.forEach { updateHelpersHashCode(it.hashCode()) }
         updateHelpersHashCode(margin.hashCode())
-        return HorizontalAnchor(id, 0, LayoutReferenceImpl(id))
+        return HorizontalAnchor(ref.id, 0, ref)
     }
 
     /**
@@ -340,21 +414,24 @@ abstract class ConstraintLayoutBaseScope {
         vararg elements: LayoutReference,
         margin: Dp = 0.dp
     ): VerticalAnchor {
-        val id = createHelperId()
-        tasks.add { state ->
-            val direction = if (state.layoutDirection == LayoutDirection.Ltr) {
-                SolverDirection.RIGHT
-            } else {
-                SolverDirection.LEFT
-            }
-            state.barrier(id, direction).apply {
-                add(*(elements.map { it.id }.toTypedArray()))
-            }.margin(state.convertDimension(margin))
+        val ref = LayoutReferenceImpl(createHelperId())
+
+        val elementArray = CLArray(charArrayOf())
+        elements.forEach {
+            elementArray.add(CLString.from(it.id.toString()))
         }
+
+        ref.asCLContainer().apply {
+            putString("type", "barrier")
+            putString("direction", "end")
+            putNumber("margin", margin.value)
+            put("contains", elementArray)
+        }
+
         updateHelpersHashCode(13)
         elements.forEach { updateHelpersHashCode(it.hashCode()) }
         updateHelpersHashCode(margin.hashCode())
-        return VerticalAnchor(id, 0, LayoutReferenceImpl(id))
+        return VerticalAnchor(ref.id, 0, ref)
     }
 
     /**
@@ -364,16 +441,24 @@ abstract class ConstraintLayoutBaseScope {
         vararg elements: LayoutReference,
         margin: Dp = 0.dp
     ): VerticalAnchor {
-        val id = createHelperId()
-        tasks.add { state ->
-            state.barrier(id, SolverDirection.RIGHT).apply {
-                add(*(elements.map { it.id }.toTypedArray()))
-            }.margin(state.convertDimension(margin))
+        val ref = LayoutReferenceImpl(createHelperId())
+
+        val elementArray = CLArray(charArrayOf())
+        elements.forEach {
+            elementArray.add(CLString.from(it.id.toString()))
         }
+
+        ref.asCLContainer().apply {
+            putString("type", "barrier")
+            putString("direction", "right")
+            putNumber("margin", margin.value)
+            put("contains", elementArray)
+        }
+
         updateHelpersHashCode(14)
         elements.forEach { updateHelpersHashCode(it.hashCode()) }
         updateHelpersHashCode(margin.hashCode())
-        return VerticalAnchor(id, 0, LayoutReferenceImpl(id))
+        return VerticalAnchor(ref.id, 0, ref)
     }
 
     /**
@@ -383,44 +468,53 @@ abstract class ConstraintLayoutBaseScope {
         vararg elements: LayoutReference,
         margin: Dp = 0.dp
     ): HorizontalAnchor {
-        val id = createHelperId()
-        tasks.add { state ->
-            state.barrier(id, SolverDirection.BOTTOM).apply {
-                add(*(elements.map { it.id }.toTypedArray()))
-            }.margin(state.convertDimension(margin))
+        val ref = LayoutReferenceImpl(createHelperId())
+
+        val elementArray = CLArray(charArrayOf())
+        elements.forEach {
+            elementArray.add(CLString.from(it.id.toString()))
         }
+
+        ref.asCLContainer().apply {
+            putString("type", "barrier")
+            putString("direction", "bottom")
+            putNumber("margin", margin.value)
+            put("contains", elementArray)
+        }
+
         updateHelpersHashCode(15)
         elements.forEach { updateHelpersHashCode(it.hashCode()) }
         updateHelpersHashCode(margin.hashCode())
-        return HorizontalAnchor(id, 0, LayoutReferenceImpl(id))
+        return HorizontalAnchor(ref.id, 0, ref)
     }
 
     /**
-     * This creates a flow helper
      * Flow helpers allows a long sequence of Composable widgets to wrap onto
      * multiple rows or columns.
-     * [flowVertically] if set to true aranges the Composables from top to bottom.
+     *
+     * @param elements [LayoutReference]s to be laid out by the Flow helper
+     * @param flowVertically if set to true arranges the Composables from top to bottom.
      * Normally they are arranged from left to right.
-     * [verticalGap] defines the gap between views in the y axis
-     * [horizontalGap] defines the gap between views in the x axis
-     * [maxElement] defines the maximum element on a row before it if the
-     * [padding] sets padding around the content
-     * [wrapMode] sets the way reach maxElements is handled
-     * Flow.WRAP_NONE (default) -- no wrap behavior,
-     * Flow.WRAP_CHAIN - create additional chains
-     * [verticalAlign] set the way elements are aligned vertically. Center is default
-     * [horizontalAlign] set the way elements are aligned horizontally. Center is default
-     * [horizontalFlowBias] set the way elements are aligned vertically Center is default
-     * [verticalFlowBias] sets the top bottom bias of the vertical chain
-     * [verticalStyle] sets the style of a vertical chain (Spread,Packed, or SpreadInside)
-     * [horizontalStyle] set the style of the horizontal chain (Spread, Packed, or SpreadInside)
+     * @param verticalGap defines the gap between views in the y axis
+     * @param horizontalGap defines the gap between views in the x axis
+     * @param maxElement defines the maximum element on a row before it if the
+     * @param padding sets padding around the content
+     * @param wrapMode sets the way reach maxElements is handled
+     * [Wrap.None] (default) -- no wrap behavior,
+     * [Wrap.Chain] - create additional chains
+     * @param verticalAlign set the way elements are aligned vertically. Center is default
+     * @param horizontalAlign set the way elements are aligned horizontally. Center is default
+     * @param horizontalFlowBias set the way elements are aligned vertically Center is default
+     * @param verticalFlowBias sets the top bottom bias of the vertical chain
+     * @param verticalStyle sets the style of a vertical chain (Spread,Packed, or SpreadInside)
+     * @param horizontalStyle set the style of the horizontal chain (Spread, Packed, or SpreadInside)
      */
     fun createFlow(
         vararg elements: LayoutReference?,
         flowVertically: Boolean = false,
         verticalGap: Dp = 0.dp,
         horizontalGap: Dp = 0.dp,
-        maxElement: Int = 0,
+        maxElement: Int = 0, // TODO: shouldn't this be -1? (aka: UNKNOWN)?
         padding: Dp = 0.dp,
         wrapMode: Wrap = Wrap.None,
         verticalAlign: VerticalAlign = VerticalAlign.Center,
@@ -430,52 +524,47 @@ abstract class ConstraintLayoutBaseScope {
         verticalStyle: FlowStyle = FlowStyle.Packed,
         horizontalStyle: FlowStyle = FlowStyle.Packed,
     ): ConstrainedLayoutReference {
-        val id = createHelperId()
-        tasks.add { state ->
-            state.getFlow(id, flowVertically).apply {
-                add(*(elements.map { it?.id }.toTypedArray()))
-                horizontalChainStyle = horizontalStyle.style
-                setVerticalChainStyle(verticalStyle.style)
-                verticalBias(verticalFlowBias)
-                horizontalBias(horizontalFlowBias)
-                setHorizontalAlign(horizontalAlign.mode)
-                setVerticalAlign(verticalAlign.mode)
-                setWrapMode(wrapMode.mode)
-                paddingLeft = state.convertDimension(padding)
-                paddingTop = state.convertDimension(padding)
-                paddingRight = state.convertDimension(padding)
-                paddingBottom = state.convertDimension(padding)
-                maxElementsWrap = maxElement
-                setHorizontalGap(state.convertDimension(horizontalGap))
-                setVerticalGap(state.convertDimension(verticalGap))
-            }
-        }
-        updateHelpersHashCode(16)
-        elements.forEach { updateHelpersHashCode(it.hashCode()) }
-
-        return ConstrainedLayoutReference(id)
+        return createFlow(
+            elements = elements,
+            flowVertically = flowVertically,
+            verticalGap = verticalGap,
+            horizontalGap = horizontalGap,
+            maxElement = maxElement,
+            paddingLeft = padding,
+            paddingTop = padding,
+            paddingRight = padding,
+            paddingBottom = padding,
+            wrapMode = wrapMode,
+            verticalAlign = verticalAlign,
+            horizontalAlign = horizontalAlign,
+            horizontalFlowBias = horizontalFlowBias,
+            verticalFlowBias = verticalFlowBias,
+            verticalStyle = verticalStyle,
+            horizontalStyle = horizontalStyle
+        )
     }
 
     /**
-     * This creates a flow helper
      * Flow helpers allows a long sequence of Composable widgets to wrap onto
      * multiple rows or columns.
-     * [flowVertically] if set to true aranges the Composables from top to bottom.
+     *
+     * @param elements [LayoutReference]s to be laid out by the Flow helper
+     * @param flowVertically if set to true aranges the Composables from top to bottom.
      * Normally they are arranged from left to right.
-     * [verticalGap] defines the gap between views in the y axis
-     * [horizontalGap] defines the gap between views in the x axis
-     * [maxElement] defines the maximum element on a row before it if the
-     * [paddingHorizontal] sets paddingLeft and paddingRight of the content
-     * [paddingVertical] sets paddingTop and paddingBottom of the content
-     * [wrapMode] sets the way reach maxElements is handled
-     * Flow.WRAP_NONE (default) -- no wrap behavior,
-     * Flow.WRAP_CHAIN - create additional chains
-     * [verticalAlign] set the way elements are aligned vertically. Center is default
-     * [horizontalAlign] set the way elements are aligned horizontally. Center is default
-     * [horizontalFlowBias] set the way elements are aligned vertically Center is default
-     * [verticalFlowBias] sets the top bottom bias of the vertical chain
-     * [verticalStyle] sets the style of a vertical chain (Spread,Packed, or SpreadInside)
-     * [horizontalStyle] set the style of the horizontal chain (Spread, Packed, or SpreadInside)
+     * @param verticalGap defines the gap between views in the y axis
+     * @param horizontalGap defines the gap between views in the x axis
+     * @param maxElement defines the maximum element on a row before it if the
+     * @param paddingHorizontal sets paddingLeft and paddingRight of the content
+     * @param paddingVertical sets paddingTop and paddingBottom of the content
+     * @param wrapMode sets the way reach maxElements is handled
+     * [Wrap.None] (default) -- no wrap behavior,
+     * [Wrap.Chain] - create additional chains
+     * @param verticalAlign set the way elements are aligned vertically. Center is default
+     * @param horizontalAlign set the way elements are aligned horizontally. Center is default
+     * @param horizontalFlowBias set the way elements are aligned vertically Center is default
+     * @param verticalFlowBias sets the top bottom bias of the vertical chain
+     * @param verticalStyle sets the style of a vertical chain (Spread,Packed, or SpreadInside)
+     * @param horizontalStyle set the style of the horizontal chain (Spread, Packed, or SpreadInside)
      */
     fun createFlow(
         vararg elements: LayoutReference?,
@@ -493,54 +582,49 @@ abstract class ConstraintLayoutBaseScope {
         verticalStyle: FlowStyle = FlowStyle.Packed,
         horizontalStyle: FlowStyle = FlowStyle.Packed,
     ): ConstrainedLayoutReference {
-        val id = createHelperId()
-        tasks.add { state ->
-            state.getFlow(id, flowVertically).apply {
-                add(*(elements.map { it?.id }.toTypedArray()))
-                horizontalChainStyle = horizontalStyle.style
-                setVerticalChainStyle(verticalStyle.style)
-                verticalBias(verticalFlowBias)
-                horizontalBias(horizontalFlowBias)
-                setHorizontalAlign(horizontalAlign.mode)
-                setVerticalAlign(verticalAlign.mode)
-                setWrapMode(wrapMode.mode)
-                paddingLeft = state.convertDimension(paddingHorizontal)
-                paddingTop = state.convertDimension(paddingVertical)
-                paddingRight = state.convertDimension(paddingHorizontal)
-                paddingBottom = state.convertDimension(paddingVertical)
-                maxElementsWrap = maxElement
-                setHorizontalGap(state.convertDimension(horizontalGap))
-                setVerticalGap(state.convertDimension(verticalGap))
-            }
-        }
-        updateHelpersHashCode(16)
-        elements.forEach { updateHelpersHashCode(it.hashCode()) }
-
-        return ConstrainedLayoutReference(id)
+        return createFlow(
+            elements = elements,
+            flowVertically = flowVertically,
+            verticalGap = verticalGap,
+            horizontalGap = horizontalGap,
+            maxElement = maxElement,
+            paddingLeft = paddingHorizontal,
+            paddingTop = paddingVertical,
+            paddingRight = paddingHorizontal,
+            paddingBottom = paddingVertical,
+            wrapMode = wrapMode,
+            verticalAlign = verticalAlign,
+            horizontalAlign = horizontalAlign,
+            horizontalFlowBias = horizontalFlowBias,
+            verticalFlowBias = verticalFlowBias,
+            verticalStyle = verticalStyle,
+            horizontalStyle = horizontalStyle
+        )
     }
 
     /**
-     * This creates a flow helper
      * Flow helpers allows a long sequence of Composable widgets to wrap onto
      * multiple rows or columns.
-     * [flowVertically] if set to true aranges the Composables from top to bottom.
+     *
+     * @param elements [LayoutReference]s to be laid out by the Flow helper
+     * @param flowVertically if set to true aranges the Composables from top to bottom.
      * Normally they are arranged from left to right.
-     * [verticalGap] defines the gap between views in the y axis
-     * [horizontalGap] defines the gap between views in the x axis
-     * [maxElement] defines the maximum element on a row before it if the
-     * [paddingLeft] sets paddingLeft of the content
-     * [paddingTop] sets paddingTop of the content
-     * [paddingRight] sets paddingRight of the content
-     * [paddingBottom] sets paddingBottom of the content
-     * [wrapMode] sets the way reach maxElements is handled
-     * Flow.WRAP_NONE (default) -- no wrap behavior,
-     * Flow.WRAP_CHAIN - create additional chains
-     * [verticalAlign] set the way elements are aligned vertically. Center is default
-     * [horizontalAlign] set the way elements are aligned horizontally. Center is default
-     * [horizontalFlowBias] set the way elements are aligned vertically Center is default
-     * [verticalFlowBias] sets the top bottom bias of the vertical chain
-     * [verticalStyle] sets the style of a vertical chain (Spread,Packed, or SpreadInside)
-     * [horizontalStyle] set the style of the horizontal chain (Spread, Packed, or SpreadInside)
+     * @param verticalGap defines the gap between views in the y axis
+     * @param horizontalGap defines the gap between views in the x axis
+     * @param maxElement defines the maximum element on a row before it if the
+     * @param paddingLeft sets paddingLeft of the content
+     * @param paddingTop sets paddingTop of the content
+     * @param paddingRight sets paddingRight of the content
+     * @param paddingBottom sets paddingBottom of the content
+     * @param wrapMode sets the way reach maxElements is handled
+     * [Wrap.None] (default) -- no wrap behavior,
+     * [Wrap.Chain] - create additional chains
+     * @param verticalAlign set the way elements are aligned vertically. Center is default
+     * @param horizontalAlign set the way elements are aligned horizontally. Center is default
+     * @param horizontalFlowBias set the way elements are aligned vertically Center is default
+     * @param verticalFlowBias sets the top bottom bias of the vertical chain
+     * @param verticalStyle sets the style of a vertical chain (Spread,Packed, or SpreadInside)
+     * @param horizontalStyle set the style of the horizontal chain (Spread, Packed, or SpreadInside)
      */
     fun createFlow(
         vararg elements: LayoutReference?,
@@ -560,30 +644,38 @@ abstract class ConstraintLayoutBaseScope {
         verticalStyle: FlowStyle = FlowStyle.Packed,
         horizontalStyle: FlowStyle = FlowStyle.Packed,
     ): ConstrainedLayoutReference {
-        val id = createHelperId()
-        tasks.add { state ->
-            state.getFlow(id, flowVertically).apply {
-                add(*(elements.map { it?.id }.toTypedArray()))
-                horizontalChainStyle = horizontalStyle.style
-                setVerticalChainStyle(verticalStyle.style)
-                verticalBias(verticalFlowBias)
-                horizontalBias(horizontalFlowBias)
-                setHorizontalAlign(horizontalAlign.mode)
-                setVerticalAlign(verticalAlign.mode)
-                setWrapMode(wrapMode.mode)
-                setPaddingLeft(state.convertDimension(paddingLeft))
-                setPaddingTop(state.convertDimension(paddingTop))
-                setPaddingRight(state.convertDimension(paddingRight))
-                setPaddingBottom(state.convertDimension(paddingBottom))
-                maxElementsWrap = maxElement
-                setHorizontalGap(state.convertDimension(horizontalGap))
-                setVerticalGap(state.convertDimension(verticalGap))
+        val ref = ConstrainedLayoutReference(createHelperId())
+        val elementArray = CLArray(charArrayOf())
+        elements.forEach {
+            if (it != null) {
+                elementArray.add(CLString.from(it.id.toString()))
             }
+        }
+        val paddingArray = CLArray(charArrayOf()).apply {
+            add(CLNumber(paddingLeft.value))
+            add(CLNumber(paddingTop.value))
+            add(CLNumber(paddingRight.value))
+            add(CLNumber(paddingBottom.value))
+        }
+        ref.asCLContainer().apply {
+            put("contains", elementArray)
+            putString("type", if (flowVertically) "vFlow" else "hFlow")
+            putNumber("vGap", verticalGap.value)
+            putNumber("hGap", horizontalGap.value)
+            putNumber("maxElement", maxElement.toFloat())
+            put("padding", paddingArray)
+            putString("wrap", wrapMode.name)
+            putString("vAlign", verticalAlign.name)
+            putString("hAlign", horizontalAlign.name)
+            putNumber("hFlowBias", horizontalFlowBias)
+            putNumber("vFlowBias", verticalFlowBias)
+            putString("vStyle", verticalStyle.name)
+            putString("hStyle", horizontalStyle.name)
         }
         updateHelpersHashCode(16)
         elements.forEach { updateHelpersHashCode(it.hashCode()) }
 
-         return ConstrainedLayoutReference(id)
+        return ref
     }
 
     /**
@@ -592,28 +684,42 @@ abstract class ConstraintLayoutBaseScope {
      * Use [constrain] with the resulting [HorizontalChainReference] to modify the start/left and
      * end/right constraints of this chain.
      */
-    // TODO(popam, b/157783937): this API should be improved
     fun createHorizontalChain(
         vararg elements: LayoutReference,
         chainStyle: ChainStyle = ChainStyle.Spread
     ): HorizontalChainReference {
-        val id = createHelperId()
-        tasks.add { state ->
-            val helper = state.helper(
-                id,
-                androidx.constraintlayout.core.state.State.Helper.HORIZONTAL_CHAIN
-            ) as androidx.constraintlayout.core.state.helpers.HorizontalChainReference
-            helper.add(*(elements.map { it.id }.toTypedArray()))
-            helper.style(chainStyle.style)
-            helper.apply()
-            if (chainStyle.bias != null) {
-                state.constraints(elements[0].id).horizontalBias(chainStyle.bias)
+        val ref = HorizontalChainReference(createHelperId())
+        val elementArray = CLArray(charArrayOf())
+        elements.forEach {
+            val chainParams = it.getHelperParams<ChainParams>()
+            val elementContent: CLElement = if (chainParams != null) {
+                CLArray(charArrayOf()).apply {
+                    add(CLString.from(it.id.toString()))
+                    add(CLNumber(chainParams.weight))
+                    add(CLNumber(chainParams.startMargin.value))
+                    add(CLNumber(chainParams.endMargin.value))
+                    add(CLNumber(chainParams.startGoneMargin.value))
+                    add(CLNumber(chainParams.endGoneMargin.value))
+                }
+            } else {
+                CLString.from(it.id.toString())
             }
+            elementArray.add(elementContent)
         }
+        val styleArray = CLArray(charArrayOf())
+        styleArray.add(CLString.from(chainStyle.name))
+        styleArray.add(CLNumber(chainStyle.bias ?: 0.5f))
+
+        ref.asCLContainer().apply {
+            putString("type", "hChain")
+            put("contains", elementArray)
+            put("style", styleArray)
+        }
+
         updateHelpersHashCode(16)
         elements.forEach { updateHelpersHashCode(it.hashCode()) }
         updateHelpersHashCode(chainStyle.hashCode())
-        return HorizontalChainReference(id)
+        return ref
     }
 
     /**
@@ -622,28 +728,205 @@ abstract class ConstraintLayoutBaseScope {
      * Use [constrain] with the resulting [VerticalChainReference] to modify the top and
      * bottom constraints of this chain.
      */
-    // TODO(popam, b/157783937): this API should be improved
     fun createVerticalChain(
         vararg elements: LayoutReference,
         chainStyle: ChainStyle = ChainStyle.Spread
     ): VerticalChainReference {
-        val id = createHelperId()
-        tasks.add { state ->
-            val helper = state.helper(
-                id,
-                androidx.constraintlayout.core.state.State.Helper.VERTICAL_CHAIN
-            ) as androidx.constraintlayout.core.state.helpers.VerticalChainReference
-            helper.add(*(elements.map { it.id }.toTypedArray()))
-            helper.style(chainStyle.style)
-            helper.apply()
-            if (chainStyle.bias != null) {
-                state.constraints(elements[0].id).verticalBias(chainStyle.bias)
+        val ref = VerticalChainReference(createHelperId())
+        val elementArray = CLArray(charArrayOf())
+        elements.forEach {
+            val chainParams = it.getHelperParams<ChainParams>()
+            val elementContent: CLElement = if (chainParams != null) {
+                CLArray(charArrayOf()).apply {
+                    add(CLString.from(it.id.toString()))
+                    add(CLNumber(chainParams.weight))
+                    add(CLNumber(chainParams.topMargin.value))
+                    add(CLNumber(chainParams.bottomMargin.value))
+                    add(CLNumber(chainParams.topGoneMargin.value))
+                    add(CLNumber(chainParams.bottomGoneMargin.value))
+                }
+            } else {
+                CLString.from(it.id.toString())
             }
+            elementArray.add(elementContent)
         }
+        val styleArray = CLArray(charArrayOf())
+        styleArray.add(CLString.from(chainStyle.name))
+        styleArray.add(CLNumber(chainStyle.bias ?: 0.5f))
+
+        ref.asCLContainer().apply {
+            putString("type", "vChain")
+            put("contains", elementArray)
+            put("style", styleArray)
+        }
+
         updateHelpersHashCode(17)
         elements.forEach { updateHelpersHashCode(it.hashCode()) }
         updateHelpersHashCode(chainStyle.hashCode())
-        return VerticalChainReference(id)
+        return ref
+    }
+
+    /**
+     * Sets the parameters that are used by chains to customize the resulting layout.
+     *
+     * Use margins to customize the space between widgets in the chain.
+     *
+     * Use weight to distribute available space to each widget when their dimensions are not
+     * fixed.
+     *
+     * &nbsp;
+     *
+     * Similarly named parameters available from [ConstrainScope.linkTo] are ignored in
+     * Chains.
+     *
+     * Since margins are only for widgets within the chain: Top, Start and End, Bottom margins are
+     * ignored when the widget is the first or the last element in the chain, respectively.
+     *
+     * @param startMargin Added space from the start of this widget to the previous widget
+     * @param topMargin Added space from the top of this widget to the previous widget
+     * @param endMargin Added space from the end of this widget to the next widget
+     * @param bottomMargin Added space from the bottom of this widget to the next widget
+     * @param startGoneMargin Added space from the start of this widget when the previous widget has [Visibility.Gone]
+     * @param topGoneMargin Added space from the top of this widget when the previous widget has [Visibility.Gone]
+     * @param endGoneMargin Added space from the end of this widget when the next widget has [Visibility.Gone]
+     * @param bottomGoneMargin Added space from the bottom of this widget when the next widget has [Visibility.Gone]
+     * @param weight Defines the proportion of space (relative to the total weight) occupied by this
+     * layout when the corresponding dimension is not a fixed value.
+     * @return The same [LayoutReference] instance with the applied values
+     */
+    fun LayoutReference.withChainParams(
+        startMargin: Dp = 0.dp,
+        topMargin: Dp = 0.dp,
+        endMargin: Dp = 0.dp,
+        bottomMargin: Dp = 0.dp,
+        startGoneMargin: Dp = 0.dp,
+        topGoneMargin: Dp = 0.dp,
+        endGoneMargin: Dp = 0.dp,
+        bottomGoneMargin: Dp = 0.dp,
+        weight: Float = Float.NaN,
+    ): LayoutReference =
+        this.apply {
+            setHelperParams(
+                ChainParams(
+                    startMargin = startMargin,
+                    topMargin = topMargin,
+                    endMargin = endMargin,
+                    bottomMargin = bottomMargin,
+                    startGoneMargin = startGoneMargin,
+                    topGoneMargin = topGoneMargin,
+                    endGoneMargin = endGoneMargin,
+                    bottomGoneMargin = bottomGoneMargin,
+                    weight = weight
+                )
+            )
+        }
+
+    /**
+     * Sets the parameters that are used by horizontal chains to customize the resulting layout.
+     *
+     * Use margins to customize the space between widgets in the chain.
+     *
+     * Use weight to distribute available space to each widget when their horizontal dimension is
+     * not fixed.
+     *
+     * &nbsp;
+     *
+     * Similarly named parameters available from [ConstrainScope.linkTo] are ignored in
+     * Chains.
+     *
+     * Since margins are only for widgets within the chain: Start and End margins are
+     * ignored when the widget is the first or the last element in the chain, respectively.
+     *
+     * @param startMargin Added space from the start of this widget to the previous widget
+     * @param endMargin Added space from the end of this widget to the next widget
+     * @param startGoneMargin Added space from the start of this widget when the previous widget has [Visibility.Gone]
+     * @param endGoneMargin Added space from the end of this widget when the next widget has [Visibility.Gone]
+     * @param weight Defines the proportion of space (relative to the total weight) occupied by this
+     * layout when the width is not a fixed dimension.
+     * @return The same [LayoutReference] instance with the applied values
+     */
+    fun LayoutReference.withHorizontalChainParams(
+        startMargin: Dp = 0.dp,
+        endMargin: Dp = 0.dp,
+        startGoneMargin: Dp = 0.dp,
+        endGoneMargin: Dp = 0.dp,
+        weight: Float = Float.NaN
+    ): LayoutReference =
+        withChainParams(
+            startMargin = startMargin,
+            topMargin = 0.dp,
+            endMargin = endMargin,
+            bottomMargin = 0.dp,
+            startGoneMargin = startGoneMargin,
+            topGoneMargin = 0.dp,
+            endGoneMargin = endGoneMargin,
+            bottomGoneMargin = 0.dp,
+            weight = weight
+        )
+
+    /**
+     * Sets the parameters that are used by vertical chains to customize the resulting layout.
+     *
+     * Use margins to customize the space between widgets in the chain.
+     *
+     * Use weight to distribute available space to each widget when their vertical dimension is not
+     * fixed.
+     *
+     * &nbsp;
+     *
+     * Similarly named parameters available from [ConstrainScope.linkTo] are ignored in
+     * Chains.
+     *
+     * Since margins are only for widgets within the chain: Top and Bottom margins are
+     * ignored when the widget is the first or the last element in the chain, respectively.
+     *
+     * @param topMargin Added space from the top of this widget to the previous widget
+     * @param bottomMargin Added space from the bottom of this widget to the next widget
+     * @param topGoneMargin Added space from the top of this widget when the previous widget has [Visibility.Gone]
+     * @param bottomGoneMargin Added space from the bottom of this widget when the next widget has [Visibility.Gone]
+     * @param weight Defines the proportion of space (relative to the total weight) occupied by this
+     * layout when the height is not a fixed dimension.
+     * @return The same [LayoutReference] instance with the applied values
+     */
+    fun LayoutReference.withVerticalChainParams(
+        topMargin: Dp = 0.dp,
+        bottomMargin: Dp = 0.dp,
+        topGoneMargin: Dp = 0.dp,
+        bottomGoneMargin: Dp = 0.dp,
+        weight: Float = Float.NaN
+    ): LayoutReference =
+        withChainParams(
+            startMargin = 0.dp,
+            topMargin = topMargin,
+            endMargin = 0.dp,
+            bottomMargin = bottomMargin,
+            startGoneMargin = 0.dp,
+            topGoneMargin = topGoneMargin,
+            endGoneMargin = 0.dp,
+            bottomGoneMargin = bottomGoneMargin,
+            weight = weight
+        )
+
+    internal fun LayoutReference.asCLContainer(): CLObject {
+        val idString = id.toString()
+        if (containerObject.getObjectOrNull(idString) == null) {
+            containerObject.put(idString, CLObject(charArrayOf()))
+        }
+        return containerObject.getObject(idString)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) {
+            return true
+        }
+        if (other is ConstraintLayoutBaseScope) {
+            return containerObject == other.containerObject
+        }
+        return false
+    }
+
+    override fun hashCode(): Int {
+        return containerObject.hashCode()
     }
 }
 
@@ -653,6 +936,11 @@ abstract class ConstraintLayoutBaseScope {
  */
 @Stable
 abstract class LayoutReference internal constructor(internal open val id: Any) {
+    /**
+     * This map should be used to store one instance of different implementations of [HelperParams].
+     */
+    private val helperParamsMap: MutableMap<String, HelperParams> = mutableMapOf()
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -666,6 +954,60 @@ abstract class LayoutReference internal constructor(internal open val id: Any) {
 
     override fun hashCode(): Int {
         return id.hashCode()
+    }
+
+    internal fun setHelperParams(helperParams: HelperParams) {
+        // Use the class name to force one instance per implementation
+        helperParamsMap[helperParams.javaClass.simpleName] = helperParams
+    }
+
+    /**
+     * Returns the [HelperParams] that corresponds to the class type [T]. Null if no instance of
+     * type [T] has been set.
+     */
+    internal inline fun <reified T> getHelperParams(): T? where T : HelperParams {
+        return helperParamsMap[T::class.java.simpleName] as? T
+    }
+}
+
+/**
+ * Helpers that need parameters on a per-widget basis may implement this interface to store custom
+ * parameters within [LayoutReference].
+ *
+ * @see [LayoutReference.getHelperParams]
+ * @see [LayoutReference.setHelperParams]
+ */
+internal interface HelperParams
+
+/**
+ * Parameters that may be defined for each widget within a chain.
+ *
+ * These will always be used instead of similarly named parameters defined with other calls such as
+ * [ConstrainScope.linkTo].
+ */
+internal class ChainParams(
+    val startMargin: Dp,
+    val topMargin: Dp,
+    val endMargin: Dp,
+    val bottomMargin: Dp,
+    val startGoneMargin: Dp,
+    val topGoneMargin: Dp,
+    val endGoneMargin: Dp,
+    val bottomGoneMargin: Dp,
+    val weight: Float,
+) : HelperParams {
+    companion object {
+        internal val Default = ChainParams(
+            startMargin = 0.dp,
+            topMargin = 0.dp,
+            endMargin = 0.dp,
+            bottomMargin = 0.dp,
+            startGoneMargin = 0.dp,
+            topGoneMargin = 0.dp,
+            endGoneMargin = 0.dp,
+            bottomGoneMargin = 0.dp,
+            weight = Float.NaN
+        )
     }
 }
 
@@ -787,7 +1129,7 @@ class VerticalChainReference internal constructor(id: Any) : LayoutReference(id)
  */
 @Immutable
 class ChainStyle internal constructor(
-    internal val style: SolverChain,
+    internal val name: String,
     internal val bias: Float? = null
 ) {
     companion object {
@@ -795,14 +1137,14 @@ class ChainStyle internal constructor(
          * A chain style that evenly distributes the contained layouts.
          */
         @Stable
-        val Spread = ChainStyle(SolverChain.SPREAD)
+        val Spread = ChainStyle("spread")
 
         /**
          * A chain style where the first and last layouts are affixed to the constraints
          * on each end of the chain and the rest are evenly distributed.
          */
         @Stable
-        val SpreadInside = ChainStyle(SolverChain.SPREAD_INSIDE)
+        val SpreadInside = ChainStyle("spread_inside")
 
         /**
          * A chain style where the contained layouts are packed together and placed to the
@@ -816,7 +1158,7 @@ class ChainStyle internal constructor(
          * the available space according to a given [bias].
          */
         @Stable
-        fun Packed(bias: Float) = ChainStyle(SolverChain.PACKED, bias)
+        fun Packed(bias: Float) = ChainStyle("packed", bias)
     }
 }
 
@@ -825,7 +1167,7 @@ class ChainStyle internal constructor(
  */
 @Immutable
 class Visibility internal constructor(
-    internal val solverValue: Int
+    internal val name: String
 ) {
     companion object {
         /**
@@ -833,7 +1175,7 @@ class Visibility internal constructor(
          * transforms will apply normally.
          */
         @Stable
-        val Visible = Visibility(ConstraintWidget.VISIBLE)
+        val Visible = Visibility("visible")
 
         /**
          * The widget will not be painted in the [ConstraintLayout] but its dimensions and constraints
@@ -842,14 +1184,14 @@ class Visibility internal constructor(
          * Equivalent to forcing the alpha to 0.0.
          */
         @Stable
-        val Invisible = Visibility(ConstraintWidget.INVISIBLE)
+        val Invisible = Visibility("invisible")
 
         /**
          * Like [Invisible], but the dimensions of the widget will collapse to (0,0), the
          * constraints will still apply.
          */
         @Stable
-        val Gone = Visibility(ConstraintWidget.GONE)
+        val Gone = Visibility("gone")
     }
 }
 
@@ -858,15 +1200,12 @@ class Visibility internal constructor(
  */
 @Immutable
 class Wrap internal constructor(
-    internal val mode: Int
-    ) {
+    internal val name: String
+) {
     companion object {
-        val None =
-            Wrap(androidx.constraintlayout.core.widgets.Flow.WRAP_NONE)
-        val Chain =
-            Wrap(androidx.constraintlayout.core.widgets.Flow.WRAP_CHAIN)
-        val Aligned =
-            Wrap(androidx.constraintlayout.core.widgets.Flow.WRAP_ALIGNED)
+        val None = Wrap("none")
+        val Chain = Wrap("chain")
+        val Aligned = Wrap("aligned")
     }
 }
 
@@ -875,16 +1214,13 @@ class Wrap internal constructor(
  */
 @Immutable
 class VerticalAlign internal constructor(
-    internal val mode: Int
-    ) {
+    internal val name: String
+) {
     companion object {
-        val Top = VerticalAlign(androidx.constraintlayout.core.widgets.Flow.VERTICAL_ALIGN_TOP)
-        val Bottom =
-            VerticalAlign(androidx.constraintlayout.core.widgets.Flow.VERTICAL_ALIGN_BOTTOM)
-        val Center =
-            VerticalAlign(androidx.constraintlayout.core.widgets.Flow.VERTICAL_ALIGN_CENTER)
-        val Baseline =
-            VerticalAlign(androidx.constraintlayout.core.widgets.Flow.VERTICAL_ALIGN_BASELINE)
+        val Top = VerticalAlign("top")
+        val Bottom = VerticalAlign("bottom")
+        val Center = VerticalAlign("center")
+        val Baseline = VerticalAlign("baseline")
     }
 }
 
@@ -893,14 +1229,12 @@ class VerticalAlign internal constructor(
  */
 @Immutable
 class HorizontalAlign internal constructor(
-    internal val mode: Int
-    ) {
+    internal val name: String
+) {
     companion object {
-        val Start =
-            HorizontalAlign(androidx.constraintlayout.core.widgets.Flow.HORIZONTAL_ALIGN_START)
-        val End = HorizontalAlign(androidx.constraintlayout.core.widgets.Flow.HORIZONTAL_ALIGN_END)
-        val Center =
-            HorizontalAlign(androidx.constraintlayout.core.widgets.Flow.HORIZONTAL_ALIGN_CENTER)
+        val Start = HorizontalAlign("start")
+        val End = HorizontalAlign("end")
+        val Center = HorizontalAlign("center")
     }
 }
 
@@ -909,11 +1243,11 @@ class HorizontalAlign internal constructor(
  */
 @Immutable
 class FlowStyle internal constructor(
-    internal val style: Int
-    ) {
+    internal val name: String
+) {
     companion object {
-        val Spread = FlowStyle(0)
-        val SpreadInside = FlowStyle(1)
-        val Packed = FlowStyle(2)
+        val Spread = FlowStyle("spread")
+        val SpreadInside = FlowStyle("spread_inside")
+        val Packed = FlowStyle("packed")
     }
 }

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintScopeCommon.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintScopeCommon.kt
@@ -16,13 +16,16 @@
 
 package androidx.constraintlayout.compose
 
+import android.util.Log
 import androidx.compose.ui.layout.FirstBaseline
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import androidx.constraintlayout.compose.AnchorFunctions.verticalAnchorFunctions
-import androidx.constraintlayout.core.state.ConstraintReference
+import androidx.constraintlayout.core.parser.CLArray
+import androidx.constraintlayout.core.parser.CLNumber
+import androidx.constraintlayout.core.parser.CLObject
+import androidx.constraintlayout.core.parser.CLString
 
+@JvmDefaultWithCompatibility
 /**
  * Represents a vertical side of a layout (i.e start and end) that can be anchored using
  * [linkTo] in their `Modifier.constrainAs` blocks.
@@ -38,6 +41,7 @@ interface VerticalAnchorable {
     )
 }
 
+@JvmDefaultWithCompatibility
 /**
  * Represents a horizontal side of a layout (i.e top and bottom) that can be anchored using
  * [linkTo] in their `Modifier.constrainAs` blocks.
@@ -53,6 +57,7 @@ interface HorizontalAnchorable {
     )
 }
 
+@JvmDefaultWithCompatibility
 /**
  * Represents the [FirstBaseline] of a layout that can be anchored
  * using [linkTo] in their `Modifier.constrainAs` blocks.
@@ -69,133 +74,70 @@ interface BaselineAnchorable {
 }
 
 internal abstract class BaseVerticalAnchorable(
-    private val tasks: MutableList<(State) -> Unit>,
-    private val index: Int
+    private val containerObject: CLObject,
+    index: Int
 ) : VerticalAnchorable {
-    abstract fun getConstraintReference(state: State): ConstraintReference
+    private val anchorName: String = AnchorFunctions.verticalAnchorIndexToAnchorName(index)
 
     final override fun linkTo(
         anchor: ConstraintLayoutBaseScope.VerticalAnchor,
         margin: Dp,
         goneMargin: Dp
     ) {
-        tasks.add { state ->
-            val layoutDirection = state.layoutDirection
-            val index1 =
-                AnchorFunctions.verticalAnchorIndexToFunctionIndex(index, layoutDirection)
-            val index2 = AnchorFunctions.verticalAnchorIndexToFunctionIndex(
-                anchor.index,
-                layoutDirection
-            )
-            with(getConstraintReference(state)) {
-                verticalAnchorFunctions[index1][index2]
-                    .invoke(this, anchor.id, state.layoutDirection)
-                    .margin(margin)
-                    .marginGone(goneMargin)
-            }
+        val targetAnchorName = AnchorFunctions.verticalAnchorIndexToAnchorName(anchor.index)
+        val constraintArray = CLArray(charArrayOf()).apply {
+            add(CLString.from(anchor.id.toString()))
+            add(CLString.from(targetAnchorName))
+            add(CLNumber(margin.value))
+            add(CLNumber(goneMargin.value))
         }
+        containerObject.put(anchorName, constraintArray)
     }
 }
 
 internal abstract class BaseHorizontalAnchorable(
-    private val tasks: MutableList<(State) -> Unit>,
-    private val index: Int
+    private val containerObject: CLObject,
+    index: Int
 ) : HorizontalAnchorable {
-    abstract fun getConstraintReference(state: State): ConstraintReference
+    private val anchorName: String = AnchorFunctions.horizontalAnchorIndexToAnchorName(index)
 
     final override fun linkTo(
         anchor: ConstraintLayoutBaseScope.HorizontalAnchor,
         margin: Dp,
         goneMargin: Dp
     ) {
-        tasks.add { state ->
-            with(getConstraintReference(state)) {
-                AnchorFunctions.horizontalAnchorFunctions[index][anchor.index]
-                    .invoke(this, anchor.id)
-                    .margin(margin)
-                    .marginGone(goneMargin)
-            }
+        val targetAnchorName = AnchorFunctions.horizontalAnchorIndexToAnchorName(anchor.index)
+        val constraintArray = CLArray(charArrayOf()).apply {
+            add(CLString.from(anchor.id.toString()))
+            add(CLString.from(targetAnchorName))
+            add(CLNumber(margin.value))
+            add(CLNumber(goneMargin.value))
         }
+        containerObject.put(anchorName, constraintArray)
     }
 }
 
 internal object AnchorFunctions {
-    val verticalAnchorFunctions:
-        Array<Array<ConstraintReference.(Any, LayoutDirection) -> ConstraintReference>> =
-        arrayOf(
-            arrayOf(
-                { other, layoutDirection ->
-                    clearLeft(layoutDirection); leftToLeft(other)
-                },
-                { other, layoutDirection ->
-                    clearLeft(layoutDirection); leftToRight(other)
-                }
-            ),
-            arrayOf(
-                { other, layoutDirection ->
-                    clearRight(layoutDirection); rightToLeft(other)
-                },
-                { other, layoutDirection ->
-                    clearRight(layoutDirection); rightToRight(other)
-                }
-            )
-        )
 
-    private fun ConstraintReference.clearLeft(layoutDirection: LayoutDirection) {
-        leftToLeft(null)
-        leftToRight(null)
-        when (layoutDirection) {
-            LayoutDirection.Ltr -> {
-                startToStart(null); startToEnd(null)
-            }
-            LayoutDirection.Rtl -> {
-                endToStart(null); endToEnd(null)
+    fun horizontalAnchorIndexToAnchorName(index: Int): String =
+        when (index) {
+            0 -> "top"
+            1 -> "bottom"
+            else -> {
+                Log.e("CCL", "horizontalAnchorIndexToAnchorName: Unknown horizontal index")
+                "top"
             }
         }
-    }
 
-    private fun ConstraintReference.clearRight(layoutDirection: LayoutDirection) {
-        rightToLeft(null)
-        rightToRight(null)
-        when (layoutDirection) {
-            LayoutDirection.Ltr -> {
-                endToStart(null); endToEnd(null)
+    fun verticalAnchorIndexToAnchorName(index: Int): String =
+        when (index) {
+            -2 -> "start"
+            -1 -> "end"
+            0 -> "left"
+            1 -> "right"
+            else -> {
+                Log.e("CCL", "verticalAnchorIndexToAnchorName: Unknown vertical index")
+                "start"
             }
-            LayoutDirection.Rtl -> {
-                startToStart(null); startToEnd(null)
-            }
-        }
-    }
-
-    /**
-     * Converts the index (-2 -> start, -1 -> end, 0 -> left, 1 -> right) to an index in
-     * the arrays above (0 -> left, 1 -> right).
-     */
-    // TODO(popam, b/157886946): this is temporary until we can use CL's own RTL handling
-    fun verticalAnchorIndexToFunctionIndex(index: Int, layoutDirection: LayoutDirection) =
-        when {
-            index >= 0 -> index // already left or right
-            layoutDirection == LayoutDirection.Ltr -> 2 + index // start -> left, end -> right
-            else -> -index - 1 // start -> right, end -> left
-        }
-
-    val horizontalAnchorFunctions:
-        Array<Array<ConstraintReference.(Any) -> ConstraintReference>> = arrayOf(
-        arrayOf(
-            { other -> topToBottom(null); baselineToBaseline(null); topToTop(other) },
-            { other -> topToTop(null); baselineToBaseline(null); topToBottom(other) }
-        ),
-        arrayOf(
-            { other -> bottomToBottom(null); baselineToBaseline(null); bottomToTop(other) },
-            { other -> bottomToTop(null); baselineToBaseline(null); bottomToBottom(other) }
-        )
-    )
-    val baselineAnchorFunction: ConstraintReference.(Any) -> ConstraintReference =
-        { other ->
-            topToTop(null)
-            topToBottom(null)
-            bottomToTop(null)
-            bottomToBottom(null)
-            baselineToBaseline(other)
         }
 }

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintSet.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintSet.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.layout.Measurable
 import androidx.constraintlayout.core.state.Transition
 
+@JvmDefaultWithCompatibility
 /**
  * Immutable description of the constraints used to layout the children of a [ConstraintLayout].
  */
@@ -38,6 +39,7 @@ interface ConstraintSet {
     fun isDirty(measurables: List<Measurable>): Boolean = true
 }
 
+@JvmDefaultWithCompatibility
 @Immutable
 internal interface DerivedConstraintSet : ConstraintSet {
     /**
@@ -50,7 +52,7 @@ internal interface DerivedConstraintSet : ConstraintSet {
 
     override fun applyTo(state: State, measurables: List<Measurable>) {
         buildMapping(state, measurables)
-        (extendFrom as? DerivedConstraintSet)?.applyTo(state, measurables)
+        extendFrom?.applyTo(state, measurables)
         applyToState(state)
     }
 

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/DslConstraintSet.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/DslConstraintSet.kt
@@ -24,16 +24,32 @@ import androidx.compose.runtime.Immutable
 @Immutable
 internal class DslConstraintSet constructor(
     val description: ConstraintSetScope.() -> Unit,
-    override val extendFrom: ConstraintSet? = null
+    extendFrom: ConstraintSet? = null
 ) : DerivedConstraintSet {
+    internal val scope: ConstraintSetScope =
+        ConstraintSetScope(
+            extendFrom = (extendFrom as? DslConstraintSet)?.scope?.containerObject
+        ).apply(description)
+
+    override val extendFrom: ConstraintSet? = null // Not needed
+
     override fun applyToState(state: State) {
-        val scope = ConstraintSetScope()
-        scope.description()
         scope.applyTo(state)
     }
 
     override fun override(name: String, value: Float): ConstraintSet {
         // nothing yet
         return this
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other is DslConstraintSet) {
+            return scope == other.scope
+        }
+        return false
+    }
+
+    override fun hashCode(): Int {
+        return scope.hashCode()
     }
 }

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ExperimentalMotionApi.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ExperimentalMotionApi.kt
@@ -17,4 +17,5 @@
 package androidx.constraintlayout.compose
 
 @RequiresOptIn("MotionLayout API is experimental and it is likely to change.")
+@Retention(AnnotationRetention.BINARY)
 annotation class ExperimentalMotionApi

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/Motion.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/Motion.kt
@@ -45,9 +45,7 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.round
-import androidx.constraintlayout.core.state.CorePixelDp
 import androidx.constraintlayout.core.state.Transition.WidgetState
 import androidx.constraintlayout.core.widgets.ConstraintWidget
 import kotlin.math.abs
@@ -169,7 +167,7 @@ class MotionScope(
         ignoreAxisChanges: Boolean = false,
         motionDescription: MotionModifierScope.() -> Unit = {},
     ): Modifier = composed {
-        val dpToPixel = with(LocalDensity.current) { 1.dp.toPx() }
+        val dpToPxFactor = with(LocalDensity.current) { density }
         val layoutId = remember { nextId++ }
         val transitionScope = remember { MotionModifierScope(layoutId) }
         val snapshotObserver = remember {
@@ -204,17 +202,14 @@ class MotionScope(
             transitionScope.motionDescription()
         }
 
-        @Suppress("RedundantSamConstructor") // Clearer this way
         val transitionImpl = remember {
-            TransitionImpl(
-                transitionScope.getObject(),
-                CorePixelDp { dpValue -> dpValue * dpToPixel }
-            )
+            TransitionImpl(transitionScope.getObject())
         }
         val transitionState = remember {
-            androidx.constraintlayout.core.state.Transition().apply {
-                transitionImpl.applyAllTo(this)
-            }
+            androidx.constraintlayout.core.state.Transition { dpValue -> dpValue * dpToPxFactor }
+                .apply {
+                    transitionImpl.applyAllTo(this)
+                }
         }
         val startWidget =
             remember { ConstraintWidget().apply { stringId = layoutId.toString() } }

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionCarousel.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionCarousel.kt
@@ -37,11 +37,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.MotionLayoutScope.MotionProperties
-
-// TODO: replace this implementation?
 import androidx.constraintlayout.compose.carousel.FractionalThreshold
-import androidx.constraintlayout.compose.carousel.rememberCarouselSwipeableState
 import androidx.constraintlayout.compose.carousel.carouselSwipeable
+import androidx.constraintlayout.compose.carousel.rememberCarouselSwipeableState
 
 /**
  * Implements an horizontal Carousel of n elements, driven by drag gestures and customizable
@@ -248,6 +246,7 @@ fun MotionCarousel(
                 state = swipeableState,
                 anchors = anchors,
                 reverseDirection = true,
+                // TODO: replace this implementation?
                 thresholds = { _, _ -> FractionalThreshold(0.3f) },
                 orientation = Orientation.Horizontal
             )

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionLayout.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionLayout.kt
@@ -363,7 +363,8 @@ internal inline fun MotionLayoutCore(
     if (forcedDebug != null && forcedDebug != MotionLayoutDebugFlags.UNKNOWN) {
         usedDebugMode = forcedDebug
     }
-    val measurer = remember { MotionMeasurer() }
+    val density = LocalDensity.current
+    val measurer = remember { MotionMeasurer(density) }
     val scope = remember { MotionLayoutScope(measurer, motionProgress) }
     val debug = EnumSet.of(usedDebugMode)
     val measurePolicy =
@@ -596,8 +597,7 @@ internal fun rememberMotionLayoutMeasurePolicy(
                 measurables,
                 optimizationLevel,
                 motionProgress.currentProgress,
-                motionLayoutFlags,
-                this
+                motionLayoutFlags
             )
             layout(layoutSize.width, layoutSize.height) {
                 with(measurer) {

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionScene.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/MotionScene.kt
@@ -21,13 +21,10 @@ import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.core.parser.CLParser
 import androidx.constraintlayout.core.parser.CLParsingException
 import androidx.constraintlayout.core.state.ConstraintSetParser
 import androidx.constraintlayout.core.state.CoreMotionScene
-import androidx.constraintlayout.core.state.CorePixelDp
 import org.intellij.lang.annotations.Language
 
 /**
@@ -50,16 +47,16 @@ interface MotionScene : CoreMotionScene {
 @ExperimentalMotionApi
 @Composable
 fun MotionScene(@Language("json5") content: String): MotionScene {
-    val density = LocalDensity.current
+    // TODO: Explore if we can make this a non-Composable, we have to make sure that it doesn't
+    //  break Link functionality
     return remember(content) {
-        JSONMotionScene(content, CorePixelDp { with(density) { 1.dp.toPx() } })
+        JSONMotionScene(content)
     }
 }
 
 @ExperimentalMotionApi
 internal class JSONMotionScene(
-    @Language("json5") content: String,
-    private val dpToPx: CorePixelDp
+    @Language("json5") content: String
 ) : EditableJSONLayout(content), MotionScene {
 
     private val constraintSetsContent = HashMap<String, String>()
@@ -113,7 +110,7 @@ internal class JSONMotionScene(
                 null
             }
         } ?: return null
-        return TransitionImpl(parsed, dpToPx)
+        return TransitionImpl(parsed)
     }
 
     // endregion

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/Transition.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/Transition.kt
@@ -18,15 +18,10 @@ package androidx.constraintlayout.compose
 
 import android.annotation.SuppressLint
 import android.util.Log
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.remember
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.core.parser.CLObject
 import androidx.constraintlayout.core.parser.CLParser
 import androidx.constraintlayout.core.parser.CLParsingException
-import androidx.constraintlayout.core.state.CorePixelDp
 import androidx.constraintlayout.core.state.TransitionParser
 import org.intellij.lang.annotations.Language
 
@@ -47,24 +42,14 @@ interface Transition {
  */
 @SuppressLint("ComposableNaming")
 @ExperimentalMotionApi
-@Composable
-fun Transition(@Language("json5") content: String): Transition? {
-    val dpToPixel = with(LocalDensity.current) { 1.dp.toPx() }
-    val transition = remember(content) {
-        val parsed = try {
-            CLParser.parse(content)
-        } catch (e: CLParsingException) {
-            Log.e("CML", "Error parsing JSON $e")
-            null
-        }
-        if (parsed != null) {
-            val pixelDp = CorePixelDp { dpValue -> dpValue * dpToPixel }
-            TransitionImpl(parsed, pixelDp)
-        } else {
-            null
-        }
+fun Transition(@Language("json5") content: String): Transition {
+    val parsed = try {
+        CLParser.parse(content)
+    } catch (e: CLParsingException) {
+        Log.e("CML", "Error parsing JSON $e")
+        null
     }
-    return transition
+    return parsed?.let { TransitionImpl(parsed) } ?: TransitionImpl.EMPTY
 }
 
 /**
@@ -74,8 +59,7 @@ fun Transition(@Language("json5") content: String): Transition? {
  */
 @ExperimentalMotionApi
 internal class TransitionImpl(
-    private val parsedTransition: CLObject,
-    private val pixelDp: CorePixelDp
+    private val parsedTransition: CLObject
 ) : Transition {
 
     /**
@@ -83,7 +67,7 @@ internal class TransitionImpl(
      */
     fun applyAllTo(transition: androidx.constraintlayout.core.state.Transition) {
         try {
-            TransitionParser.parse(parsedTransition, transition, pixelDp)
+            TransitionParser.parse(parsedTransition, transition)
         } catch (e: CLParsingException) {
             Log.e("CML", "Error parsing JSON $e")
         }
@@ -107,5 +91,24 @@ internal class TransitionImpl(
 
     override fun getEndConstraintSetId(): String {
         return parsedTransition.getStringOrNull("to") ?: "end"
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as TransitionImpl
+
+        if (parsedTransition != other.parsedTransition) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return parsedTransition.hashCode()
+    }
+
+    internal companion object {
+        internal val EMPTY = TransitionImpl(CLObject(charArrayOf()))
     }
 }

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/TransitionScope.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/TransitionScope.kt
@@ -18,68 +18,23 @@ package androidx.constraintlayout.compose
 
 import androidx.annotation.FloatRange
 import androidx.annotation.IntRange
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.RememberObserver
-import androidx.compose.runtime.currentRecomposeScope
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.snapshots.SnapshotStateObserver
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.core.parser.CLArray
 import androidx.constraintlayout.core.parser.CLContainer
 import androidx.constraintlayout.core.parser.CLNumber
 import androidx.constraintlayout.core.parser.CLObject
 import androidx.constraintlayout.core.parser.CLString
-import androidx.constraintlayout.core.state.CorePixelDp
 import kotlin.properties.ObservableProperty
 import kotlin.reflect.KProperty
 
 @ExperimentalMotionApi
-@Composable
 fun Transition(
     from: String = "start",
     to: String = "end",
     transitionContent: TransitionScope.() -> Unit
 ): Transition {
-    val dpToPixel = with(LocalDensity.current) { 1.dp.toPx() }
-    val transitionScope = remember(from, to) { TransitionScope(from, to) }
-    val snapshotObserver = remember {
-        // We use a Snapshot observer to know when state within the DSL has changed and recompose
-        // the transition object
-        SnapshotStateObserver {
-            it()
-        }
-    }
-    remember {
-        object : RememberObserver {
-            override fun onAbandoned() {
-                // TODO: Investigate if we need to do something here
-            }
-
-            override fun onForgotten() {
-                snapshotObserver.stop()
-                snapshotObserver.clear()
-            }
-
-            override fun onRemembered() {
-                snapshotObserver.start()
-            }
-        }
-    }
-    snapshotObserver.observeReads(currentRecomposeScope, {
-        it.invalidate()
-    }) {
-        transitionScope.reset()
-        // Observe state changes within the DSL, to know when to invalidate and update the
-        // Transition
-        transitionScope.transitionContent()
-    }
-    return remember {
-        TransitionImpl(
-            transitionScope.getObject(),
-            CorePixelDp { dpValue -> dpValue * dpToPixel }
-        )
-    }
+    val transitionScope = TransitionScope(from, to)
+    transitionScope.transitionContent()
+    return TransitionImpl(transitionScope.getObject())
 }
 
 @ExperimentalMotionApi
@@ -264,18 +219,48 @@ class KeyCyclesScope internal constructor(vararg targets: ConstrainedLayoutRefer
 
 @ExperimentalMotionApi
 abstract class BaseKeyFrameScope internal constructor() {
-    protected val userAttributes = mutableMapOf<String, Any>()
+    /**
+     * PropertyName-Value map for the properties of each type of key frame.
+     *
+     * The values are for a singular unspecified frame.
+     */
+    private val keyFramePropertiesValue = mutableMapOf<String, Any>()
 
+    /**
+     * PropertyName-Value map for user-defined values.
+     *
+     * Typically used on KeyAttributes only.
+     */
+    internal val customPropertiesValue = mutableMapOf<String, Any>()
+
+    /**
+     * When changed, updates the value of type [T] on the [keyFramePropertiesValue] map.
+     *
+     * Where the Key is the property's name unless [nameOverride] is not null.
+     */
     protected fun <T> addOnPropertyChange(initialValue: T, nameOverride: String? = null) =
         object : ObservableProperty<T>(initialValue) {
             override fun afterChange(property: KProperty<*>, oldValue: T, newValue: T) {
                 val name = nameOverride ?: property.name
                 if (newValue != null) {
-                    userAttributes[name] = newValue
+                    keyFramePropertiesValue[name] = newValue
                 }
             }
         }
 
+    /**
+     * Property delegate that updates the [keyFramePropertiesValue] map on value changes.
+     *
+     * Where the Key is the property's name unless [nameOverride] is not null.
+     *
+     * The value is the String given by [NamedPropertyOrValue.name].
+     *
+     * &nbsp;
+     *
+     * Use when declaring properties that have a named value.
+     *
+     * E.g.: `var curveFit: CurveFit? by addNameOnPropertyChange(null)`
+     */
     protected fun <E : NamedPropertyOrValue?> addNameOnPropertyChange(
         initialValue: E,
         nameOverride: String? = null
@@ -284,14 +269,35 @@ abstract class BaseKeyFrameScope internal constructor() {
             override fun afterChange(property: KProperty<*>, oldValue: E, newValue: E) {
                 val name = nameOverride ?: property.name
                 if (newValue != null) {
-                    userAttributes[name] = newValue.name
+                    keyFramePropertiesValue[name] = newValue.name
                 }
             }
         }
 
-    fun addToContainer(container: CLContainer) {
-        userAttributes.forEach { (name, value) ->
-            val array = container.getArrayOrCreate(name)
+    /**
+     * Adds the property maps to the given container.
+     *
+     * Where every value is treated as part of array.
+     */
+    internal fun addToContainer(container: CLContainer) {
+        container.putValuesAsArrayElements(keyFramePropertiesValue)
+        val customPropsObject = container.getObjectOrNull("custom") ?: run {
+            val custom = CLObject(charArrayOf())
+            container.put("custom", custom)
+            custom
+        }
+        customPropsObject.putValuesAsArrayElements(customPropertiesValue)
+    }
+
+    /**
+     * Adds the values from [propertiesSource] to the [CLContainer].
+     *
+     * Each value will be added as a new element of their corresponding array (given by the Key,
+     * which is the name of the affected property).
+     */
+    private fun CLContainer.putValuesAsArrayElements(propertiesSource: Map<String, Any>) {
+        propertiesSource.forEach { (name, value) ->
+            val array = this.getArrayOrCreate(name)
             when (value) {
                 is String -> {
                     val stringChars = value.toCharArray()
@@ -395,8 +401,6 @@ class Arc internal constructor(val name: String) {
         val StartVertical = Arc("startVertical")
         val StartHorizontal = Arc("startHorizontal")
         val Flip = Arc("flip")
-        val ArcDown = Arc("arcDown")
-        val ArcUp = Arc("arcUp")
     }
 }
 

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/carousel/CarouselSwipeable.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/carousel/CarouselSwipeable.kt
@@ -48,15 +48,15 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.sign
+import kotlin.math.sin
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
-import kotlin.math.PI
-import kotlin.math.abs
-import kotlin.math.sign
-import kotlin.math.sin
 
 /**
  * State of the [carouselSwipeable] modifier.

--- a/constraintlayout/core/build.gradle
+++ b/constraintlayout/core/build.gradle
@@ -9,6 +9,7 @@ globalConfig {
 }
 
 dependencies {
+    api("androidx.annotation:annotation:1.5.0")
     testImplementation "junit:junit:4.13.1"
 }
 

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/parser/CLContainer.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/parser/CLContainer.java
@@ -16,6 +16,7 @@
 package androidx.constraintlayout.core.parser;
 
 import java.util.ArrayList;
+import java.util.Objects;
 
 public class CLContainer extends CLElement {
     ArrayList<CLElement> mElements = new ArrayList<>();
@@ -347,5 +348,33 @@ public class CLContainer extends CLElement {
             return element.content();
         }
         return null;
+    }
+
+    @Override
+    public CLContainer clone() {
+        CLContainer clone = (CLContainer) super.clone();
+        ArrayList<CLElement> clonedArray = new ArrayList<>(mElements.size());
+        for (CLElement element: mElements) {
+            clonedArray.add(element.clone());
+        }
+        clone.mElements = clonedArray;
+        return clone;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (!(obj instanceof CLContainer)) {
+            return false;
+        }
+        return this.mElements.equals(((CLContainer) obj).mElements);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mElements, super.hashCode());
     }
 }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/parser/CLElement.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/parser/CLElement.java
@@ -15,7 +15,13 @@
  */
 package androidx.constraintlayout.core.parser;
 
-public class CLElement {
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Base element to represent a piece of parsed Json.
+ */
+public class CLElement implements Cloneable {
 
     private final char[] mContent;
     protected long mStart = -1;
@@ -118,6 +124,15 @@ public class CLElement {
         return content.substring((int) mStart, (int) mEnd + 1);
     }
 
+    /**
+     * Whether this element has any valid content defined.
+     * <p>
+     * The content is valid when {@link #content()} can be called without causing exceptions.
+     */
+    public boolean hasContent() {
+        return mContent != null && mContent.length >= 1;
+    }
+
     public boolean isDone() {
         return mEnd != Long.MAX_VALUE;
     }
@@ -156,5 +171,43 @@ public class CLElement {
             return ((CLNumber) this).getFloat();
         }
         return Float.NaN;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CLElement)) return false;
+
+        CLElement clElement = (CLElement) o;
+
+        if (mStart != clElement.mStart) return false;
+        if (mEnd != clElement.mEnd) return false;
+        if (mLine != clElement.mLine) return false;
+        if (!Arrays.equals(mContent, clElement.mContent)) return false;
+        return Objects.equals(mContainer, clElement.mContainer);
+    }
+
+    @Override
+    public int hashCode() {
+        // Auto-generated with Intellij Action "equals() and hashcode()"
+        int result = Arrays.hashCode(mContent);
+        result = 31 * result + (int) (mStart ^ (mStart >>> 32));
+        result = 31 * result + (int) (mEnd ^ (mEnd >>> 32));
+        result = 31 * result + (mContainer != null ? mContainer.hashCode() : 0);
+        result = 31 * result + mLine;
+        return result;
+    }
+
+    @Override
+    public CLElement clone() {
+        try {
+            CLElement clone = (CLElement) super.clone();
+            if (mContainer != null) {
+                clone.mContainer = (CLContainer) mContainer.clone();
+            }
+            return clone;
+        } catch (CloneNotSupportedException e) {
+            throw new AssertionError();
+        }
     }
 }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/parser/CLKey.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/parser/CLKey.java
@@ -16,6 +16,7 @@
 package androidx.constraintlayout.core.parser;
 
 import java.util.ArrayList;
+import java.util.Objects;
 
 public class CLKey extends CLContainer {
 
@@ -103,5 +104,25 @@ public class CLKey extends CLContainer {
             return mElements.get(0);
         }
         return null;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof CLKey) {
+            CLKey objKey = (CLKey) obj;
+            if (!Objects.equals(this.getName(), objKey.getName())) {
+                return false;
+            }
+        }
+        // Delegate the rest to parent
+        return super.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
     }
 }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/parser/CLNumber.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/parser/CLNumber.java
@@ -66,7 +66,8 @@ public class CLNumber extends CLElement {
 
     @Override
     public int getInt() {
-        if (Float.isNaN(mValue)) {
+        if (Float.isNaN(mValue) && hasContent()) {
+            // If the value is undefined, attempt to define it from the content
             mValue = Integer.parseInt(content());
         }
         return (int) mValue;
@@ -74,7 +75,8 @@ public class CLNumber extends CLElement {
 
     @Override
     public float getFloat() {
-        if (Float.isNaN(mValue)) {
+        if (Float.isNaN(mValue) && hasContent()) {
+            // If the value is undefined, attempt to define it from the content
             mValue = Float.parseFloat(content());
         }
         return mValue;
@@ -85,4 +87,30 @@ public class CLNumber extends CLElement {
         this.mValue = value;
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj instanceof CLNumber) {
+            float thisFloat = getFloat();
+            float otherFloat = ((CLNumber) obj).getFloat();
+            if (Float.isNaN(thisFloat) && Float.isNaN(otherFloat)) {
+                // Consider equal if both elements have a NaN value
+                return true;
+            }
+            return thisFloat == otherFloat;
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        // Auto-generated with Intellij Action "equals() and hashcode()"
+        int result = super.hashCode();
+        result = 31 * result + (mValue != 0.0f ? Float.floatToIntBits(mValue) : 0);
+        return result;
+    }
 }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/parser/CLObject.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/parser/CLObject.java
@@ -103,4 +103,10 @@ public class CLObject extends CLContainer implements Iterable<CLKey> {
             return key;
         }
     }
+
+    @Override
+    public CLObject clone() {
+        // Overriding to get expected return type
+        return (CLObject) super.clone();
+    }
 }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/parser/CLString.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/parser/CLString.java
@@ -15,6 +15,11 @@
  */
 package androidx.constraintlayout.core.parser;
 
+import androidx.annotation.NonNull;
+
+/**
+ * {@link CLElement} implementation for json Strings when used as property values or array elements.
+ */
 public class CLString extends CLElement {
 
     public CLString(char[] content) {
@@ -24,6 +29,17 @@ public class CLString extends CLElement {
     // @TODO: add description
     public static CLElement allocate(char[] content) {
         return new CLString(content);
+    }
+
+    /**
+     * Creates a {@link CLString} element from a String object.
+     */
+    @NonNull
+    public static CLString from(@NonNull String content) {
+        CLString stringElement = new CLString(content.toCharArray());
+        stringElement.setStart(0L);
+        stringElement.setEnd(content.length() - 1);
+        return stringElement;
     }
 
     @Override
@@ -39,6 +55,22 @@ public class CLString extends CLElement {
         json.append(content());
         json.append("'");
         return json.toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof CLString && this.content().equals(((CLString) obj).content())) {
+            return true;
+        }
+        return super.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
     }
 }
 

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintSetParser.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintSetParser.java
@@ -22,6 +22,8 @@ import static androidx.constraintlayout.core.motion.utils.TypedValues.MotionType
 import static androidx.constraintlayout.core.widgets.ConstraintWidget.HORIZONTAL;
 import static androidx.constraintlayout.core.widgets.ConstraintWidget.VERTICAL;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.RestrictTo;
 import androidx.constraintlayout.core.motion.utils.TypedBundle;
 import androidx.constraintlayout.core.motion.utils.TypedValues;
 import androidx.constraintlayout.core.parser.CLArray;
@@ -35,8 +37,8 @@ import androidx.constraintlayout.core.parser.CLString;
 import androidx.constraintlayout.core.state.helpers.BarrierReference;
 import androidx.constraintlayout.core.state.helpers.ChainReference;
 import androidx.constraintlayout.core.state.helpers.FlowReference;
-import androidx.constraintlayout.core.state.helpers.GuidelineReference;
 import androidx.constraintlayout.core.state.helpers.GridReference;
+import androidx.constraintlayout.core.state.helpers.GuidelineReference;
 import androidx.constraintlayout.core.widgets.ConstraintWidget;
 import androidx.constraintlayout.core.widgets.Flow;
 
@@ -467,100 +469,123 @@ public class ConstraintSetParser {
      * @param layoutVariables the variables to override
      */
     public static void parseJSON(String content, State state,
-            LayoutVariables layoutVariables) throws CLParsingException {
+                                 LayoutVariables layoutVariables) throws CLParsingException {
         try {
             CLObject json = CLParser.parse(content);
-            ArrayList<String> elements = json.names();
-            if (elements == null) {
-                return;
-            }
-            for (String elementName : elements) {
-                CLElement element = json.get(elementName);
-                if (PARSER_DEBUG) {
-                    System.out.println("[" + elementName + "] = " + element
-                            + " > " + element.getContainer());
-                }
-                switch (elementName) {
-                    case "Variables":
-                        if (element instanceof CLObject) {
-                            parseVariables(state, layoutVariables, (CLObject) element);
-                        }
-                        break;
-                    case "Helpers":
-                        if (element instanceof CLArray) {
-                            parseHelpers(state, layoutVariables, (CLArray) element);
-                        }
-                        break;
-                    case "Generate":
-                        if (element instanceof CLObject) {
-                            parseGenerate(state, layoutVariables, (CLObject) element);
-                        }
-                        break;
-                    default:
-                        if (element instanceof CLObject) {
-                            String type = lookForType((CLObject) element);
-                            if (type != null) {
-                                switch (type) {
-                                    case "hGuideline":
-                                        parseGuidelineParams(
-                                                ConstraintWidget.HORIZONTAL,
-                                                state,
-                                                elementName,
-                                                (CLObject) element);
-                                        break;
-                                    case "vGuideline":
-                                        parseGuidelineParams(
-                                                ConstraintWidget.VERTICAL,
-                                                state,
-                                                elementName,
-                                                (CLObject) element
-                                        );
-                                        break;
-                                    case "barrier":
-                                        parseBarrier(state, elementName, (CLObject) element);
-                                        break;
-                                    case "vChain":
-                                    case "hChain":
-                                        parseChainType(
-                                                type,
-                                                state,
-                                                elementName,
-                                                layoutVariables,
-                                                (CLObject) element
-                                        );
-                                        break;
-                                    case "vFlow":
-                                    case "hFlow":
-                                        parseFlowType(
-                                                type,
-                                                state,
-                                                elementName,
-                                                layoutVariables,
-                                                (CLObject) element
-                                        );
-                                        break;
-                                    case "Grid":
-                                    case "Row":
-                                    case "Column":
-                                        parseGridType(type,
-                                                state,
-                                                elementName,
-                                                layoutVariables,
-                                                (CLObject) element);
-                                        break;
-                                }
-                            } else {
-                                parseWidget(state, layoutVariables,
-                                        elementName, (CLObject) element);
-                            }
-                        } else if (element instanceof CLNumber) {
-                            layoutVariables.put(elementName, element.getInt());
-                        }
-                }
-            }
-
+            populateState(json, state, layoutVariables);
         } catch (CLParsingException e) {
             System.err.println("Error parsing JSON " + e);
+        }
+    }
+
+    /**
+     * Populates the given {@link State} with the parameters from {@link CLObject}. Where the
+     * object represents a parsed JSONObject of a ConstraintSet.
+     *
+     * @param parsedJson CLObject of the parsed ConstraintSet
+     * @param state the state to populate
+     * @param layoutVariables the variables to override
+     * @throws CLParsingException when parsing fails
+     * @hide
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    public static void populateState(
+            @NonNull CLObject parsedJson,
+            @NonNull State state,
+            @NonNull LayoutVariables layoutVariables
+    ) throws CLParsingException {
+        ArrayList<String> elements = parsedJson.names();
+        if (elements == null) {
+            return;
+        }
+        for (String elementName : elements) {
+            CLElement element = parsedJson.get(elementName);
+            if (PARSER_DEBUG) {
+                System.out.println("[" + elementName + "] = " + element
+                        + " > " + element.getContainer());
+            }
+            switch (elementName) {
+                case "Variables":
+                    if (element instanceof CLObject) {
+                        parseVariables(state, layoutVariables, (CLObject) element);
+                    }
+                    break;
+                case "Helpers":
+                    if (element instanceof CLArray) {
+                        parseHelpers(state, layoutVariables, (CLArray) element);
+                    }
+                    break;
+                case "Generate":
+                    if (element instanceof CLObject) {
+                        parseGenerate(state, layoutVariables, (CLObject) element);
+                    }
+                    break;
+                default:
+                    if (element instanceof CLObject) {
+                        String type = lookForType((CLObject) element);
+                        if (type != null) {
+                            switch (type) {
+                                case "hGuideline":
+                                    parseGuidelineParams(
+                                            ConstraintWidget.HORIZONTAL,
+                                            state,
+                                            elementName,
+                                            (CLObject) element
+                                    );
+                                    break;
+                                case "vGuideline":
+                                    parseGuidelineParams(
+                                            ConstraintWidget.VERTICAL,
+                                            state,
+                                            elementName,
+                                            (CLObject) element
+                                    );
+                                    break;
+                                case "barrier":
+                                    parseBarrier(state, elementName, (CLObject) element);
+                                    break;
+                                case "vChain":
+                                case "hChain":
+                                    parseChainType(
+                                            type,
+                                            state,
+                                            elementName,
+                                            layoutVariables,
+                                            (CLObject) element
+                                    );
+                                    break;
+                                case "vFlow":
+                                case "hFlow":
+                                    parseFlowType(
+                                            type,
+                                            state,
+                                            elementName,
+                                            layoutVariables,
+                                            (CLObject) element
+                                    );
+                                    break;
+                                case "grid":
+                                case "row":
+                                case "column":
+                                    parseGridType(
+                                            type,
+                                            state,
+                                            elementName,
+                                            layoutVariables,
+                                            (CLObject) element
+                                    );
+                                    break;
+                            }
+                        } else {
+                            parseWidget(state,
+                                    layoutVariables,
+                                    elementName,
+                                    (CLObject) element);
+                        }
+                    } else if (element instanceof CLNumber) {
+                        layoutVariables.put(elementName, element.getInt());
+                    }
+            }
         }
     }
 
@@ -654,7 +679,6 @@ public class ConstraintSetParser {
             }
             break;
         }
-
     }
 
     static void parseHelpers(State state,
@@ -760,9 +784,10 @@ public class ConstraintSetParser {
         }
     }
 
-    private static float toPix(State state, float dp){
-       return state.getDpToPixel().toPixels(dp);
+    private static float toPix(State state, float dp) {
+        return state.getDpToPixel().toPixels(dp);
     }
+
     /**
      * Support parsing Chain in the following manner
      * chainId : {
@@ -807,6 +832,8 @@ public class ConstraintSetParser {
                                 float weight = Float.NaN;
                                 float preMargin = Float.NaN;
                                 float postMargin = Float.NaN;
+                                float preGoneMargin = Float.NaN;
+                                float postGoneMargin = Float.NaN;
                                 switch (array.size()) {
                                     case 2: // sets only the weight
                                         weight = array.getFloat(1);
@@ -820,8 +847,21 @@ public class ConstraintSetParser {
                                         preMargin = toPix(state, array.getFloat(2));
                                         postMargin = toPix(state, array.getFloat(3));
                                         break;
+                                    case 6: // weight, preMargin, postMargin, preGoneMargin,
+                                        // postGoneMargin
+                                        weight = array.getFloat(1);
+                                        preMargin = toPix(state, array.getFloat(2));
+                                        postMargin = toPix(state, array.getFloat(3));
+                                        preGoneMargin = toPix(state, array.getFloat(4));
+                                        postGoneMargin = toPix(state, array.getFloat(5));
+                                        break;
                                 }
-                                chain.addChainElement(id, weight, preMargin, postMargin);
+                                chain.addChainElement(id,
+                                        weight,
+                                        preMargin,
+                                        postMargin,
+                                        preGoneMargin,
+                                        postGoneMargin);
                             }
                         } else {
                             chain.add(chainElement.content());
@@ -864,11 +904,38 @@ public class ConstraintSetParser {
         }
     }
 
+    /**
+     * Support parsing Grid in the following manner
+     * chainId : {
+     *      height: "parent",
+     *      width: "parent",
+     *      type: "Grid",
+     *      vGap: 10,
+     *      hGap: 10,
+     *      orientation: 0,
+     *      rows: 0,
+     *      columns: 1,
+     *      columnWeights: "",
+     *      rowWeights: "",
+     *      contains: ["btn1", "btn2", "btn3", "btn4"],
+     *      top: ["parent", "top", 10],
+     *      bottom: ["parent", "bottom", 20],
+     *      right: ["parent", "right", 30],
+     *      left: ["parent", "left", 40],
+     * }
+     *
+     * @param gridType type of the Grid helper could be "Grid"|"Row"|"Column"
+     * @param state ConstraintLayout State
+     * @param name the name of the Grid Helper
+     * @param layoutVariables layout margins
+     * @param element the element to be parsed
+     * @throws CLParsingException
+     */
     private static void parseGridType(String gridType,
-                                       State state,
-                                       String name,
-                                       LayoutVariables layoutVariables,
-                                       CLObject element) throws CLParsingException {
+                                      State state,
+                                      String name,
+                                      LayoutVariables layoutVariables,
+                                      CLObject element) throws CLParsingException {
 
         GridReference grid = state.getGrid(name, gridType);
 
@@ -882,13 +949,6 @@ public class ConstraintSetParser {
                             String elementNameReference = list.get(j).content();
                             ConstraintReference elementReference =
                                     state.constraints(elementNameReference);
-                            if (PARSER_DEBUG) {
-                                System.out.println(
-                                        "Add REFERENCE "
-                                                + "($elementNameReference = $elementReference) "
-                                                + "TO BARRIER "
-                                );
-                            }
                             grid.add(elementReference);
                         }
                     }
@@ -916,25 +976,25 @@ public class ConstraintSetParser {
                 case "spans":
                     String spans = element.get(param).content();
                     if (spans != null && spans.contains("x") && spans.contains(":")) {
-                        grid.setStrSpans(spans);
+                        grid.setSpans(spans);
                     }
                     break;
                 case "skips":
                     String skips = element.get(param).content();
                     if (skips != null && skips.contains("x") && skips.contains(":")) {
-                        grid.setStrSkips(skips);
+                        grid.setSkips(skips);
                     }
                     break;
                 case "rowWeights":
                     String rowWeights = element.get(param).content();
                     if (rowWeights != null && rowWeights.contains(",")) {
-                        grid.setStrRowWeights(rowWeights);
+                        grid.setRowWeights(rowWeights);
                     }
                     break;
                 case "columnWeights":
                     String columnWeights = element.get(param).content();
                     if (columnWeights != null && columnWeights.contains(",")) {
-                        grid.setStrColumnWeights(columnWeights);
+                        grid.setColumnWeights(columnWeights);
                     }
                     break;
                 default:
@@ -1263,20 +1323,81 @@ public class ConstraintSetParser {
             state.verticalGuideline(guidelineId);
         }
 
+        // Ignore LTR for Horizontal guidelines, since `start` & `end` represent the distance
+        // from `top` and `bottom` respectively
+        boolean isLtr = state.isLtr() || orientation == ConstraintWidget.HORIZONTAL;
+
         GuidelineReference guidelineReference = (GuidelineReference) reference.getFacade();
+
+        // Whether the guideline is based on percentage or distance
+        boolean isPercent = false;
+
+        // Percent or distance value of the guideline
+        float value = 0f;
+
+        // Indicates if the value is considered from the "start" position,
+        // meaning "left" anchor for vertical guidelines and "top" anchor for
+        // horizontal guidelines
+        boolean fromStart = true;
         for (String constraintName : constraints) {
             switch (constraintName) {
+                // left and right are here just to support LTR independent vertical guidelines
+                case "left":
+                    value = toPix(state, params.getFloat(constraintName));
+                    fromStart = true;
+                    break;
+                case "right":
+                    value = toPix(state, params.getFloat(constraintName));
+                    fromStart = false;
+                    break;
                 case "start":
-                    int margin = state.convertDimension(params.getFloat(constraintName));
-                    guidelineReference.start(state.getDpToPixel().toPixels(margin));
+                    value = toPix(state, params.getFloat(constraintName));
+                    fromStart = isLtr;
                     break;
                 case "end":
-                    margin = state.convertDimension(params.getFloat(constraintName));
-                    guidelineReference.end(state.getDpToPixel().toPixels(margin));
+                    value = toPix(state, params.getFloat(constraintName));
+                    fromStart = !isLtr;
                     break;
                 case "percent":
-                    guidelineReference.percent(params.getFloat(constraintName));
+                    isPercent = true;
+                    CLArray percentParams = params.getArrayOrNull(constraintName);
+                    if (percentParams == null) {
+                        fromStart = true;
+                        value = params.getFloat(constraintName);
+                    } else if (percentParams.size() > 1) {
+                        String origin = percentParams.getString(0);
+                        value = percentParams.getFloat(1);
+                        switch (origin) {
+                            case "left":
+                                fromStart = true;
+                                break;
+                            case "right":
+                                fromStart = false;
+                                break;
+                            case "start":
+                                fromStart = isLtr;
+                                break;
+                            case "end":
+                                fromStart = !isLtr;
+                                break;
+                        }
+                    }
                     break;
+            }
+        }
+
+        // Populate the guideline based on the resolved properties
+        if (isPercent) {
+            if (fromStart) {
+                guidelineReference.percent(value);
+            } else {
+                guidelineReference.percent(1f - value);
+            }
+        } else {
+            if (fromStart) {
+                guidelineReference.start(value);
+            } else {
+                guidelineReference.end(value);
             }
         }
     }
@@ -1285,6 +1406,7 @@ public class ConstraintSetParser {
             State state,
             String elementName, CLObject element
     ) throws CLParsingException {
+        boolean isLtr = state.isLtr();
         BarrierReference reference = state.barrier(elementName, State.Direction.END);
         ArrayList<String> constraints = element.names();
         if (constraints == null) {
@@ -1295,10 +1417,18 @@ public class ConstraintSetParser {
                 case "direction": {
                     switch (element.getString(constraintName)) {
                         case "start":
-                            reference.setBarrierDirection(State.Direction.START);
+                            if (isLtr) {
+                                reference.setBarrierDirection(State.Direction.LEFT);
+                            } else {
+                                reference.setBarrierDirection(State.Direction.RIGHT);
+                            }
                             break;
                         case "end":
-                            reference.setBarrierDirection(State.Direction.END);
+                            if (isLtr) {
+                                reference.setBarrierDirection(State.Direction.RIGHT);
+                            } else {
+                                reference.setBarrierDirection(State.Direction.LEFT);
+                            }
                             break;
                         case "left":
                             reference.setBarrierDirection(State.Direction.LEFT);
@@ -1318,7 +1448,7 @@ public class ConstraintSetParser {
                 case "margin":
                     float margin = element.getFloatOrNaN(constraintName);
                     if (!Float.isNaN(margin)) {
-                        reference.margin(margin); // TODO is this a bug
+                        reference.margin(toPix(state, margin));
                     }
                     break;
                 case "contains":
@@ -1472,6 +1602,16 @@ public class ConstraintSetParser {
                 value = layoutVariables.get(element.get(attributeName));
                 reference.verticalBias(value);
                 break;
+            case "hRtlBias":
+                // TODO: This is a temporary solution to support bias with start/end constraints,
+                //  where the bias needs to be reversed in RTL, we probably want a better or more
+                //  intuitive way to do this
+                value = layoutVariables.get(element.get(attributeName));
+                if (!state.isLtr()) {
+                    value = 1f - value;
+                }
+                reference.horizontalBias(value);
+                break;
             case "hBias":
                 value = layoutVariables.get(element.get(attributeName));
                 reference.horizontalBias(value);
@@ -1587,8 +1727,7 @@ public class ConstraintSetParser {
             switch (constraintName) {
                 case "pathArc":
                     String val = obj.getString(constraintName);
-                    int ord = indexOf(val, "none", "startVertical", "startHorizontal", "flip",
-                            "arcDown", "arcUp");
+                    int ord = indexOf(val, "none", "startVertical", "startHorizontal", "flip");
                     if (ord == -1) {
                         System.err.println(obj.getLine() + " pathArc = '" + val + "'");
                         break;
@@ -1635,68 +1774,46 @@ public class ConstraintSetParser {
             ConstraintReference reference,
             String constraintName
     ) throws CLParsingException {
+        boolean isLtr = state.isLtr();
         CLArray constraint = element.getArrayOrNull(constraintName);
         if (constraint != null && constraint.size() > 1) {
+            // params: target, anchor
             String target = constraint.getString(0);
             String anchor = constraint.getStringOrNull(1);
             float margin = 0f;
             float marginGone = 0f;
             if (constraint.size() > 2) {
+                // params: target, anchor, margin
                 CLElement arg2 = constraint.getOrNull(2);
                 margin = layoutVariables.get(arg2);
-                margin = state.convertDimension(state.getDpToPixel().toPixels(margin));
+                margin = state.convertDimension(toPix(state, margin));
             }
             if (constraint.size() > 3) {
+                // params: target, anchor, margin, marginGone
                 CLElement arg2 = constraint.getOrNull(3);
                 marginGone = layoutVariables.get(arg2);
-                marginGone = state.convertDimension(state.getDpToPixel().toPixels(margin));
+                marginGone = state.convertDimension(toPix(state, marginGone));
             }
 
             ConstraintReference targetReference = target.equals("parent")
                     ? state.constraints(State.PARENT) :
                     state.constraints(target);
 
+            // For simplicity, we'll apply horizontal constraints separately
+            boolean isHorizontalConstraint = false;
+            boolean isHorOriginLeft = true;
+            boolean isHorTargetLeft = true;
+
             switch (constraintName) {
                 case "circular":
                     float angle = layoutVariables.get(constraint.get(1));
-                    reference.circularConstraint(targetReference, angle, 0f);
-                    break;
-                case "start":
-                    switch (anchor) {
-                        case "start":
-                            reference.startToStart(targetReference);
-                            break;
-                        case "end":
-                            reference.startToEnd(targetReference);
+                    float distance = 0f;
+                    if (constraint.size() > 2) {
+                        CLElement distanceArg = constraint.getOrNull(2);
+                        distance = layoutVariables.get(distanceArg);
+                        distance = state.convertDimension(toPix(state, distance));
                     }
-                    break;
-                case "end":
-                    switch (anchor) {
-                        case "start":
-                            reference.endToStart(targetReference);
-                            break;
-                        case "end":
-                            reference.endToEnd(targetReference);
-                    }
-                    break;
-                case "left":
-
-                    switch (anchor) {
-                        case "left":
-                            reference.leftToLeft(targetReference);
-                            break;
-                        case "right":
-                            reference.leftToRight(targetReference);
-                    }
-                    break;
-                case "right":
-                    switch (anchor) {
-                        case "left":
-                            reference.rightToLeft(targetReference);
-                            break;
-                        case "right":
-                            reference.rightToRight(targetReference);
-                    }
+                    reference.circularConstraint(targetReference, angle, distance);
                     break;
                 case "top":
                     switch (anchor) {
@@ -1722,21 +1839,68 @@ public class ConstraintSetParser {
                             state.baselineNeededFor(reference.getKey());
                             state.baselineNeededFor(targetReference.getKey());
                             reference.baselineToBaseline(targetReference);
-
                             break;
                         case "top":
                             state.baselineNeededFor(reference.getKey());
                             state.baselineNeededFor(targetReference.getKey());
                             reference.baselineToTop(targetReference);
-
                             break;
                         case "bottom":
                             state.baselineNeededFor(reference.getKey());
                             state.baselineNeededFor(targetReference.getKey());
                             reference.baselineToBottom(targetReference);
-
                             break;
                     }
+                    break;
+                case "left":
+                    isHorizontalConstraint = true;
+                    isHorOriginLeft = true;
+                    break;
+                case "right":
+                    isHorizontalConstraint = true;
+                    isHorOriginLeft = false;
+                    break;
+                case "start":
+                    isHorizontalConstraint = true;
+                    isHorOriginLeft = isLtr;
+                    break;
+                case "end":
+                    isHorizontalConstraint = true;
+                    isHorOriginLeft = !isLtr;
+                    break;
+            }
+
+            if (isHorizontalConstraint) {
+                // Resolve horizontal target anchor
+                switch (anchor) {
+                    case "left":
+                        isHorTargetLeft = true;
+                        break;
+                    case "right":
+                        isHorTargetLeft = false;
+                        break;
+                    case "start":
+                        isHorTargetLeft = isLtr;
+                        break;
+                    case "end":
+                        isHorTargetLeft = !isLtr;
+                        break;
+                }
+
+                // Resolved anchors, apply corresponding constraint
+                if (isHorOriginLeft) {
+                    if (isHorTargetLeft) {
+                        reference.leftToLeft(targetReference);
+                    } else {
+                        reference.leftToRight(targetReference);
+                    }
+                } else {
+                    if (isHorTargetLeft) {
+                        reference.rightToLeft(targetReference);
+                    } else {
+                        reference.rightToRight(targetReference);
+                    }
+                }
             }
 
             reference.margin(margin).marginGone(marginGone);
@@ -1749,10 +1913,18 @@ public class ConstraintSetParser {
 
                 switch (constraintName) {
                     case "start":
-                        reference.startToStart(targetReference);
+                        if (isLtr) {
+                            reference.leftToLeft(targetReference);
+                        } else {
+                            reference.rightToRight(targetReference);
+                        }
                         break;
                     case "end":
-                        reference.endToEnd(targetReference);
+                        if (isLtr) {
+                            reference.rightToRight(targetReference);
+                        } else {
+                            reference.leftToLeft(targetReference);
+                        }
                         break;
                     case "top":
                         reference.topToTop(targetReference);
@@ -1765,7 +1937,6 @@ public class ConstraintSetParser {
                         state.baselineNeededFor(targetReference.getKey());
                         reference.baselineToBaseline(targetReference);
                         break;
-
                 }
             }
         }
@@ -1868,7 +2039,6 @@ public class ConstraintSetParser {
                 return element.getString("type");
             }
         }
-
         return null;
     }
 }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/Transition.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/Transition.java
@@ -16,6 +16,7 @@
 
 package androidx.constraintlayout.core.state;
 
+import androidx.annotation.NonNull;
 import androidx.constraintlayout.core.motion.CustomVariable;
 import androidx.constraintlayout.core.motion.Motion;
 import androidx.constraintlayout.core.motion.MotionWidget;
@@ -63,11 +64,15 @@ public class Transition implements TypedValues {
     private int mDuration = 400;
     private float mStagger = 0.0f;
     private OnSwipe mOnSwipe = null;
-    CorePixelDp mToPixel; // Todo placed here as a temp till the refactor is done
+    final CorePixelDp mToPixel; // Todo placed here as a temp till the refactor is done
     int mParentStartWidth, mParentStartHeight;
     int mParentEndWidth, mParentEndHeight;
     int mParentInterpolatedWidth, mParentInterpolateHeight;
     boolean mWrap;
+
+    public Transition(@NonNull CorePixelDp dpToPixel) {
+        mToPixel = dpToPixel;
+    }
 
     // @TODO: add description
     @SuppressWarnings("HiddenTypeParameter")

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/TransitionParser.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/TransitionParser.java
@@ -18,6 +18,8 @@ package androidx.constraintlayout.core.state;
 
 import static androidx.constraintlayout.core.state.ConstraintSetParser.parseColorString;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.RestrictTo;
 import androidx.constraintlayout.core.motion.CustomVariable;
 import androidx.constraintlayout.core.motion.utils.TypedBundle;
 import androidx.constraintlayout.core.motion.utils.TypedValues;
@@ -36,14 +38,28 @@ public class TransitionParser {
     /**
      * Parse a JSON string of a Transition and insert it into the Transition object
      *
+     * @deprecated dpToPixel is unused now
      * @param json       Transition Object to parse.
      * @param transition Transition Object to write transition to
      */
+    @Deprecated
     public static void parse(CLObject json, Transition transition, CorePixelDp dpToPixel)
+            throws CLParsingException {
+        parse(json, transition);
+    }
+
+    /**
+     * Parse a JSON string of a Transition and insert it into the Transition object
+     *
+     * @param json       Transition Object to parse.
+     * @param transition Transition Object to write transition to
+     * @hide
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    public static void parse(@NonNull CLObject json, @NonNull Transition transition)
             throws CLParsingException {
         String pathMotionArc = json.getStringOrNull("pathMotionArc");
         TypedBundle bundle = new TypedBundle();
-        transition.mToPixel = dpToPixel;
         boolean setBundle = false;
         if (pathMotionArc != null) {
             setBundle = true;
@@ -60,12 +76,6 @@ public class TransitionParser {
                     break;
                 case "flip":
                     bundle.add(TypedValues.PositionType.TYPE_PATH_MOTION_ARC, 3);
-                    break;
-                case "arcDown":
-                    bundle.add(TypedValues.PositionType.TYPE_PATH_MOTION_ARC, 4);
-                    break;
-                case "arcUp":
-                    bundle.add(TypedValues.PositionType.TYPE_PATH_MOTION_ARC, 5);
             }
 
         }
@@ -225,7 +235,7 @@ public class TransitionParser {
 
             if (pathMotionArc != null) {
                 map(bundle, TypedValues.PositionType.TYPE_PATH_MOTION_ARC, pathMotionArc,
-                        "none", "startVertical", "startHorizontal", "flip", "arcDown", "arcUp");
+                        "none", "startVertical", "startHorizontal", "flip");
             }
 
             for (int j = 0; j < frames.size(); j++) {

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/ChainReference.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/ChainReference.java
@@ -18,76 +18,171 @@ package androidx.constraintlayout.core.state.helpers;
 
 import static androidx.constraintlayout.core.widgets.ConstraintWidget.UNKNOWN;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.RestrictTo;
 import androidx.constraintlayout.core.state.HelperReference;
 import androidx.constraintlayout.core.state.State;
 
 import java.util.HashMap;
 
+/**
+ * {@link HelperReference} for Chains.
+ *
+ * Elements should be added with {@link ChainReference#addChainElement}
+ */
 public class ChainReference extends HelperReference {
 
     protected float mBias = 0.5f;
-    protected HashMap<String ,Float> mMapWeights;
-    protected HashMap<String,Float> mMapPreMargin;
-    protected HashMap<String,Float> mMapPostMargin;
 
-    protected State.Chain mStyle = State.Chain.SPREAD;
+    /**
+     * @deprecated Unintended visibility, use {@link #getWeight(String)} instead
+     */
+    @Deprecated // TODO(b/253515185): Change to private visibility once we change major version
+    protected @NonNull HashMap<String, Float> mMapWeights = new HashMap<>();
 
-    public ChainReference(State state, State.Helper type) {
+    /**
+     * @deprecated Unintended visibility, use {@link #getPreMargin(String)} instead
+     */
+    @Deprecated // TODO(b/253515185): Change to private visibility once we change major version
+    protected @NonNull HashMap<String, Float> mMapPreMargin = new HashMap<>();
+
+    /**
+     * @deprecated Unintended visibility, use {@link #getPostMargin(String)} instead
+     */
+    @Deprecated // TODO(b/253515185): Change to private visibility once we change major version
+    protected @NonNull HashMap<String, Float> mMapPostMargin = new HashMap<>();
+
+    private HashMap<String, Float> mMapPreGoneMargin;
+    private HashMap<String, Float> mMapPostGoneMargin;
+
+    protected @NonNull State.Chain mStyle = State.Chain.SPREAD;
+
+    public ChainReference(@NonNull State state, @NonNull State.Helper type) {
         super(state, type);
     }
 
-    public State.Chain getStyle() {
+    public @NonNull State.Chain getStyle() {
         return State.Chain.SPREAD;
     }
 
-    // @TODO: add description
-    public ChainReference style(State.Chain style) {
+    /**
+     * Sets the {@link State.Chain style}.
+     *
+     * @param style Defines the way the chain will lay out its elements
+     * @return This same instance
+     */
+    @NonNull
+    public ChainReference style(@NonNull State.Chain style) {
         mStyle = style;
         return this;
     }
 
-    public void addChainElement(String id, float weight, float preMargin, float  postMargin ) {
-        super.add(id);
+    /**
+     * Adds the element by the given id to the Chain.
+     *
+     * The order in which the elements are added is important. It will represent the element's
+     * position in the Chain.
+     *
+     * @param id         Id of the element to add
+     * @param weight     Weight used to distribute remaining space to each element
+     * @param preMargin  Additional space in pixels between the added element and the previous one
+     *                   (if any)
+     * @param postMargin Additional space in pixels between the added element and the next one (if
+     *                   any)
+     */
+    public void addChainElement(@NonNull String id,
+            float weight,
+            float preMargin,
+            float postMargin) {
+        addChainElement(id, weight, preMargin, postMargin, 0, 0);
+    }
+
+    /**
+     * Adds the element by the given id to the Chain.
+     *
+     * The object's {@link Object#toString()} result will be used to map the given margins and
+     * weight to it, so it must stable and comparable.
+     *
+     * The order in which the elements are added is important. It will represent the element's
+     * position in the Chain.
+     *
+     * @param id             Id of the element to add
+     * @param weight         Weight used to distribute remaining space to each element
+     * @param preMargin      Additional space in pixels between the added element and the
+     *                       previous one
+     *                       (if any)
+     * @param postMargin     Additional space in pixels between the added element and the next
+     *                       one (if
+     *                       any)
+     * @param preGoneMargin  Additional space in pixels between the added element and the previous
+     *                       one (if any) when the previous element has Gone visibility
+     * @param postGoneMargin Additional space in pixels between the added element and the next
+     *                       one (if any) when the next element has Gone visibility
+     * @hide
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    public void addChainElement(@NonNull Object id,
+            float weight,
+            float preMargin,
+            float postMargin,
+            float preGoneMargin,
+            float postGoneMargin) {
+        super.add(id); // Add element id as is, it's expected to return the same given instance
+        String idString = id.toString();
         if (!Float.isNaN(weight)) {
-            if (mMapWeights == null) {
-                mMapWeights = new HashMap<>();
-            }
-            mMapWeights.put(id, weight);
+            mMapWeights.put(idString, weight);
         }
         if (!Float.isNaN(preMargin)) {
-            if (mMapPreMargin == null) {
-                mMapPreMargin = new HashMap<>();
-            }
-            mMapPreMargin.put(id, preMargin);
+            mMapPreMargin.put(idString, preMargin);
         }
         if (!Float.isNaN(postMargin)) {
-            if (mMapPostMargin == null) {
-                mMapPostMargin = new HashMap<>();
+            mMapPostMargin.put(idString, postMargin);
+        }
+        if (!Float.isNaN(preGoneMargin)) {
+            if (mMapPreGoneMargin == null) {
+                mMapPreGoneMargin = new HashMap<>();
             }
-            mMapPostMargin.put(id, postMargin);
+            mMapPreGoneMargin.put(idString, preGoneMargin);
+        }
+        if (!Float.isNaN(postGoneMargin)) {
+            if (mMapPostGoneMargin == null) {
+                mMapPostGoneMargin = new HashMap<>();
+            }
+            mMapPostGoneMargin.put(idString, postGoneMargin);
         }
     }
 
-  protected float getWeight(String id) {
-       if (mMapWeights == null) {
-           return UNKNOWN;
-       }
-       if (mMapWeights.containsKey(id)) {
-           return mMapWeights.get(id);
-       }
-       return UNKNOWN;
+    protected float getWeight(@NonNull String id) {
+        if (mMapWeights.containsKey(id)) {
+            return mMapWeights.get(id);
+        }
+        return UNKNOWN;
     }
 
-    protected float getPostMargin(String id) {
-        if (mMapPostMargin != null  && mMapPostMargin.containsKey(id)) {
+    protected float getPostMargin(@NonNull String id) {
+        if (mMapPostMargin.containsKey(id)) {
             return mMapPostMargin.get(id);
         }
         return 0;
     }
 
-    protected float getPreMargin(String id) {
-        if (mMapPreMargin != null  && mMapPreMargin.containsKey(id)) {
+    protected float getPreMargin(@NonNull String id) {
+        if (mMapPreMargin.containsKey(id)) {
             return mMapPreMargin.get(id);
+        }
+        return 0;
+    }
+
+    protected float getPostGoneMargin(@NonNull String id) {
+        if (mMapPostGoneMargin != null && mMapPostGoneMargin.containsKey(id)) {
+            return mMapPostGoneMargin.get(id);
+        }
+        return 0;
+    }
+
+    protected float getPreGoneMargin(@NonNull String id) {
+        if (mMapPreGoneMargin != null && mMapPreGoneMargin.containsKey(id)) {
+            return mMapPreGoneMargin.get(id);
         }
         return 0;
     }
@@ -97,10 +192,10 @@ public class ChainReference extends HelperReference {
     }
 
     // @TODO: add description
+    @NonNull
     @Override
     public ChainReference bias(float bias) {
         mBias = bias;
         return this;
     }
-
 }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/GridReference.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/GridReference.java
@@ -16,10 +16,11 @@
 
 package androidx.constraintlayout.core.state.helpers;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.constraintlayout.core.state.HelperReference;
 import androidx.constraintlayout.core.state.State;
 import androidx.constraintlayout.core.utils.GridCore;
-import androidx.constraintlayout.core.widgets.Flow;
 import androidx.constraintlayout.core.widgets.HelperWidget;
 
 /**
@@ -27,7 +28,7 @@ import androidx.constraintlayout.core.widgets.HelperWidget;
  */
 public class GridReference extends HelperReference {
 
-    public GridReference(State state, State.Helper type) {
+    public GridReference(@NonNull State state, @NonNull State.Helper type) {
         super(state, type);
         if (type == State.Helper.ROW) {
             this.mColumnsSet = 1;
@@ -39,52 +40,52 @@ public class GridReference extends HelperReference {
     /**
      * The Grid Object
      */
-    protected GridCore mGrid;
+    private GridCore mGrid;
 
     /**
      * The orientation of the widgets arrangement horizontally or vertically
      */
-    protected int mOrientation;
+    private int mOrientation;
 
     /**
      * Number of rows of the Grid
      */
-    protected int mRowsSet;
+    private int mRowsSet;
 
     /**
      * Number of columns of the Grid
      */
-    protected int mColumnsSet;
+    private int mColumnsSet;
 
     /**
      * The horizontal gaps between widgets
      */
-    protected float mHorizontalGaps;
+    private float mHorizontalGaps;
 
     /**
      * The vertical gaps between widgets
      */
-    protected float mVerticalGaps;
+    private float mVerticalGaps;
 
     /**
      * The weight of each widget in a row
      */
-    protected String mStrRowWeights;
+    private String mRowWeights;
 
     /**
      * The weight of each widget in a column
      */
-    protected String mStrColumnWeights;
+    private String mColumnWeights;
 
     /**
      * Specify the spanned areas of widgets
      */
-    protected String mStrSpans;
+    private String mSpans;
 
     /**
-     * Specify the positions to be skipped in a Grid
+     * Specify the positions to be skipped in the Grid
      */
-    protected String mStrSkips;
+    private String mSkips;
 
     /**
      * Get the number of rows
@@ -160,64 +161,68 @@ public class GridReference extends HelperReference {
      * Get the row weights
      * @return the row weights
      */
-    public String getStrRowWeights() {
-        return mStrRowWeights;
+    @Nullable
+    public String getRowWeights() {
+        return mRowWeights;
     }
 
     /**
      * Set the row weights
-     * @param strRowWeights the row weights
+     * @param rowWeights the row weights
      */
-    public void setStrRowWeights(String strRowWeights) {
-        mStrRowWeights = strRowWeights;
+    public void setRowWeights(@NonNull String rowWeights) {
+        mRowWeights = rowWeights;
     }
 
     /**
      * Get the column weights
      * @return the column weights
      */
-    public String getStrColumnWeights() {
-        return mStrColumnWeights;
+    @Nullable
+    public String getColumnWeights() {
+        return mColumnWeights;
     }
 
     /**
      * Set the column weights
-     * @param strColumnWeights the column weights
+     * @param columnWeights the column weights
      */
-    public void setStrColumnWeights(String strColumnWeights) {
-        mStrColumnWeights = strColumnWeights;
+    public void setColumnWeights(@NonNull String columnWeights) {
+        mColumnWeights = columnWeights;
     }
 
     /**
      * Get the spans
      * @return the spans
      */
-    public String getStrSpans() {
-        return mStrSpans;
+    @Nullable
+    public String getSpans() {
+        return mSpans;
     }
 
     /**
      * Set the spans
-     * @param strSpans the spans
+     * @param spans the spans
      */
-    public void setStrSpans(String strSpans) {
-        mStrSpans = strSpans;
+    public void setSpans(@NonNull String spans) {
+        mSpans = spans;
     }
 
     /**
      * Get the skips
      * @return the skips
      */
-    public String getStrSkips() {
-        return mStrSkips;
+    @Nullable
+    public String getSkips() {
+        return mSkips;
     }
 
     /**
      * Set the skips
-     * @param strSkips the skips
+     * @param skips the skips
      */
-    public void setStrSkips(String strSkips) {
-        mStrSkips = strSkips;
+    public void setSkips(@NonNull String skips) {
+        mSkips = skips;
     }
 
     /**
@@ -225,6 +230,7 @@ public class GridReference extends HelperReference {
      * @return the helper widget (Grid)
      */
     @Override
+    @NonNull
     public HelperWidget getHelperWidget() {
         if (mGrid == null) {
             mGrid = new GridCore();
@@ -237,8 +243,8 @@ public class GridReference extends HelperReference {
      * @param widget the helper widget (Grid)
      */
     @Override
-    public void setHelperWidget(HelperWidget widget) {
-        if (widget instanceof Flow) {
+    public void setHelperWidget(@Nullable HelperWidget widget) {
+        if (widget instanceof GridCore) {
             mGrid = (GridCore) widget;
         } else {
             mGrid = null;
@@ -287,20 +293,20 @@ public class GridReference extends HelperReference {
             mGrid.setVerticalGaps(mVerticalGaps);
         }
 
-        if (mStrRowWeights != null && !mStrRowWeights.equals("")) {
-            mGrid.setRowWeights(mStrRowWeights);
+        if (mRowWeights != null && !mRowWeights.equals("")) {
+            mGrid.setRowWeights(mRowWeights);
         }
 
-        if (mStrColumnWeights != null && !mStrColumnWeights.equals("")) {
-            mGrid.setColumnWeights(mStrColumnWeights);
+        if (mColumnWeights != null && !mColumnWeights.equals("")) {
+            mGrid.setColumnWeights(mColumnWeights);
         }
 
-        if (mStrSpans != null && !mStrSpans.equals("")) {
-            mGrid.setSpans(mStrSpans);
+        if (mSpans != null && !mSpans.equals("")) {
+            mGrid.setSpans(mSpans);
         }
 
-        if (mStrSkips != null && !mStrSkips.equals("")) {
-            mGrid.setSkips(mStrSkips);
+        if (mSkips != null && !mSkips.equals("")) {
+            mGrid.setSkips(mSkips);
         }
 
         // General attributes of a widget

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/HorizontalChainReference.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/HorizontalChainReference.java
@@ -23,7 +23,7 @@ import androidx.constraintlayout.core.state.State;
 import androidx.constraintlayout.core.widgets.ConstraintWidget;
 
 public class HorizontalChainReference extends ChainReference {
-    private boolean useLeftRight;
+
     public HorizontalChainReference(State state) {
         super(state, State.Helper.HORIZONTAL_CHAIN);
     }
@@ -37,7 +37,7 @@ public class HorizontalChainReference extends ChainReference {
             ConstraintReference reference = mHelperState.constraints(key);
             reference.clearHorizontal();
         }
-         boolean lrMode = (mLeftToLeft != null || mLeftToRight != null);
+
         for (Object key : mReferences) {
             ConstraintReference reference = mHelperState.constraints(key);
 
@@ -51,31 +51,24 @@ public class HorizontalChainReference extends ChainReference {
                     first.startToEnd(mStartToEnd).margin(mMarginStart).marginGone(mMarginStartGone);
                 } else if (mLeftToLeft != null) {
                     // TODO: Hack until we support RTL properly
-                    first.leftToLeft(mLeftToLeft).margin(mMarginLeft).marginGone(mMarginLeftGone);
+                    first.startToStart(mLeftToLeft).margin(mMarginLeft).marginGone(mMarginLeftGone);
                 } else if (mLeftToRight != null) {
                     // TODO: Hack until we support RTL properly
-                    first.leftToRight(mLeftToRight).margin(mMarginLeft).marginGone(mMarginLeftGone);
+                    first.startToEnd(mLeftToRight).margin(mMarginLeft).marginGone(mMarginLeftGone);
                 } else {
                     // No constraint declared, default to Parent.
                     String refKey = reference.getKey().toString();
-                    if (lrMode) {
-                        first.leftToLeft(State.PARENT).margin(getPreMargin(refKey));
-
-                    } else {
-                        first.startToStart(State.PARENT).margin(getPreMargin(refKey));
-                    }
+                    first.startToStart(State.PARENT).margin(getPreMargin(refKey)).marginGone(
+                            getPreGoneMargin(refKey));
                 }
             }
             if (previous != null) {
                 String preKey = previous.getKey().toString();
                 String refKey = reference.getKey().toString();
-                if (lrMode) {
-                    previous.rightToLeft(reference.getKey()).margin(getPostMargin(preKey));
-                    reference.leftToRight(previous.getKey()).margin(getPreMargin(refKey));
-                } else {
-                    previous.endToStart(reference.getKey()).margin(getPostMargin(preKey));
-                    reference.startToEnd(previous.getKey()).margin(getPreMargin(refKey));
-                }
+                previous.endToStart(reference.getKey()).margin(getPostMargin(preKey)).marginGone(
+                        getPostGoneMargin(preKey));
+                reference.startToEnd(previous.getKey()).margin(getPreMargin(refKey)).marginGone(
+                        getPreGoneMargin(refKey));
             }
             float weight = getWeight(key.toString());
             if (weight != UNKNOWN) {
@@ -90,18 +83,16 @@ public class HorizontalChainReference extends ChainReference {
             } else if (mEndToEnd != null) {
                 previous.endToEnd(mEndToEnd).margin(mMarginEnd).marginGone(mMarginEndGone);
             } else if (mRightToLeft != null) {
-                previous.rightToLeft(mRightToLeft).margin(mMarginRight).marginGone(mMarginRightGone);
+                // TODO: Hack until we support RTL properly
+                previous.endToStart(mRightToLeft).margin(mMarginRight).marginGone(mMarginRightGone);
             } else if (mRightToRight != null) {
-                previous.rightToRight(mRightToRight).margin(mMarginRight).marginGone(mMarginRightGone);
+                // TODO: Hack until we support RTL properly
+                previous.endToEnd(mRightToRight).margin(mMarginRight).marginGone(mMarginRightGone);
             } else {
                 // No constraint declared, default to Parent.
                 String preKey = previous.getKey().toString();
-                if (lrMode) {
-                    previous.rightToRight(State.PARENT).margin(getPostMargin(preKey));
-
-                } else {
-                    previous.endToEnd(State.PARENT).margin(getPostMargin(preKey));
-                }
+                previous.endToEnd(State.PARENT).margin(getPostMargin(preKey)).marginGone(
+                        getPostGoneMargin(preKey));
             }
         }
 

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/VerticalChainReference.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/VerticalChainReference.java
@@ -49,14 +49,17 @@ public class VerticalChainReference extends ChainReference {
                 } else {
                     // No constraint declared, default to Parent.
                     String refKey = reference.getKey().toString();
-                    first.topToTop(State.PARENT).margin(getPreMargin(refKey));
+                    first.topToTop(State.PARENT).margin(getPreMargin(refKey)).marginGone(
+                            getPreGoneMargin(refKey));
                 }
             }
             if (previous != null) {
                 String preKey = previous.getKey().toString();
                 String refKey = reference.getKey().toString();
-                previous.bottomToTop(reference.getKey()).margin(getPostMargin(preKey));
-                reference.topToBottom(previous.getKey()).margin(getPreMargin(refKey));
+                previous.bottomToTop(reference.getKey()).margin(getPostMargin(preKey)).marginGone(
+                        getPostGoneMargin(preKey));
+                reference.topToBottom(previous.getKey()).margin(getPreMargin(refKey)).marginGone(
+                        getPreGoneMargin(refKey));
             }
             float weight = getWeight(key.toString());
             if (weight != UNKNOWN) {
@@ -77,7 +80,8 @@ public class VerticalChainReference extends ChainReference {
             } else {
                 // No constraint declared, default to Parent.
                 String preKey = previous.getKey().toString();
-                previous.bottomToBottom(State.PARENT).margin(getPostMargin(preKey));
+                previous.bottomToBottom(State.PARENT).margin(getPostMargin(preKey)).marginGone(
+                        getPostGoneMargin(preKey));
             }
         }
 

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/utils/GridCore.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/utils/GridCore.java
@@ -18,6 +18,8 @@ package androidx.constraintlayout.core.utils;
 
 import static androidx.constraintlayout.core.widgets.ConstraintWidget.DimensionBehaviour.MATCH_CONSTRAINT;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.constraintlayout.core.LinearSystem;
 import androidx.constraintlayout.core.widgets.ConstraintWidget;
 import androidx.constraintlayout.core.widgets.ConstraintWidgetContainer;
@@ -32,20 +34,16 @@ import java.util.Set;
  */
 public class GridCore extends VirtualLayout {
 
-    public static final int VERTICAL = 1;
     public static final int HORIZONTAL = 0;
+    public static final int VERTICAL = 1;
+    private static final int DEFAULT_SIZE = 3; // default rows and columns.
     private static final int MAX_ROWS = 50; // maximum number of rows can be specified.
     private static final int MAX_COLUMNS = 50; // maximum number of columns can be specified.
-    private static final int DEFAULT_SIZE = 3; // default rows and columns.
 
     /**
      * Container for all the ConstraintWidgets
      */
     ConstraintWidgetContainer mContainer;
-
-    public ConstraintWidget[] getBoxWidgets() {
-        return mBoxWidgets;
-    }
 
     /**
      * boxWidgets were created as anchor points for arranging the associated widgets
@@ -85,22 +83,22 @@ public class GridCore extends VirtualLayout {
     /**
      * string format of the row weight
      */
-    private String mStrRowWeights;
+    private String mRowWeights;
 
     /**
      * string format of the column weight
      */
-    private String mStrColumnWeights;
+    private String mColumnWeights;
 
     /**
      * string format of the input Spans
      */
-    private String mStrSpans;
+    private String mSpans;
 
     /**
      * string format of the input Skips
      */
-    private String mStrSkips;
+    private String mSkips;
 
     /**
      * orientation of the widget arrangement - vertical or horizontal
@@ -108,7 +106,7 @@ public class GridCore extends VirtualLayout {
     private int mOrientation;
 
     /**
-     * Indicates what is the next available position to place an widget
+     * Indicates what is the next available position to place a widget
      */
     private int mNextAvailableIndex = 0;
 
@@ -156,6 +154,7 @@ public class GridCore extends VirtualLayout {
      *
      * @return the parent ConstraintWidgetContainer
      */
+    @Nullable
     public ConstraintWidgetContainer getContainer() {
         return mContainer;
     }
@@ -164,7 +163,7 @@ public class GridCore extends VirtualLayout {
      * Set the parent ConstraintWidgetContainer
      * @param container the parent ConstraintWidgetContainer
      */
-    public void setContainer(ConstraintWidgetContainer container) {
+    public void setContainer(@NonNull ConstraintWidgetContainer container) {
         mContainer = container;
     }
 
@@ -173,12 +172,12 @@ public class GridCore extends VirtualLayout {
      *
      * @param spans new spans value
      */
-    public void setSpans(CharSequence spans) {
-        if (mStrSpans != null && mStrSpans.equals(spans.toString())) {
+    public void setSpans(@NonNull CharSequence spans) {
+        if (mSpans != null && mSpans.equals(spans.toString())) {
             return;
         }
 
-        mStrSpans = spans.toString();
+        mSpans = spans.toString();
     }
 
     /**
@@ -186,12 +185,12 @@ public class GridCore extends VirtualLayout {
      *
      * @param skips new spans value
      */
-    public void setSkips(String skips) {
-        if (mStrSkips != null && mStrSkips.equals(skips)) {
+    public void setSkips(@NonNull String skips) {
+        if (mSkips != null && mSkips.equals(skips)) {
             return;
         }
 
-        mStrSkips = skips;
+        mSkips = skips;
 
     }
 
@@ -252,8 +251,9 @@ public class GridCore extends VirtualLayout {
      *
      * @return the string value of rowWeights
      */
+    @Nullable
     public String getRowWeights() {
-        return mStrRowWeights;
+        return mRowWeights;
     }
 
     /**
@@ -261,12 +261,12 @@ public class GridCore extends VirtualLayout {
      *
      * @param rowWeights new rowWeights value
      */
-    public void setRowWeights(String rowWeights) {
-        if (mStrRowWeights != null && mStrRowWeights.equals(rowWeights)) {
+    public void setRowWeights(@NonNull String rowWeights) {
+        if (mRowWeights != null && mRowWeights.equals(rowWeights)) {
             return;
         }
 
-        mStrRowWeights = rowWeights;
+        mRowWeights = rowWeights;
     }
 
     /**
@@ -274,8 +274,9 @@ public class GridCore extends VirtualLayout {
      *
      * @return the string value of columnWeights
      */
+    @Nullable
     public String getColumnWeights() {
-        return mStrColumnWeights;
+        return mColumnWeights;
     }
 
     /**
@@ -283,12 +284,12 @@ public class GridCore extends VirtualLayout {
      *
      * @param columnWeights new columnWeights value
      */
-    public void setColumnWeights(String columnWeights) {
-        if (mStrColumnWeights != null && mStrColumnWeights.equals(columnWeights)) {
+    public void setColumnWeights(@NonNull String columnWeights) {
+        if (mColumnWeights != null && mColumnWeights.equals(columnWeights)) {
             return;
         }
 
-        mStrColumnWeights = columnWeights;
+        mColumnWeights = columnWeights;
     }
 
     /**
@@ -404,7 +405,7 @@ public class GridCore extends VirtualLayout {
      *
      * @param isUpdate whether to update the existing grid (true) or create a new one (false)
      */
-    public void setupGrid(boolean isUpdate) {
+    private void setupGrid(boolean isUpdate) {
         if (mRows < 1 || mColumns < 1) {
             return;
         }
@@ -421,15 +422,15 @@ public class GridCore extends VirtualLayout {
         mNextAvailableIndex = 0;
         createBoxes();
 
-        if (mStrSkips != null && !mStrSkips.trim().isEmpty()) {
-            int[][] mSkips = parseSpans(mStrSkips);
+        if (mSkips != null && !mSkips.trim().isEmpty()) {
+            int[][] mSkips = parseSpans(this.mSkips);
             if (mSkips != null) {
                 handleSkips(mSkips);
             }
         }
 
-        if (mStrSpans != null && !mStrSpans.trim().isEmpty()) {
-            int[][] mSpans = parseSpans(mStrSpans);
+        if (mSpans != null && !mSpans.trim().isEmpty()) {
+            int[][] mSpans = parseSpans(this.mSpans);
             if (mSpans != null) {
                 handleSpans(mSpans);
             }
@@ -437,7 +438,7 @@ public class GridCore extends VirtualLayout {
     }
 
     /**
-     * Convert a 1D index to a 2D index that has index for row and index for column
+     * Convert a 1D index to a 2D index that has index for row
      *
      * @param index index in 1D
      * @return row as its values.
@@ -452,7 +453,7 @@ public class GridCore extends VirtualLayout {
     }
 
     /**
-     * Convert a 1D index to a 2D index that has index for row and index for column
+     * Convert a 1D index to a 2D index that has index for column
      *
      * @param index index in 1D
      * @return column as its values.
@@ -491,7 +492,7 @@ public class GridCore extends VirtualLayout {
      * @return true if we could properly invalidate the positions else false
      */
     private boolean invalidatePositions(int startRow, int startColumn,
-            int rowSpan, int columnSpan) {
+                                        int rowSpan, int columnSpan) {
         for (int i = startRow; i < startRow + rowSpan; i++) {
             for (int j = startColumn; j < startColumn + columnSpan; j++) {
                 if (i >= mPositionMatrix.length || j >= mPositionMatrix[0].length
@@ -598,7 +599,7 @@ public class GridCore extends VirtualLayout {
      * @param column column position to place the widget
      */
     private void connectWidget(ConstraintWidget widget, int row, int column,
-            int rowSpan, int columnSpan) {
+                               int rowSpan, int columnSpan) {
         // Connect the 4 sides
         widget.mLeft.connect(mBoxWidgets[column].mLeft, 0);
         widget.mTop.connect(mBoxWidgets[row].mTop, 0);
@@ -613,7 +614,7 @@ public class GridCore extends VirtualLayout {
         int maxVal = Math.max(mRows, mColumns);
 
         ConstraintWidget widget = mBoxWidgets[0];
-        float[] columnWeights = parseWeights(mColumns, mStrColumnWeights);
+        float[] columnWeights = parseWeights(mColumns, mColumnWeights);
         // chain all the widgets on the longer side (either horizontal or vertical)
         if (mColumns == 1) {
             clearHorizontalAttributes(widget);
@@ -660,7 +661,7 @@ public class GridCore extends VirtualLayout {
         int maxVal = Math.max(mRows, mColumns);
 
         ConstraintWidget widget = mBoxWidgets[0];
-        float[] rowWeights = parseWeights(mRows, mStrRowWeights);
+        float[] rowWeights = parseWeights(mRows, mRowWeights);
         // chain all the widgets on the longer side (either horizontal or vertical)
         if (mRows == 1) {
             clearVerticalAttributes(widget);
@@ -704,7 +705,7 @@ public class GridCore extends VirtualLayout {
     /**
      * Chains the boxWidgets and add constraints to the widgets
      */
-    public void addConstraints() {
+    private void addConstraints() {
         setBoxWidgetVerticalChains();
         setBoxWidgetHorizontalChains();
         arrangeWidgets();
@@ -713,7 +714,7 @@ public class GridCore extends VirtualLayout {
     /**
      * Create all the boxWidgets that will be used to constrain widgets
      */
-    public void createBoxes() {
+    private void createBoxes() {
         int boxCount = Math.max(mRows, mColumns);
         if (mBoxWidgets == null) { // no box widgets build all
             mBoxWidgets = new ConstraintWidget[boxCount];
@@ -832,15 +833,15 @@ public class GridCore extends VirtualLayout {
 
         mNextAvailableIndex = 0;
 
-        if (mStrSkips != null && !mStrSkips.trim().isEmpty()) {
-            int[][] mSkips = parseSpans(mStrSkips);
+        if (mSkips != null && !mSkips.trim().isEmpty()) {
+            int[][] mSkips = parseSpans(this.mSkips);
             if (mSkips != null) {
                 handleSkips(mSkips);
             }
         }
 
-        if (mStrSpans != null && !mStrSpans.trim().isEmpty()) {
-            int[][] mSpans = parseSpans(mStrSpans);
+        if (mSpans != null && !mSpans.trim().isEmpty()) {
+            int[][] mSpans = parseSpans(this.mSpans);
             if (mSpans != null) {
                 handleSpans(mSpans);
             }
@@ -850,7 +851,7 @@ public class GridCore extends VirtualLayout {
     /**
      * Set up the Grid engine.
      */
-    public void initMatrices() {
+    private void initMatrices() {
         boolean isUpdate = mConstraintMatrix != null
                 && mConstraintMatrix.length == mWidgetsCount
                 && mPositionMatrix != null
@@ -874,7 +875,7 @@ public class GridCore extends VirtualLayout {
     }
 
     @Override
-    public void addToSolver(LinearSystem system, boolean optimize) {
+    public void addToSolver(@Nullable LinearSystem system, boolean optimize) {
         super.addToSolver(system, optimize);
         addConstraints();
     }

--- a/constraintlayout/swing/src/main/java/org/constraintlayout/swing/core/motion/model/MotionEngine.java
+++ b/constraintlayout/swing/src/main/java/org/constraintlayout/swing/core/motion/model/MotionEngine.java
@@ -46,7 +46,7 @@ public class MotionEngine {
     MotionRenderDebug mRenderDebug = new MotionRenderDebug(23); // TODO only create when needed
 
     private TransitionModel mCurrentTransition;
-    private Transition mTransition = new Transition();
+    private Transition mTransition = new Transition(dpValue -> dpValue);
     ConstraintSetModel mStartConstraintSet;
     ConstraintSetModel mEndConstraintSet;
     boolean mNeedMeasure = true;


### PR DESCRIPTION
Sync Core and Compose src from AndroidX back to Github

Need to update build.gradle for Core and Compose.
1. Core: add androidx.annotation:annotation:1.5.0 dependency to specify @Null and @Nonull
2. Compose: add the -Xjvm-default option to be able to use @JvmDefaultWithCompatibility 
<img width="587" alt="image" src="https://user-images.githubusercontent.com/20599348/211083091-d5549b5b-19ca-4192-8350-85de1120975f.png">
The updates above need to be applied to the existing projects to make them work properly

The change made in https://github.com/androidx/constraintlayout/compare/main...jswong65:sync-0106?expand=1#diff-35a5417bf4670237154587289a9cda917dc088fa60fba32f282ca8c89e42e408R73 also causes an issue in https://github.com/androidx/constraintlayout/blob/f284d8aa5c5feeba2548c1e740487ce0e8af0620/constraintlayout/swing/src/main/java/org/constraintlayout/swing/core/motion/model/MotionEngine.java#L49

@jafu888 could you please help with addressing the issue?
