### PR TITLE
[DSL] Enable Grid with DSL syntax

### DIFF
--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/GridDslTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/GridDslTest.kt
@@ -78,8 +78,8 @@ class GridDslTest {
                 vGap = 0,
                 gridSpans = "",
                 gridSkips = "",
-                gridRowWeights = "",
-                gridColumnWeights = ""
+                gridRowWeights = null,
+                gridColumnWeights = null,
             )
         }
         var leftX = 0.dp
@@ -117,8 +117,8 @@ class GridDslTest {
                 vGap = 0,
                 gridSpans = "",
                 gridSkips = "",
-                gridRowWeights = "",
-                gridColumnWeights = ""
+                gridRowWeights = null,
+                gridColumnWeights = null
             )
         }
         var leftX = 0.dp
@@ -156,8 +156,8 @@ class GridDslTest {
                 vGap = 0,
                 gridSpans = "",
                 gridSkips = "",
-                gridRowWeights = "",
-                gridColumnWeights = ""
+                gridRowWeights = null,
+                gridColumnWeights = null
             )
         }
         var expectedX = 0.dp
@@ -195,8 +195,8 @@ class GridDslTest {
                 vGap = 0,
                 gridSpans = "",
                 gridSkips = "",
-                gridRowWeights = "",
-                gridColumnWeights = ""
+                gridRowWeights = null,
+                gridColumnWeights = null
             )
         }
         var expectedX = 0.dp
@@ -234,8 +234,8 @@ class GridDslTest {
                 vGap = 0,
                 gridSpans = "",
                 gridSkips = "0:1x1",
-                gridRowWeights = "",
-                gridColumnWeights = ""
+                gridRowWeights = null,
+                gridColumnWeights = null
             )
         }
         var leftX = 0.dp
@@ -272,8 +272,8 @@ class GridDslTest {
                 vGap = 0,
                 gridSpans = "0:1x2",
                 gridSkips = "",
-                gridRowWeights = "",
-                gridColumnWeights = ""
+                gridRowWeights = null,
+                gridColumnWeights = null
             )
         }
         var leftX = 0.dp
@@ -300,6 +300,7 @@ class GridDslTest {
         val boxesCount = 2
         val rows = 0
         val columns = 1
+        val weights = intArrayOf(1, 3)
         rule.setContent {
             gridComposableTest(
                 modifier = Modifier.size(rootSize),
@@ -311,8 +312,8 @@ class GridDslTest {
                 vGap = 0,
                 gridSpans = "",
                 gridSkips = "",
-                gridRowWeights = "1,3",
-                gridColumnWeights = ""
+                gridRowWeights = weights,
+                gridColumnWeights = null
             )
         }
         var expectedLeft = (rootSize - 10.dp) / 2f
@@ -336,6 +337,7 @@ class GridDslTest {
         val boxesCount = 2
         val rows = 1
         val columns = 0
+        val weights = intArrayOf(1, 3)
         rule.setContent {
             gridComposableTest(
                 modifier = Modifier.size(rootSize),
@@ -347,8 +349,8 @@ class GridDslTest {
                 vGap = 0,
                 gridSpans = "",
                 gridSkips = "",
-                gridRowWeights = "",
-                gridColumnWeights = "1,3"
+                gridRowWeights = null,
+                gridColumnWeights = weights
             )
         }
         var expectedLeft = 0.dp
@@ -401,8 +403,8 @@ class GridDslTest {
         numColumns: Int,
         gridSpans: String,
         gridSkips: String,
-        gridRowWeights: String,
-        gridColumnWeights: String,
+        gridRowWeights: IntArray?,
+        gridColumnWeights: IntArray?,
         boxesCount: Int,
         gridOrientation: Int,
         vGap: Int,

--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/GridDslTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/GridDslTest.kt
@@ -411,13 +411,13 @@ class GridDslTest {
         ConstraintLayout(
             ConstraintSet {
                 val ids = (0 until boxesCount).map { "box$it" }.toTypedArray()
-                val elem = arrayOfNulls<LayoutReference>(ids.size)
+                val elem = arrayListOf<LayoutReference>()
                 for (i in ids.indices) {
-                    elem[i] = createRefFor(ids[i])
+                    elem.add(createRefFor(ids[i]))
                 }
 
                 val g1 = createGrid(
-                    elements = *elem,
+                    elements = *elem.toTypedArray(),
                     orientation = gridOrientation,
                     skips = gridSkips,
                     spans = gridSpans,

--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/GridDslTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/GridDslTest.kt
@@ -1,0 +1,505 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.platform.isDebugInspectorInfoEnabled
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertPositionInRootIsEqualTo
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Tests for the Grid Helper
+ */
+@MediumTest
+@RunWith(AndroidJUnit4::class)
+class GridDslTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Before
+    fun setup() {
+        isDebugInspectorInfoEnabled = true
+    }
+
+    @After
+    fun tearDown() {
+        isDebugInspectorInfoEnabled = false
+    }
+
+    @Test
+    fun testTwoByTwo() {
+        val rootSize = 200.dp
+        val boxesCount = 4
+        val rows = 2
+        val columns = 2
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                boxesCount = boxesCount,
+                gridOrientation = 0,
+                numRows = rows,
+                numColumns = columns,
+                hGap = 0,
+                vGap = 0,
+                gridSpans = "",
+                gridSkips = "",
+                gridRowWeights = "",
+                gridColumnWeights = ""
+            )
+        }
+        var leftX = 0.dp
+        var topY = 0.dp
+        var rightX: Dp
+        var bottomY: Dp
+
+        // 10.dp is the size of a singular box
+        val gapSize = (rootSize - (10.dp * 2f)) / (columns * 2f)
+        rule.waitForIdle()
+        leftX += gapSize
+        topY += gapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(leftX, topY)
+        rightX = leftX + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(rightX, topY)
+        bottomY = topY + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(leftX, bottomY)
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(rightX, bottomY)
+    }
+
+    @Test
+    fun testOrientation() {
+        val rootSize = 200.dp
+        val boxesCount = 4
+        val rows = 2
+        val columns = 2
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                boxesCount = boxesCount,
+                gridOrientation = 1,
+                numRows = rows,
+                numColumns = columns,
+                hGap = 0,
+                vGap = 0,
+                gridSpans = "",
+                gridSkips = "",
+                gridRowWeights = "",
+                gridColumnWeights = ""
+            )
+        }
+        var leftX = 0.dp
+        var topY = 0.dp
+        var rightX: Dp
+        var bottomY: Dp
+
+        // 10.dp is the size of a singular box
+        val gapSize = (rootSize - (10.dp * 2f)) / (columns * 2f)
+        rule.waitForIdle()
+        leftX += gapSize
+        topY += gapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(leftX, topY)
+        rightX = leftX + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(rightX, topY)
+        bottomY = topY + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(leftX, bottomY)
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(rightX, bottomY)
+    }
+
+    @Test
+    fun testRows() {
+        val rootSize = 200.dp
+        val boxesCount = 4
+        val rows = 0
+        val columns = 1
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                boxesCount = boxesCount,
+                gridOrientation = 0,
+                numRows = rows,
+                numColumns = columns,
+                hGap = 0,
+                vGap = 0,
+                gridSpans = "",
+                gridSkips = "",
+                gridRowWeights = "",
+                gridColumnWeights = ""
+            )
+        }
+        var expectedX = 0.dp
+        var expectedY = 0.dp
+
+        // 10.dp is the size of a singular box
+        val hGapSize = (rootSize - 10.dp) / 2f
+        val vGapSize = (rootSize - (10.dp * 4f)) / (boxesCount * 2f)
+        rule.waitForIdle()
+        expectedX += hGapSize
+        expectedY += vGapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
+    }
+
+    @Test
+    fun testColumns() {
+        val rootSize = 200.dp
+        val boxesCount = 4
+        val rows = 1
+        val columns = 0
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                boxesCount = boxesCount,
+                gridOrientation = 0,
+                numRows = rows,
+                numColumns = columns,
+                hGap = 0,
+                vGap = 0,
+                gridSpans = "",
+                gridSkips = "",
+                gridRowWeights = "",
+                gridColumnWeights = ""
+            )
+        }
+        var expectedX = 0.dp
+        var expectedY = 0.dp
+
+        // 10.dp is the size of a singular box
+        val hGapSize = (rootSize - (10.dp * 4f)) / (boxesCount * 2f)
+        val vGapSize = (rootSize - 10.dp) / 2f
+        rule.waitForIdle()
+        expectedX += hGapSize
+        expectedY += vGapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
+    }
+
+    @Test
+    fun testSkips() {
+        val rootSize = 200.dp
+        val boxesCount = 3
+        val rows = 2
+        val columns = 2
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                boxesCount = boxesCount,
+                gridOrientation = 0,
+                numRows = rows,
+                numColumns = columns,
+                hGap = 0,
+                vGap = 0,
+                gridSpans = "",
+                gridSkips = "0:1x1",
+                gridRowWeights = "",
+                gridColumnWeights = ""
+            )
+        }
+        var leftX = 0.dp
+        var topY = 0.dp
+        var rightX: Dp
+        var bottomY: Dp
+
+        // 10.dp is the size of a singular box
+        val gapSize = (rootSize - (10.dp * 2f)) / (columns * 2f)
+        rule.waitForIdle()
+        leftX += gapSize
+        topY += gapSize
+        rightX = leftX + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(rightX, topY)
+        bottomY = topY + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(leftX, bottomY)
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(rightX, bottomY)
+    }
+
+    @Test
+    fun testSpans() {
+        val rootSize = 200.dp
+        val boxesCount = 3
+        val rows = 2
+        val columns = 2
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                boxesCount = boxesCount,
+                gridOrientation = 0,
+                numRows = rows,
+                numColumns = columns,
+                hGap = 0,
+                vGap = 0,
+                gridSpans = "0:1x2",
+                gridSkips = "",
+                gridRowWeights = "",
+                gridColumnWeights = ""
+            )
+        }
+        var leftX = 0.dp
+        var topY = 0.dp
+        var rightX: Dp
+        var bottomY: Dp
+
+        // 10.dp is the size of a singular box
+        var spanLeft = (rootSize - 10.dp) / 2f
+        val gapSize = (rootSize - (10.dp * 2f)) / (columns * 2f)
+        rule.waitForIdle()
+        leftX += gapSize
+        topY += gapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(spanLeft, topY)
+        rightX = leftX + 10.dp + gapSize + gapSize
+        bottomY = topY + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(leftX, bottomY)
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(rightX, bottomY)
+    }
+
+    @Test
+    fun testRowWeights() {
+        val rootSize = 200.dp
+        val boxesCount = 2
+        val rows = 0
+        val columns = 1
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                boxesCount = boxesCount,
+                gridOrientation = 0,
+                numRows = rows,
+                numColumns = columns,
+                hGap = 0,
+                vGap = 0,
+                gridSpans = "",
+                gridSkips = "",
+                gridRowWeights = "1,3",
+                gridColumnWeights = ""
+            )
+        }
+        var expectedLeft = (rootSize - 10.dp) / 2f
+        var expectedTop = 0.dp
+
+        // 10.dp is the size of a singular box
+        // first box takes the 1/4 of the height
+        val firstGapSize = (rootSize / 4 - 10.dp) / 2
+        // second box takes the 3/4 of the height
+        val secondGapSize = ((rootSize * 3 / 4) - 10.dp) / 2
+        rule.waitForIdle()
+        expectedTop += firstGapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedLeft, expectedTop)
+        expectedTop += 10.dp + firstGapSize + secondGapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedLeft, expectedTop)
+    }
+
+    @Test
+    fun testColumnWeights() {
+        val rootSize = 200.dp
+        val boxesCount = 2
+        val rows = 1
+        val columns = 0
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                boxesCount = boxesCount,
+                gridOrientation = 0,
+                numRows = rows,
+                numColumns = columns,
+                hGap = 0,
+                vGap = 0,
+                gridSpans = "",
+                gridSkips = "",
+                gridRowWeights = "",
+                gridColumnWeights = "1,3"
+            )
+        }
+        var expectedLeft = 0.dp
+        var expectedTop = (rootSize - 10.dp) / 2f
+
+        // 10.dp is the size of a singular box
+        // first box takes the 1/4 of the width
+        val firstGapSize = (rootSize / 4 - 10.dp) / 2
+        // second box takes the 3/4 of the width
+        val secondGapSize = ((rootSize * 3 / 4) - 10.dp) / 2
+        rule.waitForIdle()
+        expectedLeft += firstGapSize
+
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedLeft, expectedTop)
+        expectedLeft += 10.dp + firstGapSize + secondGapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedLeft, expectedTop)
+    }
+
+    @Test
+    fun testGaps() {
+        val rootSize = 200.dp
+        val hGap = 10.dp
+        val vGap = 20.dp
+        rule.setContent {
+            gridComposableGapTest(
+                modifier = Modifier.size(rootSize),
+                hGap = Math.round(hGap.value),
+                vGap = Math.round(vGap.value),
+            )
+        }
+        var expectedLeft = 0.dp
+        var expectedTop = 0.dp
+
+        val boxWidth = (rootSize - hGap) / 2f
+        val boxHeight = (rootSize - vGap) / 2f
+
+        rule.waitForIdle()
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(0.dp, 0.dp)
+        expectedLeft += boxWidth + hGap
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedLeft, 0.dp)
+        expectedTop += boxHeight + vGap
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(0.dp, expectedTop)
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedLeft, expectedTop)
+    }
+
+    @Composable
+    private fun gridComposableTest(
+        modifier: Modifier = Modifier,
+        numRows: Int,
+        numColumns: Int,
+        gridSpans: String,
+        gridSkips: String,
+        gridRowWeights: String,
+        gridColumnWeights: String,
+        boxesCount: Int,
+        gridOrientation: Int,
+        vGap: Int,
+        hGap: Int,
+    ) {
+        ConstraintLayout(
+            ConstraintSet {
+                val ids = (0 until boxesCount).map { "box$it" }.toTypedArray()
+                val elem = arrayOfNulls<LayoutReference>(ids.size)
+                for (i in ids.indices) {
+                    elem[i] = createRefFor(ids[i])
+                }
+
+                val g1 = createGrid(
+                    elements = *elem,
+                    orientation = gridOrientation,
+                    skips = gridSkips,
+                    spans = gridSpans,
+                    rows = numRows,
+                    columns = numColumns,
+                    verticalGap = vGap.dp,
+                    horizontalGap = hGap.dp,
+                    rowWeights = gridRowWeights,
+                    columnWeights = gridColumnWeights,
+                )
+                constrain(g1) {
+                    width = Dimension.matchParent
+                    height = Dimension.matchParent
+                }
+            },
+            modifier = modifier
+        ) {
+            val ids = (0 until boxesCount).map { "box$it" }.toTypedArray()
+            ids.forEach { id ->
+                Box(
+                    Modifier
+                        .layoutId(id)
+                        .background(Color.Red)
+                        .testTag(id)
+                        .size(10.dp)
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun gridComposableGapTest(
+        modifier: Modifier = Modifier,
+        vGap: Int,
+        hGap: Int,
+    ) {
+        ConstraintLayout(
+            ConstraintSet {
+                val a = createRefFor("box0")
+                val b = createRefFor("box1")
+                val c = createRefFor("box2")
+                val d = createRefFor("box3")
+                val g1 = createGrid(
+                    a, b, c, d,
+                    rows = 2,
+                    columns = 2,
+                    verticalGap = vGap.dp,
+                    horizontalGap = hGap.dp,
+                )
+                constrain(g1) {
+                    width = Dimension.matchParent
+                    height = Dimension.matchParent
+                }
+                constrain(a) {
+                    width = Dimension.fillToConstraints
+                    height = Dimension.fillToConstraints
+                }
+                constrain(b) {
+                    width = Dimension.fillToConstraints
+                    height = Dimension.fillToConstraints
+                }
+                constrain(c) {
+                    width = Dimension.fillToConstraints
+                    height = Dimension.fillToConstraints
+                }
+                constrain(d) {
+                    width = Dimension.fillToConstraints
+                    height = Dimension.fillToConstraints
+                }
+            },
+            modifier = modifier,
+        ) {
+            val ids = (0 until 4).map { "box$it" }.toTypedArray()
+            ids.forEach { id ->
+                Box(
+                    Modifier
+                        .layoutId(id)
+                        .background(Color.Red)
+                        .testTag(id)
+                        .size(10.dp)
+                )
+            }
+        }
+    }
+}

--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/RowColumnDslTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/RowColumnDslTest.kt
@@ -145,7 +145,6 @@ class RowColumnDslTest {
                     skips = gridSkips,
                     spans = gridSpans,
                     verticalGap = vGap.dp,
-                    horizontalGap = hGap.dp,
                     rowWeights = gridRowWeights,
                 )
                 constrain(g1) {
@@ -190,7 +189,6 @@ class RowColumnDslTest {
                     elements = *elem.toTypedArray(),
                     skips = gridSkips,
                     spans = gridSpans,
-                    verticalGap = vGap.dp,
                     horizontalGap = hGap.dp,
                     columnWeights = gridColumnWeights,
                 )

--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/RowColumnDslTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/RowColumnDslTest.kt
@@ -64,11 +64,8 @@ class RowColumnDslTest {
             RowComposableTest(
                 modifier = Modifier.size(rootSize),
                 boxesCount = boxesCount,
-                hGap = 0,
                 vGap = 0,
-                gridSpans = "",
-                gridSkips = "",
-                gridRowWeights = "",
+                gridRowWeights = emptyArray(),
             )
         }
         var expectedX = 0.dp
@@ -98,10 +95,7 @@ class RowColumnDslTest {
                 modifier = Modifier.size(rootSize),
                 boxesCount = boxesCount,
                 hGap = 0,
-                vGap = 0,
-                gridSpans = "",
-                gridSkips = "",
-                gridColumnWeights = ""
+                gridColumnWeights = emptyArray()
             )
         }
         var expectedX = 0.dp
@@ -125,12 +119,9 @@ class RowColumnDslTest {
     @Composable
     private fun RowComposableTest(
         modifier: Modifier = Modifier,
-        gridSpans: String,
-        gridSkips: String,
-        gridRowWeights: String,
+        gridRowWeights: Array<Int>,
         boxesCount: Int,
         vGap: Int,
-        hGap: Int,
     ) {
         ConstraintLayout(
             ConstraintSet {
@@ -142,10 +133,7 @@ class RowColumnDslTest {
 
                 val g1 = createRow(
                     elements = *elem.toTypedArray(),
-                    skips = gridSkips,
-                    spans = gridSpans,
                     verticalGap = vGap.dp,
-                    rowWeights = gridRowWeights,
                 )
                 constrain(g1) {
                     width = Dimension.matchParent
@@ -170,11 +158,8 @@ class RowColumnDslTest {
     @Composable
     private fun ColumnComposableTest(
         modifier: Modifier = Modifier,
-        gridSpans: String,
-        gridSkips: String,
-        gridColumnWeights: String,
+        gridColumnWeights: Array<Int>,
         boxesCount: Int,
-        vGap: Int,
         hGap: Int,
     ) {
         ConstraintLayout(
@@ -187,10 +172,7 @@ class RowColumnDslTest {
 
                 val g1 = createColumn(
                     elements = *elem.toTypedArray(),
-                    skips = gridSkips,
-                    spans = gridSpans,
                     horizontalGap = hGap.dp,
-                    columnWeights = gridColumnWeights,
                 )
                 constrain(g1) {
                     width = Dimension.matchParent

--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/RowColumnDslTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/RowColumnDslTest.kt
@@ -1,0 +1,228 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.platform.isDebugInspectorInfoEnabled
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertPositionInRootIsEqualTo
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Tests for the Grid Helper (Row / Column)
+ */
+@MediumTest
+@RunWith(AndroidJUnit4::class)
+class RowColumnDslTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Before
+    fun setup() {
+        isDebugInspectorInfoEnabled = true
+    }
+
+    @After
+    fun tearDown() {
+        isDebugInspectorInfoEnabled = false
+    }
+
+    @Test
+    fun testRows() {
+        val rootSize = 200.dp
+        val boxesCount = 4
+        rule.setContent {
+            RowComposableTest(
+                modifier = Modifier.size(rootSize),
+                boxesCount = boxesCount,
+                gridOrientation = 0,
+                hGap = 0,
+                vGap = 0,
+                gridSpans = "''",
+                gridSkips = "''",
+                gridRowWeights = "''",
+                gridColumnWeights = "''"
+            )
+        }
+        var expectedX = 0.dp
+        var expectedY = 0.dp
+
+        // 10.dp is the size of a singular box
+        val hGapSize = (rootSize - 10.dp) / 2f
+        val vGapSize = (rootSize - (10.dp * 4f)) / (boxesCount * 2f)
+        rule.waitForIdle()
+        expectedX += hGapSize
+        expectedY += vGapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
+    }
+
+    @Test
+    fun testColumns() {
+        val rootSize = 200.dp
+        val boxesCount = 4
+        rule.setContent {
+            ColumnComposableTest(
+                modifier = Modifier.size(rootSize),
+                boxesCount = boxesCount,
+                gridOrientation = 0,
+                hGap = 0,
+                vGap = 0,
+                gridSpans = "''",
+                gridSkips = "''",
+                gridRowWeights = "''",
+                gridColumnWeights = "''"
+            )
+        }
+        var expectedX = 0.dp
+        var expectedY = 0.dp
+
+        // 10.dp is the size of a singular box
+        val hGapSize = (rootSize - (10.dp * 4f)) / (boxesCount * 2f)
+        val vGapSize = (rootSize - 10.dp) / 2f
+        rule.waitForIdle()
+        expectedX += hGapSize
+        expectedY += vGapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
+    }
+
+    @Composable
+    private fun RowComposableTest(
+        modifier: Modifier = Modifier,
+        gridSpans: String,
+        gridSkips: String,
+        gridRowWeights: String,
+        gridColumnWeights: String,
+        boxesCount: Int,
+        gridOrientation: Int,
+        vGap: Int,
+        hGap: Int,
+    ) {
+        ConstraintLayout(
+            ConstraintSet {
+                val ids = (0 until boxesCount).map { "box$it" }.toTypedArray()
+                val elem = arrayOfNulls<LayoutReference>(ids.size)
+                for (i in ids.indices) {
+                    elem[i] = createRefFor(ids[i])
+                }
+
+                val g1 = createRow(
+                    elements = *elem,
+                    orientation = gridOrientation,
+                    skips = gridSkips,
+                    spans = gridSpans,
+                    verticalGap = vGap.dp,
+                    horizontalGap = hGap.dp,
+                    rowWeights = gridRowWeights,
+                    columnWeights = gridColumnWeights,
+                )
+                constrain(g1) {
+                    width = Dimension.matchParent
+                    height = Dimension.matchParent
+                }
+            },
+            modifier = modifier
+        ) {
+            val ids = (0 until boxesCount).map { "box$it" }.toTypedArray()
+            ids.forEach { id ->
+                Box(
+                    Modifier
+                        .layoutId(id)
+                        .background(Color.Red)
+                        .testTag(id)
+                        .size(10.dp)
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun ColumnComposableTest(
+        modifier: Modifier = Modifier,
+        gridSpans: String,
+        gridSkips: String,
+        gridRowWeights: String,
+        gridColumnWeights: String,
+        boxesCount: Int,
+        gridOrientation: Int,
+        vGap: Int,
+        hGap: Int,
+    ) {
+        ConstraintLayout(
+            ConstraintSet {
+                val ids = (0 until boxesCount).map { "box$it" }.toTypedArray()
+                val elem = arrayOfNulls<LayoutReference>(ids.size)
+                for (i in ids.indices) {
+                    elem[i] = createRefFor(ids[i])
+                }
+
+                val g1 = createColumn(
+                    elements = *elem,
+                    orientation = gridOrientation,
+                    skips = gridSkips,
+                    spans = gridSpans,
+                    verticalGap = vGap.dp,
+                    horizontalGap = hGap.dp,
+                    rowWeights = gridRowWeights,
+                    columnWeights = gridColumnWeights,
+                )
+                constrain(g1) {
+                    width = Dimension.matchParent
+                    height = Dimension.matchParent
+                }
+            },
+            modifier = modifier
+        ) {
+            val ids = (0 until boxesCount).map { "box$it" }.toTypedArray()
+            ids.forEach { id ->
+                Box(
+                    Modifier
+                        .layoutId(id)
+                        .background(Color.Red)
+                        .testTag(id)
+                        .size(10.dp)
+                )
+            }
+        }
+    }
+}

--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/RowColumnDslTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/RowColumnDslTest.kt
@@ -64,13 +64,11 @@ class RowColumnDslTest {
             RowComposableTest(
                 modifier = Modifier.size(rootSize),
                 boxesCount = boxesCount,
-                gridOrientation = 0,
                 hGap = 0,
                 vGap = 0,
-                gridSpans = "''",
-                gridSkips = "''",
-                gridRowWeights = "''",
-                gridColumnWeights = "''"
+                gridSpans = "",
+                gridSkips = "",
+                gridRowWeights = "",
             )
         }
         var expectedX = 0.dp
@@ -99,13 +97,11 @@ class RowColumnDslTest {
             ColumnComposableTest(
                 modifier = Modifier.size(rootSize),
                 boxesCount = boxesCount,
-                gridOrientation = 0,
                 hGap = 0,
                 vGap = 0,
-                gridSpans = "''",
-                gridSkips = "''",
-                gridRowWeights = "''",
-                gridColumnWeights = "''"
+                gridSpans = "",
+                gridSkips = "",
+                gridColumnWeights = ""
             )
         }
         var expectedX = 0.dp
@@ -132,29 +128,25 @@ class RowColumnDslTest {
         gridSpans: String,
         gridSkips: String,
         gridRowWeights: String,
-        gridColumnWeights: String,
         boxesCount: Int,
-        gridOrientation: Int,
         vGap: Int,
         hGap: Int,
     ) {
         ConstraintLayout(
             ConstraintSet {
                 val ids = (0 until boxesCount).map { "box$it" }.toTypedArray()
-                val elem = arrayOfNulls<LayoutReference>(ids.size)
+                val elem = arrayListOf<LayoutReference>()
                 for (i in ids.indices) {
-                    elem[i] = createRefFor(ids[i])
+                    elem.add(createRefFor(ids[i]))
                 }
 
                 val g1 = createRow(
-                    elements = *elem,
-                    orientation = gridOrientation,
+                    elements = *elem.toTypedArray(),
                     skips = gridSkips,
                     spans = gridSpans,
                     verticalGap = vGap.dp,
                     horizontalGap = hGap.dp,
                     rowWeights = gridRowWeights,
-                    columnWeights = gridColumnWeights,
                 )
                 constrain(g1) {
                     width = Dimension.matchParent
@@ -181,29 +173,25 @@ class RowColumnDslTest {
         modifier: Modifier = Modifier,
         gridSpans: String,
         gridSkips: String,
-        gridRowWeights: String,
         gridColumnWeights: String,
         boxesCount: Int,
-        gridOrientation: Int,
         vGap: Int,
         hGap: Int,
     ) {
         ConstraintLayout(
             ConstraintSet {
                 val ids = (0 until boxesCount).map { "box$it" }.toTypedArray()
-                val elem = arrayOfNulls<LayoutReference>(ids.size)
+                val elem = arrayListOf<LayoutReference>()
                 for (i in ids.indices) {
-                    elem[i] = createRefFor(ids[i])
+                    elem.add(createRefFor(ids[i]))
                 }
 
                 val g1 = createColumn(
-                    elements = *elem,
-                    orientation = gridOrientation,
+                    elements = *elem.toTypedArray(),
                     skips = gridSkips,
                     spans = gridSpans,
                     verticalGap = vGap.dp,
                     horizontalGap = hGap.dp,
-                    rowWeights = gridRowWeights,
                     columnWeights = gridColumnWeights,
                 )
                 constrain(g1) {

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayoutBaseScope.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayoutBaseScope.kt
@@ -679,38 +679,40 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
     }
 
     /**
-     * Grid helpers make build a Row representation more intuitively.
+     * Creates a Grid based helper that lays out its elements in a single Row.
      *
-     * @param elements [LayoutReference]s to be laid out by the Flow helper
-     * @param elements [LayoutReference]s to be laid out by the Flow helper
-     * @param orientation 0 if horizontal and 1 if vertical
+     * @param elements [LayoutReference]s to be laid out by the Grid helper
      * @param verticalGap defines the gap between views in the y axis
      * @param horizontalGap defines the gap between views in the x axis
      * @param rowWeights defines the weight of each row
-     * @param columnWeights defines the weight of each column
+     *        the format of input string is "w1,w2,w3, ..."
      * @param skips defines the positions in a Grid to be skipped
+     *        the format of the input string is "index:rowxcol"
+     *        index - the index of the starting position
+     *        row - the number of rows to skip
+     *        col- the number of columns to skip
      * @param spans defines the spanned area(s) in Grid
+     *        the format of the input string is "index:rowxcol"
+     *        index - the index of the starting position
+     *        row - the number of rows to span
+     *        col- the number of columns to span
      * @param padding sets padding around the content
      */
     fun createRow(
-        vararg elements: LayoutReference?,
+        vararg elements: LayoutReference,
         verticalGap: Dp = 0.dp,
         horizontalGap: Dp = 0.dp,
-        rowWeights: String,
-        columnWeights: String,
-        orientation: Int = 0,
-        skips: String,
-        spans: String,
+        rowWeights: String = "",
+        skips: String = "",
+        spans: String = "",
         padding: Dp = 0.dp,
     ): ConstrainedLayoutReference {
         return createGrid(
             elements = elements,
-            orientation = orientation,
             columns = 1,
             horizontalGap = horizontalGap,
             verticalGap = verticalGap,
             rowWeights = rowWeights,
-            columnWeights = columnWeights,
             skips = skips,
             spans = spans,
             paddingLeft = padding,
@@ -721,26 +723,31 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
     }
 
     /**
-     * Grid helpers make build a Row representation more intuitively.
+     * Creates a Grid based helper that lays out its elements in a single Row.
      *
-     * @param elements [LayoutReference]s to be laid out by the Flow helper
-     * @param orientation 0 if horizontal and 1 if vertical
+     * @param elements [LayoutReference]s to be laid out by the Grid helper
      * @param verticalGap defines the gap between views in the y axis
      * @param horizontalGap defines the gap between views in the x axis
      * @param rowWeights defines the weight of each row
-     * @param columnWeights defines the weight of each column
+     *        the format of input string is "w1,w2,w3, ..."
      * @param skips defines the positions in a Grid to be skipped
+     *        the format of the input string is "index:rowxcol"
+     *        index - the index of the starting position
+     *        row - the number of rows to skip
+     *        col- the number of columns to skip
      * @param spans defines the spanned area(s) in Grid
+     *        the format of the input string is "index:rowxcol"
+     *        index - the index of the starting position
+     *        row - the number of rows to span
+     *        col- the number of columns to span
      * @param paddingHorizontal sets paddingLeft and paddingRight of the content
      * @param paddingVertical sets paddingTop and paddingBottom of the content
      */
     fun createRow(
-        vararg elements: LayoutReference?,
-        orientation: Int = 0,
+        vararg elements: LayoutReference,
         verticalGap: Dp = 0.dp,
         horizontalGap: Dp = 0.dp,
         rowWeights: String = "",
-        columnWeights: String = "",
         skips: String = "",
         spans: String = "",
         paddingHorizontal: Dp = 0.dp,
@@ -748,12 +755,10 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
     ): ConstrainedLayoutReference {
         return createGrid(
             elements = elements,
-            orientation = orientation,
             columns = 1,
             horizontalGap = horizontalGap,
             verticalGap = verticalGap,
             rowWeights = rowWeights,
-            columnWeights = columnWeights,
             skips = skips,
             spans = spans,
             paddingLeft = paddingHorizontal,
@@ -764,28 +769,33 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
     }
 
     /**
-     * Grid helpers make build a Row representation more intuitively.
+     * Creates a Grid based helper that lays out its elements in a single Row.
      *
-     * @param elements [LayoutReference]s to be laid out by the Flow helper
-     * @param orientation 0 if horizontal and 1 if vertical
+     * @param elements [LayoutReference]s to be laid out by the Grid helper
      * @param verticalGap defines the gap between views in the y axis
      * @param horizontalGap defines the gap between views in the x axis
      * @param rowWeights defines the weight of each row
-     * @param columnWeights defines the weight of each column
+     *        the format of input string is "w1,w2,w3, ..."
      * @param skips defines the positions in a Grid to be skipped
+     *        the format of the input string is "index:rowxcol"
+     *        index - the index of the starting position
+     *        row - the number of rows to skip
+     *        col- the number of columns to skip
      * @param spans defines the spanned area(s) in Grid
+     *        the format of the input string is "index:rowxcol"
+     *        index - the index of the starting position
+     *        row - the number of rows to span
+     *        col- the number of columns to span
      * @param paddingLeft sets paddingLeft of the content
      * @param paddingTop sets paddingTop of the content
      * @param paddingRight sets paddingRight of the content
      * @param paddingBottom sets paddingBottom of the content
      */
     fun createRow(
-        vararg elements: LayoutReference?,
-        orientation: Int = 0,
+        vararg elements: LayoutReference,
         verticalGap: Dp = 0.dp,
         horizontalGap: Dp = 0.dp,
         rowWeights: String = "",
-        columnWeights: String = "",
         skips: String = "",
         spans: String = "",
         paddingLeft: Dp = 0.dp,
@@ -809,54 +819,54 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
         ref.asCLContainer().apply {
             put("contains", elementArray)
             putString("type", "grid")
-            putNumber("orientation", orientation.toFloat())
+            putNumber("orientation", 0f)
             putNumber("columns", 1f)
             putNumber("vGap", verticalGap.value)
             putNumber("hGap", horizontalGap.value)
             put("padding", paddingArray)
             putString("rowWeights", rowWeights)
-            putString("columnWeights", columnWeights)
+            putString("columnWeights", "")
             putString("skips", skips)
             putString("spans", spans)
         }
-        updateHelpersHashCode(18)
-        elements.forEach { updateHelpersHashCode(it.hashCode()) }
 
         return ref
     }
 
     /**
-     * Grid helpers make build a Column representation more intuitively.
+     * Creates a Grid based helper that lays out its elements in a single Column.
      *
-     * @param elements [LayoutReference]s to be laid out by the Flow helper
-     * @param elements [LayoutReference]s to be laid out by the Flow helper
-     * @param orientation 0 if horizontal and 1 if vertical
+     * @param elements [LayoutReference]s to be laid out by the Grid helper
      * @param verticalGap defines the gap between views in the y axis
      * @param horizontalGap defines the gap between views in the x axis
-     * @param rowWeights defines the weight of each row
      * @param columnWeights defines the weight of each column
+     *        the format of input string is "w1,w2,w3, ..."
      * @param skips defines the positions in a Grid to be skipped
+     *        the format of the input string is "index:rowxcol"
+     *        index - the index of the starting position
+     *        row - the number of rows to skip
+     *        col- the number of columns to skip
      * @param spans defines the spanned area(s) in Grid
+     *        the format of the input string is "index:rowxcol"
+     *        index - the index of the starting position
+     *        row - the number of rows to span
+     *        col- the number of columns to span
      * @param padding sets padding around the content
      */
     fun createColumn(
-        vararg elements: LayoutReference?,
+        vararg elements: LayoutReference,
         verticalGap: Dp = 0.dp,
         horizontalGap: Dp = 0.dp,
-        rowWeights: String,
-        columnWeights: String,
-        orientation: Int = 0,
-        skips: String,
-        spans: String,
+        columnWeights: String = "",
+        skips: String = "",
+        spans: String = "",
         padding: Dp = 0.dp,
     ): ConstrainedLayoutReference {
         return createGrid(
             elements = elements,
-            orientation = orientation,
             rows = 1,
             horizontalGap = horizontalGap,
             verticalGap = verticalGap,
-            rowWeights = rowWeights,
             columnWeights = columnWeights,
             skips = skips,
             spans = spans,
@@ -868,25 +878,30 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
     }
 
     /**
-     * Grid helpers make build a Column representation more intuitively.
+     * Creates a Grid based helper that lays out its elements in a single Column.
      *
-     * @param elements [LayoutReference]s to be laid out by the Flow helper
-     * @param orientation 0 if horizontal and 1 if vertical
+     * @param elements [LayoutReference]s to be laid out by the Grid helper
      * @param verticalGap defines the gap between views in the y axis
      * @param horizontalGap defines the gap between views in the x axis
-     * @param rowWeights defines the weight of each row
      * @param columnWeights defines the weight of each column
+     *        the format of input string is "w1,w2,w3, ..."
      * @param skips defines the positions in a Grid to be skipped
+     *        the format of the input string is "index:rowxcol"
+     *        index - the index of the starting position
+     *        row - the number of rows to skip
+     *        col- the number of columns to skip
      * @param spans defines the spanned area(s) in Grid
+     *        the format of the input string is "index:rowxcol"
+     *        index - the index of the starting position
+     *        row - the number of rows to span
+     *        col- the number of columns to span
      * @param paddingHorizontal sets paddingLeft and paddingRight of the content
      * @param paddingVertical sets paddingTop and paddingBottom of the content
      */
     fun createColumn(
-        vararg elements: LayoutReference?,
-        orientation: Int = 0,
+        vararg elements: LayoutReference,
         verticalGap: Dp = 0.dp,
         horizontalGap: Dp = 0.dp,
-        rowWeights: String = "",
         columnWeights: String = "",
         skips: String = "",
         spans: String = "",
@@ -895,11 +910,9 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
     ): ConstrainedLayoutReference {
         return createGrid(
             elements = elements,
-            orientation = orientation,
             rows = 1,
             horizontalGap = horizontalGap,
             verticalGap = verticalGap,
-            rowWeights = rowWeights,
             columnWeights = columnWeights,
             skips = skips,
             spans = spans,
@@ -911,27 +924,32 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
     }
 
     /**
-     * Grid helpers make build a Grid representation more intuitively.
+     * Creates a Grid based helper that lays out its elements in a single Column.
      *
-     * @param elements [LayoutReference]s to be laid out by the Flow helper
-     * @param orientation 0 if horizontal and 1 if vertical
+     * @param elements [LayoutReference]s to be laid out by the Grid helper
      * @param verticalGap defines the gap between views in the y axis
      * @param horizontalGap defines the gap between views in the x axis
-     * @param rowWeights defines the weight of each row
      * @param columnWeights defines the weight of each column
+     *        the format of input string is "w1,w2,w3, ..."
      * @param skips defines the positions in a Grid to be skipped
+     *        the format of the input string is "index:rowxcol"
+     *        index - the index of the starting position
+     *        row - the number of rows to skip
+     *        col- the number of columns to skip
      * @param spans defines the spanned area(s) in Grid
+     *        the format of the input string is "index:rowxcol"
+     *        index - the index of the starting position
+     *        row - the number of rows to span
+     *        col- the number of columns to span
      * @param paddingLeft sets paddingLeft of the content
      * @param paddingTop sets paddingTop of the content
      * @param paddingRight sets paddingRight of the content
      * @param paddingBottom sets paddingBottom of the content
      */
     fun createColumn(
-        vararg elements: LayoutReference?,
-        orientation: Int = 0,
+        vararg elements: LayoutReference,
         verticalGap: Dp = 0.dp,
         horizontalGap: Dp = 0.dp,
-        rowWeights: String = "",
         columnWeights: String = "",
         skips: String = "",
         spans: String = "",
@@ -956,49 +974,56 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
         ref.asCLContainer().apply {
             put("contains", elementArray)
             putString("type", "grid")
-            putNumber("orientation", orientation.toFloat())
+            putNumber("orientation", 0f)
             putNumber("rows", 1f)
             putNumber("vGap", verticalGap.value)
             putNumber("hGap", horizontalGap.value)
             put("padding", paddingArray)
-            putString("rowWeights", rowWeights)
+            putString("rowWeights", "")
             putString("columnWeights", columnWeights)
             putString("skips", skips)
             putString("spans", spans)
         }
-        updateHelpersHashCode(18)
-        elements.forEach { updateHelpersHashCode(it.hashCode()) }
 
         return ref
     }
 
     /**
-     * Grid helpers make build a Grid representation more intuitively.
+     * Creates a Grid representation with a Grid Helper.
      *
-     * @param elements [LayoutReference]s to be laid out by the Flow helper
-     * @param elements [LayoutReference]s to be laid out by the Flow helper
+     * @param elements [LayoutReference]s to be laid out by the Grid helper
      * @param orientation 0 if horizontal and 1 if vertical
      * @param rows sets the number of rows in Grid
      * @param columns sets the number of columns in Grid
      * @param verticalGap defines the gap between views in the y axis
      * @param horizontalGap defines the gap between views in the x axis
      * @param rowWeights defines the weight of each row
+     *        the format of input string is "w1,w2,w3, ..."
      * @param columnWeights defines the weight of each column
+     *        the format of input string is "w1,w2,w3, ..."
      * @param skips defines the positions in a Grid to be skipped
+     *        the format of the input string is "index:rowxcol"
+     *        index - the index of the starting position
+     *        row - the number of rows to skip
+     *        col- the number of columns to skip
      * @param spans defines the spanned area(s) in Grid
+     *        the format of the input string is "index:rowxcol"
+     *        index - the index of the starting position
+     *        row - the number of rows to span
+     *        col- the number of columns to span
      * @param padding sets padding around the content
      */
     fun createGrid(
-        vararg elements: LayoutReference?,
+        vararg elements: LayoutReference,
+        orientation: Int = 0,
         rows: Int = 0,
         columns: Int = 0,
         verticalGap: Dp = 0.dp,
         horizontalGap: Dp = 0.dp,
-        rowWeights: String,
-        columnWeights: String,
-        orientation: Int = 0,
-        skips: String,
-        spans: String,
+        rowWeights: String = "",
+        columnWeights: String = "",
+        skips: String = "",
+        spans: String = "",
         padding: Dp = 0.dp,
     ): ConstrainedLayoutReference {
         return createGrid(
@@ -1020,23 +1045,33 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
     }
 
     /**
-     * Grid helpers make build a Grid representation more intuitively.
+     * Creates a Grid representation with a Grid Helper.
      *
-     * @param elements [LayoutReference]s to be laid out by the Flow helper
+     * @param elements [LayoutReference]s to be laid out by the Grid helper
      * @param orientation 0 if horizontal and 1 if vertical
      * @param rows sets the number of rows in Grid
      * @param columns sets the number of columns in Grid
      * @param verticalGap defines the gap between views in the y axis
      * @param horizontalGap defines the gap between views in the x axis
      * @param rowWeights defines the weight of each row
+     *        the format of input string is "w1,w2,w3, ..."
      * @param columnWeights defines the weight of each column
+     *        the format of input string is "w1,w2,w3, ..."
      * @param skips defines the positions in a Grid to be skipped
+     *        the format of the input string is "index:rowxcol"
+     *        index - the index of the starting position
+     *        row - the number of rows to skip
+     *        col- the number of columns to skip
      * @param spans defines the spanned area(s) in Grid
+     *        the format of the input string is "index:rowxcol"
+     *        index - the index of the starting position
+     *        row - the number of rows to span
+     *        col- the number of columns to span
      * @param paddingHorizontal sets paddingLeft and paddingRight of the content
      * @param paddingVertical sets paddingTop and paddingBottom of the content
      */
     fun createGrid(
-        vararg elements: LayoutReference?,
+        vararg elements: LayoutReference,
         orientation: Int = 0,
         rows: Int = 0,
         columns: Int = 0,
@@ -1068,25 +1103,35 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
     }
 
     /**
-     * Grid helpers make build a Grid representation more intuitively.
+     * Creates a Grid representation with a Grid Helper.
      *
-     * @param elements [LayoutReference]s to be laid out by the Flow helper
+     * @param elements [LayoutReference]s to be laid out by the Grid helper
      * @param orientation 0 if horizontal and 1 if vertical
      * @param rows sets the number of rows in Grid
      * @param columns sets the number of columns in Grid
      * @param verticalGap defines the gap between views in the y axis
      * @param horizontalGap defines the gap between views in the x axis
      * @param rowWeights defines the weight of each row
+     *        the format of input string is "w1,w2,w3, ..."
      * @param columnWeights defines the weight of each column
+     *        the format of input string is "w1,w2,w3, ..."
      * @param skips defines the positions in a Grid to be skipped
+     *        the format of the input string is "index:rowxcol"
+     *        index - the index of the starting position
+     *        row - the number of rows to skip
+     *        col- the number of columns to skip
      * @param spans defines the spanned area(s) in Grid
+     *        the format of the input string is "index:rowxcol"
+     *        index - the index of the starting position
+     *        row - the number of rows to span
+     *        col- the number of columns to span
      * @param paddingLeft sets paddingLeft of the content
      * @param paddingTop sets paddingTop of the content
      * @param paddingRight sets paddingRight of the content
      * @param paddingBottom sets paddingBottom of the content
      */
     fun createGrid(
-        vararg elements: LayoutReference?,
+        vararg elements: LayoutReference,
         orientation: Int = 0,
         rows: Int = 0,
         columns: Int = 0,
@@ -1128,8 +1173,6 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
             putString("skips", skips)
             putString("spans", spans)
         }
-        updateHelpersHashCode(18)
-        elements.forEach { updateHelpersHashCode(it.hashCode()) }
 
         return ref
     }

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayoutBaseScope.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayoutBaseScope.kt
@@ -684,34 +684,20 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      * @param elements [LayoutReference]s to be laid out by the Grid helper
      * @param verticalGap defines the gap between views in the y axis
      * @param rowWeights defines the weight of each row
-     *        the format of input string is "w1,w2,w3, ..."
-     * @param skips defines the positions in a Grid to be skipped
-     *        the format of the input string is "index:rowxcol"
-     *        index - the index of the starting position
-     *        row - the number of rows to skip
-     *        col- the number of columns to skip
-     * @param spans defines the spanned area(s) in Grid
-     *        the format of the input string is "index:rowxcol"
-     *        index - the index of the starting position
-     *        row - the number of rows to span
-     *        col- the number of columns to span
      * @param padding sets padding around the content
      */
     fun createRow(
         vararg elements: LayoutReference,
         verticalGap: Dp = 0.dp,
-        rowWeights: String = "",
-        skips: String = "",
-        spans: String = "",
+        rowWeights: IntArray? = null,
         padding: Dp = 0.dp,
     ): ConstrainedLayoutReference {
         return createGrid(
             elements = elements,
+            rowWeights = rowWeights,
             columns = 1,
             verticalGap = verticalGap,
-            rowWeights = rowWeights,
-            skips = skips,
-            spans = spans,
+            columnWeights = null,
             paddingLeft = padding,
             paddingTop = padding,
             paddingRight = padding,
@@ -725,26 +711,13 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      * @param elements [LayoutReference]s to be laid out by the Grid helper
      * @param verticalGap defines the gap between views in the y axis
      * @param rowWeights defines the weight of each row
-     *        the format of input string is "w1,w2,w3, ..."
-     * @param skips defines the positions in a Grid to be skipped
-     *        the format of the input string is "index:rowxcol"
-     *        index - the index of the starting position
-     *        row - the number of rows to skip
-     *        col- the number of columns to skip
-     * @param spans defines the spanned area(s) in Grid
-     *        the format of the input string is "index:rowxcol"
-     *        index - the index of the starting position
-     *        row - the number of rows to span
-     *        col- the number of columns to span
      * @param paddingHorizontal sets paddingLeft and paddingRight of the content
      * @param paddingVertical sets paddingTop and paddingBottom of the content
      */
     fun createRow(
         vararg elements: LayoutReference,
         verticalGap: Dp = 0.dp,
-        rowWeights: String = "",
-        skips: String = "",
-        spans: String = "",
+        rowWeights: IntArray? = null,
         paddingHorizontal: Dp = 0.dp,
         paddingVertical: Dp = 0.dp,
     ): ConstrainedLayoutReference {
@@ -753,8 +726,7 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
             columns = 1,
             verticalGap = verticalGap,
             rowWeights = rowWeights,
-            skips = skips,
-            spans = spans,
+            columnWeights = null,
             paddingLeft = paddingHorizontal,
             paddingTop = paddingVertical,
             paddingRight = paddingHorizontal,
@@ -763,100 +735,25 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
     }
 
     /**
-     * Creates a Grid based helper that lays out its elements in a single Row.
-     *
-     * @param elements [LayoutReference]s to be laid out by the Grid helper
-     * @param verticalGap defines the gap between views in the y axis
-     * @param rowWeights defines the weight of each row
-     *        the format of input string is "w1,w2,w3, ..."
-     * @param skips defines the positions in a Grid to be skipped
-     *        the format of the input string is "index:rowxcol"
-     *        index - the index of the starting position
-     *        row - the number of rows to skip
-     *        col- the number of columns to skip
-     * @param spans defines the spanned area(s) in Grid
-     *        the format of the input string is "index:rowxcol"
-     *        index - the index of the starting position
-     *        row - the number of rows to span
-     *        col- the number of columns to span
-     * @param paddingLeft sets paddingLeft of the content
-     * @param paddingTop sets paddingTop of the content
-     * @param paddingRight sets paddingRight of the content
-     * @param paddingBottom sets paddingBottom of the content
-     */
-    fun createRow(
-        vararg elements: LayoutReference,
-        verticalGap: Dp = 0.dp,
-        rowWeights: String = "",
-        skips: String = "",
-        spans: String = "",
-        paddingLeft: Dp = 0.dp,
-        paddingTop: Dp = 0.dp,
-        paddingRight: Dp = 0.dp,
-        paddingBottom: Dp = 0.dp,
-    ): ConstrainedLayoutReference {
-        val ref = ConstrainedLayoutReference(createHelperId())
-        val elementArray = CLArray(charArrayOf())
-        elements.forEach {
-            if (it != null) {
-                elementArray.add(CLString.from(it.id.toString()))
-            }
-        }
-        val paddingArray = CLArray(charArrayOf()).apply {
-            add(CLNumber(paddingLeft.value))
-            add(CLNumber(paddingTop.value))
-            add(CLNumber(paddingRight.value))
-            add(CLNumber(paddingBottom.value))
-        }
-        ref.asCLContainer().apply {
-            put("contains", elementArray)
-            putString("type", "grid")
-            putNumber("orientation", 0f)
-            putNumber("columns", 1f)
-            putNumber("vGap", verticalGap.value)
-            put("padding", paddingArray)
-            putString("rowWeights", rowWeights)
-            putString("skips", skips)
-            putString("spans", spans)
-        }
-
-        return ref
-    }
-
-    /**
      * Creates a Grid based helper that lays out its elements in a single Column.
      *
      * @param elements [LayoutReference]s to be laid out by the Grid helper
      * @param horizontalGap defines the gap between views in the x axis
      * @param columnWeights defines the weight of each column
-     *        the format of input string is "w1,w2,w3, ..."
-     * @param skips defines the positions in a Grid to be skipped
-     *        the format of the input string is "index:rowxcol"
-     *        index - the index of the starting position
-     *        row - the number of rows to skip
-     *        col- the number of columns to skip
-     * @param spans defines the spanned area(s) in Grid
-     *        the format of the input string is "index:rowxcol"
-     *        index - the index of the starting position
-     *        row - the number of rows to span
-     *        col- the number of columns to span
      * @param padding sets padding around the content
      */
     fun createColumn(
         vararg elements: LayoutReference,
+        columnWeights: IntArray? = null,
         horizontalGap: Dp = 0.dp,
-        columnWeights: String = "",
-        skips: String = "",
-        spans: String = "",
         padding: Dp = 0.dp,
     ): ConstrainedLayoutReference {
         return createGrid(
             elements = elements,
             rows = 1,
             horizontalGap = horizontalGap,
+            rowWeights = null,
             columnWeights = columnWeights,
-            skips = skips,
-            spans = spans,
             paddingLeft = padding,
             paddingTop = padding,
             paddingRight = padding,
@@ -870,26 +767,13 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      * @param elements [LayoutReference]s to be laid out by the Grid helper
      * @param horizontalGap defines the gap between views in the x axis
      * @param columnWeights defines the weight of each column
-     *        the format of input string is "w1,w2,w3, ..."
-     * @param skips defines the positions in a Grid to be skipped
-     *        the format of the input string is "index:rowxcol"
-     *        index - the index of the starting position
-     *        row - the number of rows to skip
-     *        col- the number of columns to skip
-     * @param spans defines the spanned area(s) in Grid
-     *        the format of the input string is "index:rowxcol"
-     *        index - the index of the starting position
-     *        row - the number of rows to span
-     *        col- the number of columns to span
      * @param paddingHorizontal sets paddingLeft and paddingRight of the content
      * @param paddingVertical sets paddingTop and paddingBottom of the content
      */
     fun createColumn(
         vararg elements: LayoutReference,
         horizontalGap: Dp = 0.dp,
-        columnWeights: String = "",
-        skips: String = "",
-        spans: String = "",
+        columnWeights: IntArray? = null,
         paddingHorizontal: Dp = 0.dp,
         paddingVertical: Dp = 0.dp,
     ): ConstrainedLayoutReference {
@@ -897,75 +781,13 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
             elements = elements,
             rows = 1,
             horizontalGap = horizontalGap,
+            rowWeights = null,
             columnWeights = columnWeights,
-            skips = skips,
-            spans = spans,
             paddingLeft = paddingHorizontal,
             paddingTop = paddingVertical,
             paddingRight = paddingHorizontal,
             paddingBottom = paddingVertical,
         )
-    }
-
-    /**
-     * Creates a Grid based helper that lays out its elements in a single Column.
-     *
-     * @param elements [LayoutReference]s to be laid out by the Grid helper
-     * @param horizontalGap defines the gap between views in the x axis
-     * @param columnWeights defines the weight of each column
-     *        the format of input string is "w1,w2,w3, ..."
-     * @param skips defines the positions in a Grid to be skipped
-     *        the format of the input string is "index:rowxcol"
-     *        index - the index of the starting position
-     *        row - the number of rows to skip
-     *        col- the number of columns to skip
-     * @param spans defines the spanned area(s) in Grid
-     *        the format of the input string is "index:rowxcol"
-     *        index - the index of the starting position
-     *        row - the number of rows to span
-     *        col- the number of columns to span
-     * @param paddingLeft sets paddingLeft of the content
-     * @param paddingTop sets paddingTop of the content
-     * @param paddingRight sets paddingRight of the content
-     * @param paddingBottom sets paddingBottom of the content
-     */
-    fun createColumn(
-        vararg elements: LayoutReference,
-        horizontalGap: Dp = 0.dp,
-        columnWeights: String = "",
-        skips: String = "",
-        spans: String = "",
-        paddingLeft: Dp = 0.dp,
-        paddingTop: Dp = 0.dp,
-        paddingRight: Dp = 0.dp,
-        paddingBottom: Dp = 0.dp,
-    ): ConstrainedLayoutReference {
-        val ref = ConstrainedLayoutReference(createHelperId())
-        val elementArray = CLArray(charArrayOf())
-        elements.forEach {
-            if (it != null) {
-                elementArray.add(CLString.from(it.id.toString()))
-            }
-        }
-        val paddingArray = CLArray(charArrayOf()).apply {
-            add(CLNumber(paddingLeft.value))
-            add(CLNumber(paddingTop.value))
-            add(CLNumber(paddingRight.value))
-            add(CLNumber(paddingBottom.value))
-        }
-        ref.asCLContainer().apply {
-            put("contains", elementArray)
-            putString("type", "grid")
-            putNumber("orientation", 0f)
-            putNumber("rows", 1f)
-            putNumber("hGap", horizontalGap.value)
-            put("padding", paddingArray)
-            putString("columnWeights", columnWeights)
-            putString("skips", skips)
-            putString("spans", spans)
-        }
-
-        return ref
     }
 
     /**
@@ -978,9 +800,7 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      * @param verticalGap defines the gap between views in the y axis
      * @param horizontalGap defines the gap between views in the x axis
      * @param rowWeights defines the weight of each row
-     *        the format of input string is "w1,w2,w3, ..."
      * @param columnWeights defines the weight of each column
-     *        the format of input string is "w1,w2,w3, ..."
      * @param skips defines the positions in a Grid to be skipped
      *        the format of the input string is "index:rowxcol"
      *        index - the index of the starting position
@@ -1000,8 +820,8 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
         columns: Int = 0,
         verticalGap: Dp = 0.dp,
         horizontalGap: Dp = 0.dp,
-        rowWeights: String = "",
-        columnWeights: String = "",
+        rowWeights: IntArray? = null,
+        columnWeights: IntArray? = null,
         skips: String = "",
         spans: String = "",
         padding: Dp = 0.dp,
@@ -1028,15 +848,13 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      * Creates a Grid representation with a Grid Helper.
      *
      * @param elements [LayoutReference]s to be laid out by the Grid helper
-     * @param orientation 0 if horizontal and 1 if vertical
+     * @param rowWeights defines the weight of each row
      * @param rows sets the number of rows in Grid
      * @param columns sets the number of columns in Grid
      * @param verticalGap defines the gap between views in the y axis
      * @param horizontalGap defines the gap between views in the x axis
-     * @param rowWeights defines the weight of each row
-     *        the format of input string is "w1,w2,w3, ..."
      * @param columnWeights defines the weight of each column
-     *        the format of input string is "w1,w2,w3, ..."
+     * @param orientation 0 if horizontal and 1 if vertical
      * @param skips defines the positions in a Grid to be skipped
      *        the format of the input string is "index:rowxcol"
      *        index - the index of the starting position
@@ -1057,8 +875,8 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
         columns: Int = 0,
         verticalGap: Dp = 0.dp,
         horizontalGap: Dp = 0.dp,
-        rowWeights: String = "",
-        columnWeights: String = "",
+        rowWeights: IntArray? = null,
+        columnWeights: IntArray? = null,
         skips: String = "",
         spans: String = "",
         paddingHorizontal: Dp = 0.dp,
@@ -1066,13 +884,13 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
     ): ConstrainedLayoutReference {
         return createGrid(
             elements = elements,
+            rowWeights = rowWeights,
+            columnWeights = columnWeights,
             orientation = orientation,
             rows = rows,
             columns = columns,
             horizontalGap = horizontalGap,
             verticalGap = verticalGap,
-            rowWeights = rowWeights,
-            columnWeights = columnWeights,
             skips = skips,
             spans = spans,
             paddingLeft = paddingHorizontal,
@@ -1092,9 +910,7 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      * @param verticalGap defines the gap between views in the y axis
      * @param horizontalGap defines the gap between views in the x axis
      * @param rowWeights defines the weight of each row
-     *        the format of input string is "w1,w2,w3, ..."
      * @param columnWeights defines the weight of each column
-     *        the format of input string is "w1,w2,w3, ..."
      * @param skips defines the positions in a Grid to be skipped
      *        the format of the input string is "index:rowxcol"
      *        index - the index of the starting position
@@ -1117,8 +933,8 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
         columns: Int = 0,
         verticalGap: Dp = 0.dp,
         horizontalGap: Dp = 0.dp,
-        rowWeights: String = "",
-        columnWeights: String = "",
+        rowWeights: IntArray? = null,
+        columnWeights: IntArray? = null,
         skips: String = "",
         spans: String = "",
         paddingLeft: Dp = 0.dp,
@@ -1129,9 +945,7 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
         val ref = ConstrainedLayoutReference(createHelperId())
         val elementArray = CLArray(charArrayOf())
         elements.forEach {
-            if (it != null) {
-                elementArray.add(CLString.from(it.id.toString()))
-            }
+            elementArray.add(CLString.from(it.id.toString()))
         }
         val paddingArray = CLArray(charArrayOf()).apply {
             add(CLNumber(paddingLeft.value))
@@ -1139,6 +953,15 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
             add(CLNumber(paddingRight.value))
             add(CLNumber(paddingBottom.value))
         }
+        var strRowWeights = ""
+        var strColumnWeights = ""
+        if (rowWeights != null && rowWeights.size > 1) {
+            strRowWeights = rowWeights.joinToString(",")
+        }
+        if (columnWeights != null && columnWeights.size > 1) {
+            strColumnWeights = columnWeights.joinToString(",")
+        }
+
         ref.asCLContainer().apply {
             put("contains", elementArray)
             putString("type", "grid")
@@ -1148,8 +971,8 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
             putNumber("vGap", verticalGap.value)
             putNumber("hGap", horizontalGap.value)
             put("padding", paddingArray)
-            putString("rowWeights", rowWeights)
-            putString("columnWeights", columnWeights)
+            putString("rowWeights", strRowWeights)
+            putString("columnWeights", strColumnWeights)
             putString("skips", skips)
             putString("spans", spans)
         }

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayoutBaseScope.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayoutBaseScope.kt
@@ -679,6 +679,463 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
     }
 
     /**
+     * Grid helpers make build a Row representation more intuitively.
+     *
+     * @param elements [LayoutReference]s to be laid out by the Flow helper
+     * @param elements [LayoutReference]s to be laid out by the Flow helper
+     * @param orientation 0 if horizontal and 1 if vertical
+     * @param verticalGap defines the gap between views in the y axis
+     * @param horizontalGap defines the gap between views in the x axis
+     * @param rowWeights defines the weight of each row
+     * @param columnWeights defines the weight of each column
+     * @param skips defines the positions in a Grid to be skipped
+     * @param spans defines the spanned area(s) in Grid
+     * @param padding sets padding around the content
+     */
+    fun createRow(
+        vararg elements: LayoutReference?,
+        verticalGap: Dp = 0.dp,
+        horizontalGap: Dp = 0.dp,
+        rowWeights: String,
+        columnWeights: String,
+        orientation: Int = 0,
+        skips: String,
+        spans: String,
+        padding: Dp = 0.dp,
+    ): ConstrainedLayoutReference {
+        return createGrid(
+            elements = elements,
+            orientation = orientation,
+            columns = 1,
+            horizontalGap = horizontalGap,
+            verticalGap = verticalGap,
+            rowWeights = rowWeights,
+            columnWeights = columnWeights,
+            skips = skips,
+            spans = spans,
+            paddingLeft = padding,
+            paddingTop = padding,
+            paddingRight = padding,
+            paddingBottom = padding,
+        )
+    }
+
+    /**
+     * Grid helpers make build a Row representation more intuitively.
+     *
+     * @param elements [LayoutReference]s to be laid out by the Flow helper
+     * @param orientation 0 if horizontal and 1 if vertical
+     * @param verticalGap defines the gap between views in the y axis
+     * @param horizontalGap defines the gap between views in the x axis
+     * @param rowWeights defines the weight of each row
+     * @param columnWeights defines the weight of each column
+     * @param skips defines the positions in a Grid to be skipped
+     * @param spans defines the spanned area(s) in Grid
+     * @param paddingHorizontal sets paddingLeft and paddingRight of the content
+     * @param paddingVertical sets paddingTop and paddingBottom of the content
+     */
+    fun createRow(
+        vararg elements: LayoutReference?,
+        orientation: Int = 0,
+        verticalGap: Dp = 0.dp,
+        horizontalGap: Dp = 0.dp,
+        rowWeights: String = "",
+        columnWeights: String = "",
+        skips: String = "",
+        spans: String = "",
+        paddingHorizontal: Dp = 0.dp,
+        paddingVertical: Dp = 0.dp,
+    ): ConstrainedLayoutReference {
+        return createGrid(
+            elements = elements,
+            orientation = orientation,
+            columns = 1,
+            horizontalGap = horizontalGap,
+            verticalGap = verticalGap,
+            rowWeights = rowWeights,
+            columnWeights = columnWeights,
+            skips = skips,
+            spans = spans,
+            paddingLeft = paddingHorizontal,
+            paddingTop = paddingVertical,
+            paddingRight = paddingHorizontal,
+            paddingBottom = paddingVertical,
+        )
+    }
+
+    /**
+     * Grid helpers make build a Row representation more intuitively.
+     *
+     * @param elements [LayoutReference]s to be laid out by the Flow helper
+     * @param orientation 0 if horizontal and 1 if vertical
+     * @param verticalGap defines the gap between views in the y axis
+     * @param horizontalGap defines the gap between views in the x axis
+     * @param rowWeights defines the weight of each row
+     * @param columnWeights defines the weight of each column
+     * @param skips defines the positions in a Grid to be skipped
+     * @param spans defines the spanned area(s) in Grid
+     * @param paddingLeft sets paddingLeft of the content
+     * @param paddingTop sets paddingTop of the content
+     * @param paddingRight sets paddingRight of the content
+     * @param paddingBottom sets paddingBottom of the content
+     */
+    fun createRow(
+        vararg elements: LayoutReference?,
+        orientation: Int = 0,
+        verticalGap: Dp = 0.dp,
+        horizontalGap: Dp = 0.dp,
+        rowWeights: String = "",
+        columnWeights: String = "",
+        skips: String = "",
+        spans: String = "",
+        paddingLeft: Dp = 0.dp,
+        paddingTop: Dp = 0.dp,
+        paddingRight: Dp = 0.dp,
+        paddingBottom: Dp = 0.dp,
+    ): ConstrainedLayoutReference {
+        val ref = ConstrainedLayoutReference(createHelperId())
+        val elementArray = CLArray(charArrayOf())
+        elements.forEach {
+            if (it != null) {
+                elementArray.add(CLString.from(it.id.toString()))
+            }
+        }
+        val paddingArray = CLArray(charArrayOf()).apply {
+            add(CLNumber(paddingLeft.value))
+            add(CLNumber(paddingTop.value))
+            add(CLNumber(paddingRight.value))
+            add(CLNumber(paddingBottom.value))
+        }
+        ref.asCLContainer().apply {
+            put("contains", elementArray)
+            putString("type", "grid")
+            putNumber("orientation", orientation.toFloat())
+            putNumber("columns", 1f)
+            putNumber("vGap", verticalGap.value)
+            putNumber("hGap", horizontalGap.value)
+            put("padding", paddingArray)
+            putString("rowWeights", rowWeights)
+            putString("columnWeights", columnWeights)
+            putString("skips", skips)
+            putString("spans", spans)
+        }
+        updateHelpersHashCode(18)
+        elements.forEach { updateHelpersHashCode(it.hashCode()) }
+
+        return ref
+    }
+
+    /**
+     * Grid helpers make build a Column representation more intuitively.
+     *
+     * @param elements [LayoutReference]s to be laid out by the Flow helper
+     * @param elements [LayoutReference]s to be laid out by the Flow helper
+     * @param orientation 0 if horizontal and 1 if vertical
+     * @param verticalGap defines the gap between views in the y axis
+     * @param horizontalGap defines the gap between views in the x axis
+     * @param rowWeights defines the weight of each row
+     * @param columnWeights defines the weight of each column
+     * @param skips defines the positions in a Grid to be skipped
+     * @param spans defines the spanned area(s) in Grid
+     * @param padding sets padding around the content
+     */
+    fun createColumn(
+        vararg elements: LayoutReference?,
+        verticalGap: Dp = 0.dp,
+        horizontalGap: Dp = 0.dp,
+        rowWeights: String,
+        columnWeights: String,
+        orientation: Int = 0,
+        skips: String,
+        spans: String,
+        padding: Dp = 0.dp,
+    ): ConstrainedLayoutReference {
+        return createGrid(
+            elements = elements,
+            orientation = orientation,
+            rows = 1,
+            horizontalGap = horizontalGap,
+            verticalGap = verticalGap,
+            rowWeights = rowWeights,
+            columnWeights = columnWeights,
+            skips = skips,
+            spans = spans,
+            paddingLeft = padding,
+            paddingTop = padding,
+            paddingRight = padding,
+            paddingBottom = padding,
+        )
+    }
+
+    /**
+     * Grid helpers make build a Column representation more intuitively.
+     *
+     * @param elements [LayoutReference]s to be laid out by the Flow helper
+     * @param orientation 0 if horizontal and 1 if vertical
+     * @param verticalGap defines the gap between views in the y axis
+     * @param horizontalGap defines the gap between views in the x axis
+     * @param rowWeights defines the weight of each row
+     * @param columnWeights defines the weight of each column
+     * @param skips defines the positions in a Grid to be skipped
+     * @param spans defines the spanned area(s) in Grid
+     * @param paddingHorizontal sets paddingLeft and paddingRight of the content
+     * @param paddingVertical sets paddingTop and paddingBottom of the content
+     */
+    fun createColumn(
+        vararg elements: LayoutReference?,
+        orientation: Int = 0,
+        verticalGap: Dp = 0.dp,
+        horizontalGap: Dp = 0.dp,
+        rowWeights: String = "",
+        columnWeights: String = "",
+        skips: String = "",
+        spans: String = "",
+        paddingHorizontal: Dp = 0.dp,
+        paddingVertical: Dp = 0.dp,
+    ): ConstrainedLayoutReference {
+        return createGrid(
+            elements = elements,
+            orientation = orientation,
+            rows = 1,
+            horizontalGap = horizontalGap,
+            verticalGap = verticalGap,
+            rowWeights = rowWeights,
+            columnWeights = columnWeights,
+            skips = skips,
+            spans = spans,
+            paddingLeft = paddingHorizontal,
+            paddingTop = paddingVertical,
+            paddingRight = paddingHorizontal,
+            paddingBottom = paddingVertical,
+        )
+    }
+
+    /**
+     * Grid helpers make build a Grid representation more intuitively.
+     *
+     * @param elements [LayoutReference]s to be laid out by the Flow helper
+     * @param orientation 0 if horizontal and 1 if vertical
+     * @param verticalGap defines the gap between views in the y axis
+     * @param horizontalGap defines the gap between views in the x axis
+     * @param rowWeights defines the weight of each row
+     * @param columnWeights defines the weight of each column
+     * @param skips defines the positions in a Grid to be skipped
+     * @param spans defines the spanned area(s) in Grid
+     * @param paddingLeft sets paddingLeft of the content
+     * @param paddingTop sets paddingTop of the content
+     * @param paddingRight sets paddingRight of the content
+     * @param paddingBottom sets paddingBottom of the content
+     */
+    fun createColumn(
+        vararg elements: LayoutReference?,
+        orientation: Int = 0,
+        verticalGap: Dp = 0.dp,
+        horizontalGap: Dp = 0.dp,
+        rowWeights: String = "",
+        columnWeights: String = "",
+        skips: String = "",
+        spans: String = "",
+        paddingLeft: Dp = 0.dp,
+        paddingTop: Dp = 0.dp,
+        paddingRight: Dp = 0.dp,
+        paddingBottom: Dp = 0.dp,
+    ): ConstrainedLayoutReference {
+        val ref = ConstrainedLayoutReference(createHelperId())
+        val elementArray = CLArray(charArrayOf())
+        elements.forEach {
+            if (it != null) {
+                elementArray.add(CLString.from(it.id.toString()))
+            }
+        }
+        val paddingArray = CLArray(charArrayOf()).apply {
+            add(CLNumber(paddingLeft.value))
+            add(CLNumber(paddingTop.value))
+            add(CLNumber(paddingRight.value))
+            add(CLNumber(paddingBottom.value))
+        }
+        ref.asCLContainer().apply {
+            put("contains", elementArray)
+            putString("type", "grid")
+            putNumber("orientation", orientation.toFloat())
+            putNumber("rows", 1f)
+            putNumber("vGap", verticalGap.value)
+            putNumber("hGap", horizontalGap.value)
+            put("padding", paddingArray)
+            putString("rowWeights", rowWeights)
+            putString("columnWeights", columnWeights)
+            putString("skips", skips)
+            putString("spans", spans)
+        }
+        updateHelpersHashCode(18)
+        elements.forEach { updateHelpersHashCode(it.hashCode()) }
+
+        return ref
+    }
+
+    /**
+     * Grid helpers make build a Grid representation more intuitively.
+     *
+     * @param elements [LayoutReference]s to be laid out by the Flow helper
+     * @param elements [LayoutReference]s to be laid out by the Flow helper
+     * @param orientation 0 if horizontal and 1 if vertical
+     * @param rows sets the number of rows in Grid
+     * @param columns sets the number of columns in Grid
+     * @param verticalGap defines the gap between views in the y axis
+     * @param horizontalGap defines the gap between views in the x axis
+     * @param rowWeights defines the weight of each row
+     * @param columnWeights defines the weight of each column
+     * @param skips defines the positions in a Grid to be skipped
+     * @param spans defines the spanned area(s) in Grid
+     * @param padding sets padding around the content
+     */
+    fun createGrid(
+        vararg elements: LayoutReference?,
+        rows: Int = 0,
+        columns: Int = 0,
+        verticalGap: Dp = 0.dp,
+        horizontalGap: Dp = 0.dp,
+        rowWeights: String,
+        columnWeights: String,
+        orientation: Int = 0,
+        skips: String,
+        spans: String,
+        padding: Dp = 0.dp,
+    ): ConstrainedLayoutReference {
+        return createGrid(
+            elements = elements,
+            orientation = orientation,
+            rows = rows,
+            columns = columns,
+            horizontalGap = horizontalGap,
+            verticalGap = verticalGap,
+            rowWeights = rowWeights,
+            columnWeights = columnWeights,
+            skips = skips,
+            spans = spans,
+            paddingLeft = padding,
+            paddingTop = padding,
+            paddingRight = padding,
+            paddingBottom = padding,
+        )
+    }
+
+    /**
+     * Grid helpers make build a Grid representation more intuitively.
+     *
+     * @param elements [LayoutReference]s to be laid out by the Flow helper
+     * @param orientation 0 if horizontal and 1 if vertical
+     * @param rows sets the number of rows in Grid
+     * @param columns sets the number of columns in Grid
+     * @param verticalGap defines the gap between views in the y axis
+     * @param horizontalGap defines the gap between views in the x axis
+     * @param rowWeights defines the weight of each row
+     * @param columnWeights defines the weight of each column
+     * @param skips defines the positions in a Grid to be skipped
+     * @param spans defines the spanned area(s) in Grid
+     * @param paddingHorizontal sets paddingLeft and paddingRight of the content
+     * @param paddingVertical sets paddingTop and paddingBottom of the content
+     */
+    fun createGrid(
+        vararg elements: LayoutReference?,
+        orientation: Int = 0,
+        rows: Int = 0,
+        columns: Int = 0,
+        verticalGap: Dp = 0.dp,
+        horizontalGap: Dp = 0.dp,
+        rowWeights: String = "",
+        columnWeights: String = "",
+        skips: String = "",
+        spans: String = "",
+        paddingHorizontal: Dp = 0.dp,
+        paddingVertical: Dp = 0.dp,
+    ): ConstrainedLayoutReference {
+        return createGrid(
+            elements = elements,
+            orientation = orientation,
+            rows = rows,
+            columns = columns,
+            horizontalGap = horizontalGap,
+            verticalGap = verticalGap,
+            rowWeights = rowWeights,
+            columnWeights = columnWeights,
+            skips = skips,
+            spans = spans,
+            paddingLeft = paddingHorizontal,
+            paddingTop = paddingVertical,
+            paddingRight = paddingHorizontal,
+            paddingBottom = paddingVertical,
+        )
+    }
+
+    /**
+     * Grid helpers make build a Grid representation more intuitively.
+     *
+     * @param elements [LayoutReference]s to be laid out by the Flow helper
+     * @param orientation 0 if horizontal and 1 if vertical
+     * @param rows sets the number of rows in Grid
+     * @param columns sets the number of columns in Grid
+     * @param verticalGap defines the gap between views in the y axis
+     * @param horizontalGap defines the gap between views in the x axis
+     * @param rowWeights defines the weight of each row
+     * @param columnWeights defines the weight of each column
+     * @param skips defines the positions in a Grid to be skipped
+     * @param spans defines the spanned area(s) in Grid
+     * @param paddingLeft sets paddingLeft of the content
+     * @param paddingTop sets paddingTop of the content
+     * @param paddingRight sets paddingRight of the content
+     * @param paddingBottom sets paddingBottom of the content
+     */
+    fun createGrid(
+        vararg elements: LayoutReference?,
+        orientation: Int = 0,
+        rows: Int = 0,
+        columns: Int = 0,
+        verticalGap: Dp = 0.dp,
+        horizontalGap: Dp = 0.dp,
+        rowWeights: String = "",
+        columnWeights: String = "",
+        skips: String = "",
+        spans: String = "",
+        paddingLeft: Dp = 0.dp,
+        paddingTop: Dp = 0.dp,
+        paddingRight: Dp = 0.dp,
+        paddingBottom: Dp = 0.dp,
+    ): ConstrainedLayoutReference {
+        val ref = ConstrainedLayoutReference(createHelperId())
+        val elementArray = CLArray(charArrayOf())
+        elements.forEach {
+            if (it != null) {
+                elementArray.add(CLString.from(it.id.toString()))
+            }
+        }
+        val paddingArray = CLArray(charArrayOf()).apply {
+            add(CLNumber(paddingLeft.value))
+            add(CLNumber(paddingTop.value))
+            add(CLNumber(paddingRight.value))
+            add(CLNumber(paddingBottom.value))
+        }
+        ref.asCLContainer().apply {
+            put("contains", elementArray)
+            putString("type", "grid")
+            putNumber("orientation", orientation.toFloat())
+            putNumber("rows", rows.toFloat())
+            putNumber("columns", columns.toFloat())
+            putNumber("vGap", verticalGap.value)
+            putNumber("hGap", horizontalGap.value)
+            put("padding", paddingArray)
+            putString("rowWeights", rowWeights)
+            putString("columnWeights", columnWeights)
+            putString("skips", skips)
+            putString("spans", spans)
+        }
+        updateHelpersHashCode(18)
+        elements.forEach { updateHelpersHashCode(it.hashCode()) }
+
+        return ref
+    }
+
+
+    /**
      * Creates a horizontal chain including the referenced layouts.
      *
      * Use [constrain] with the resulting [HorizontalChainReference] to modify the start/left and

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayoutBaseScope.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayoutBaseScope.kt
@@ -683,7 +683,6 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      *
      * @param elements [LayoutReference]s to be laid out by the Grid helper
      * @param verticalGap defines the gap between views in the y axis
-     * @param horizontalGap defines the gap between views in the x axis
      * @param rowWeights defines the weight of each row
      *        the format of input string is "w1,w2,w3, ..."
      * @param skips defines the positions in a Grid to be skipped
@@ -701,7 +700,6 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
     fun createRow(
         vararg elements: LayoutReference,
         verticalGap: Dp = 0.dp,
-        horizontalGap: Dp = 0.dp,
         rowWeights: String = "",
         skips: String = "",
         spans: String = "",
@@ -710,7 +708,6 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
         return createGrid(
             elements = elements,
             columns = 1,
-            horizontalGap = horizontalGap,
             verticalGap = verticalGap,
             rowWeights = rowWeights,
             skips = skips,
@@ -727,7 +724,6 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      *
      * @param elements [LayoutReference]s to be laid out by the Grid helper
      * @param verticalGap defines the gap between views in the y axis
-     * @param horizontalGap defines the gap between views in the x axis
      * @param rowWeights defines the weight of each row
      *        the format of input string is "w1,w2,w3, ..."
      * @param skips defines the positions in a Grid to be skipped
@@ -746,7 +742,6 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
     fun createRow(
         vararg elements: LayoutReference,
         verticalGap: Dp = 0.dp,
-        horizontalGap: Dp = 0.dp,
         rowWeights: String = "",
         skips: String = "",
         spans: String = "",
@@ -756,7 +751,6 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
         return createGrid(
             elements = elements,
             columns = 1,
-            horizontalGap = horizontalGap,
             verticalGap = verticalGap,
             rowWeights = rowWeights,
             skips = skips,
@@ -773,7 +767,6 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      *
      * @param elements [LayoutReference]s to be laid out by the Grid helper
      * @param verticalGap defines the gap between views in the y axis
-     * @param horizontalGap defines the gap between views in the x axis
      * @param rowWeights defines the weight of each row
      *        the format of input string is "w1,w2,w3, ..."
      * @param skips defines the positions in a Grid to be skipped
@@ -794,7 +787,6 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
     fun createRow(
         vararg elements: LayoutReference,
         verticalGap: Dp = 0.dp,
-        horizontalGap: Dp = 0.dp,
         rowWeights: String = "",
         skips: String = "",
         spans: String = "",
@@ -822,10 +814,8 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
             putNumber("orientation", 0f)
             putNumber("columns", 1f)
             putNumber("vGap", verticalGap.value)
-            putNumber("hGap", horizontalGap.value)
             put("padding", paddingArray)
             putString("rowWeights", rowWeights)
-            putString("columnWeights", "")
             putString("skips", skips)
             putString("spans", spans)
         }
@@ -837,7 +827,6 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      * Creates a Grid based helper that lays out its elements in a single Column.
      *
      * @param elements [LayoutReference]s to be laid out by the Grid helper
-     * @param verticalGap defines the gap between views in the y axis
      * @param horizontalGap defines the gap between views in the x axis
      * @param columnWeights defines the weight of each column
      *        the format of input string is "w1,w2,w3, ..."
@@ -855,7 +844,6 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      */
     fun createColumn(
         vararg elements: LayoutReference,
-        verticalGap: Dp = 0.dp,
         horizontalGap: Dp = 0.dp,
         columnWeights: String = "",
         skips: String = "",
@@ -866,7 +854,6 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
             elements = elements,
             rows = 1,
             horizontalGap = horizontalGap,
-            verticalGap = verticalGap,
             columnWeights = columnWeights,
             skips = skips,
             spans = spans,
@@ -881,7 +868,6 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      * Creates a Grid based helper that lays out its elements in a single Column.
      *
      * @param elements [LayoutReference]s to be laid out by the Grid helper
-     * @param verticalGap defines the gap between views in the y axis
      * @param horizontalGap defines the gap between views in the x axis
      * @param columnWeights defines the weight of each column
      *        the format of input string is "w1,w2,w3, ..."
@@ -900,7 +886,6 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      */
     fun createColumn(
         vararg elements: LayoutReference,
-        verticalGap: Dp = 0.dp,
         horizontalGap: Dp = 0.dp,
         columnWeights: String = "",
         skips: String = "",
@@ -912,7 +897,6 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
             elements = elements,
             rows = 1,
             horizontalGap = horizontalGap,
-            verticalGap = verticalGap,
             columnWeights = columnWeights,
             skips = skips,
             spans = spans,
@@ -927,7 +911,6 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      * Creates a Grid based helper that lays out its elements in a single Column.
      *
      * @param elements [LayoutReference]s to be laid out by the Grid helper
-     * @param verticalGap defines the gap between views in the y axis
      * @param horizontalGap defines the gap between views in the x axis
      * @param columnWeights defines the weight of each column
      *        the format of input string is "w1,w2,w3, ..."
@@ -948,7 +931,6 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      */
     fun createColumn(
         vararg elements: LayoutReference,
-        verticalGap: Dp = 0.dp,
         horizontalGap: Dp = 0.dp,
         columnWeights: String = "",
         skips: String = "",
@@ -976,10 +958,8 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
             putString("type", "grid")
             putNumber("orientation", 0f)
             putNumber("rows", 1f)
-            putNumber("vGap", verticalGap.value)
             putNumber("hGap", horizontalGap.value)
             put("padding", paddingArray)
-            putString("rowWeights", "")
             putString("columnWeights", columnWeights)
             putString("skips", skips)
             putString("spans", spans)

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/parser/CLElement.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/parser/CLElement.java
@@ -118,6 +118,10 @@ public class CLElement implements Cloneable {
     // @TODO: add description
     public String content() {
         String content = new String(mContent);
+        // Handle empty string
+        if (content.length() < 1) {
+            return "";
+        }
         if (mEnd == Long.MAX_VALUE || mEnd < mStart) {
             return content.substring((int) mStart, (int) mStart + 1);
         }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintSetParser.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintSetParser.java
@@ -959,11 +959,15 @@ public class ConstraintSetParser {
                     break;
                 case "rows":
                     int rows = element.get(param).getInt();
-                    grid.setRowsSet(rows);
+                    if (rows > 0) {
+                        grid.setRowsSet(rows);
+                    }
                     break;
                 case "columns":
                     int columns = element.get(param).getInt();
-                    grid.setColumnsSet(columns);
+                    if (columns > 0) {
+                        grid.setColumnsSet(columns);
+                    }
                     break;
                 case "hGap":
                     float hGap = element.get(param).getFloat();
@@ -996,6 +1000,37 @@ public class ConstraintSetParser {
                     if (columnWeights != null && columnWeights.contains(",")) {
                         grid.setColumnWeights(columnWeights);
                     }
+                    break;
+                case "padding":
+                    CLElement paddingObject = element.get(param);
+                    int paddingLeft = 0;
+                    int paddingTop = 0;
+                    int paddingRight = 0;
+                    int paddingBottom = 0;
+                    if (paddingObject instanceof CLArray && ((CLArray) paddingObject).size() > 1) {
+                        paddingLeft = ((CLArray) paddingObject).getInt(0);
+                        paddingRight = paddingLeft;
+                        paddingTop = ((CLArray) paddingObject).getInt(1);
+                        paddingBottom = paddingTop;
+                        if (((CLArray) paddingObject).size() > 2) {
+                            paddingRight = ((CLArray) paddingObject).getInt(2);
+                            try {
+                                paddingBottom = ((CLArray) paddingObject).getInt(3);
+                            } catch (ArrayIndexOutOfBoundsException e) {
+                                paddingBottom = 0;
+                            }
+
+                        }
+                    } else {
+                        paddingLeft = paddingObject.getInt();
+                        paddingTop = paddingLeft;
+                        paddingRight = paddingLeft;
+                        paddingBottom = paddingLeft;
+                    }
+                    grid.setPaddingLeft(paddingLeft);
+                    grid.setPaddingTop(paddingTop);
+                    grid.setPaddingRight(paddingRight);
+                    grid.setPaddingBottom(paddingBottom);
                     break;
                 default:
                     ConstraintReference reference = state.constraints(name);
@@ -1094,31 +1129,16 @@ public class ConstraintSetParser {
                     flow.setWrapMode(State.Wrap.getValueByString(wrapValue));
                     break;
                 case "vGap":
-                    String vGapValue = element.get(param).content();
-                    try {
-                        int value = Integer.parseInt(vGapValue);
-                        flow.setVerticalGap(value);
-                    } catch(NumberFormatException e) {
-
-                    }
+                    int vGapValue = element.get(param).getInt();
+                    flow.setVerticalGap(vGapValue);
                     break;
                 case "hGap":
-                    String hGapValue = element.get(param).content();
-                    try {
-                        int value = Integer.parseInt(hGapValue);
-                        flow.setHorizontalGap(value);
-                    } catch(NumberFormatException e) {
-
-                    }
+                    int hGapValue = element.get(param).getInt();
+                    flow.setHorizontalGap(hGapValue);
                     break;
                 case "maxElement":
-                    String maxElementValue = element.get(param).content();
-                    try {
-                        int value = Integer.parseInt(maxElementValue);
-                        flow.setMaxElementsWrap(value);
-                    } catch(NumberFormatException e) {
-
-                    }
+                    int maxElementValue = element.get(param).getInt();
+                    flow.setMaxElementsWrap(maxElementValue);
                     break;
                 case "padding":
                     CLElement paddingObject = element.get(param);

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/GridReference.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/GridReference.java
@@ -43,6 +43,26 @@ public class GridReference extends HelperReference {
     private GridCore mGrid;
 
     /**
+     * padding left
+     */
+    private int mPaddingLeft = 0;
+
+    /**
+     * padding right
+     */
+    private int mPaddingRight = 0;
+
+    /**
+     * padding top
+     */
+    private int mPaddingTop = 0;
+
+    /**
+     * padding bottom
+     */
+    private int mPaddingBottom = 0;
+
+    /**
      * The orientation of the widgets arrangement horizontally or vertically
      */
     private int mOrientation;
@@ -86,6 +106,70 @@ public class GridReference extends HelperReference {
      * Specify the positions to be skipped in the Grid
      */
     private String mSkips;
+
+    /**
+     * get padding left
+     * @return padding left
+     */
+    public int getPaddingLeft() {
+        return mPaddingLeft;
+    }
+
+    /**
+     * set padding left
+     * @param paddingLeft padding left to be set
+     */
+    public void setPaddingLeft(int paddingLeft) {
+        mPaddingLeft = paddingLeft;
+    }
+
+    /**
+     * get padding right
+     * @return padding right
+     */
+    public int getPaddingRight() {
+        return mPaddingRight;
+    }
+
+    /**
+     * set padding right
+     * @param paddingRight padding right to be set
+     */
+    public void setPaddingRight(int paddingRight) {
+        mPaddingRight = paddingRight;
+    }
+
+    /**
+     * get padding top
+     * @return padding top
+     */
+    public int getPaddingTop() {
+        return mPaddingTop;
+    }
+
+    /**
+     * set padding top
+     * @param paddingTop padding top to be set
+     */
+    public void setPaddingTop(int paddingTop) {
+        mPaddingTop = paddingTop;
+    }
+
+    /**
+     * get padding bottom
+     * @return padding bottom
+     */
+    public int getPaddingBottom() {
+        return mPaddingBottom;
+    }
+
+    /**
+     * set padding bottom
+     * @param paddingBottom padding bottom to be set
+     */
+    public void setPaddingBottom(int paddingBottom) {
+        mPaddingBottom = paddingBottom;
+    }
 
     /**
      * Get the number of rows

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/GridDemo.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/GridDemo.kt
@@ -50,7 +50,7 @@ fun GridDemo1() {
             grid: { 
                 height: "parent",
                 width: "parent",
-                type: "Grid",
+                type: "grid",
                 margin: 20,
                 orientation: 0,
                 vGap: 25,
@@ -142,7 +142,7 @@ fun GridDemo2() {
             grid: { 
                 height: "parent",
                 width: "parent",
-                type: "Grid",
+                type: "grid",
                 vGap: 10,
                 hGap: 10,
                 orientation: 0,
@@ -173,7 +173,7 @@ fun GridDemo3() {
             grid: { 
                 height: "parent",
                 width: "parent",
-                type: "Grid",
+                type: "grid",
                 vGap: 10,
                 hGap: 10,
                 orientation: 0,
@@ -204,7 +204,7 @@ fun GridDemo4() {
             grid: { 
                 height: "parent",
                 width: "parent",
-                type: "Grid",
+                type: "grid",
                 vGap: 10,
                 hGap: 10,
                 orientation: 0,
@@ -283,7 +283,7 @@ fun GridDemo5() {
             grid: { 
                 height: "parent",
                 width: "parent",
-                type: "Grid",
+                type: "grid",
                 vGap: 10,
                 hGap: 10,
                 orientation: 0,
@@ -337,7 +337,7 @@ fun GridDemo6() {
             grid: { 
                 height: "parent",
                 width: "parent",
-                type: "Grid",
+                type: "grid",
                 orientation: 0,
                 skips: "1:1x1,4:1x1,6:1x1",
                 rows: 3,
@@ -347,7 +347,7 @@ fun GridDemo6() {
               grid2: { 
                 height: "spread",
                 width: "spread",
-                type: "Grid",
+                type: "grid",
                 skips: "0:1x2,4:1x1,6:1x1",
                 orientation: 0,
                 rows: 3,

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/GridDslDemo.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/GridDslDemo.kt
@@ -1,0 +1,347 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.constraintlayout
+
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.constraintlayout.compose.ConstrainedLayoutReference
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.ConstraintLayoutBaseScope
+import androidx.constraintlayout.compose.ConstraintSet
+import androidx.constraintlayout.compose.Dimension
+import androidx.constraintlayout.compose.FlowStyle
+import androidx.constraintlayout.compose.LayoutReference
+import androidx.constraintlayout.compose.Wrap
+import java.util.Arrays
+
+@Preview(group = "grid1")
+@Composable
+public fun GridDslDemo1() {
+    // Currently, we still have problem with positioning the Flow Helper
+    // and/or setting the width/height properly.
+    ConstraintLayout(
+
+        ConstraintSet {
+            val a = createRefFor("btn1")
+            val b = createRefFor("btn2")
+            val c = createRefFor("btn3")
+            val d = createRefFor("btn4")
+            val e = createRefFor("btn5")
+            val f = createRefFor("btn6")
+            val g = createRefFor("btn7")
+            val h = createRefFor("btn8")
+            val i = createRefFor("btn9")
+            val j = createRefFor("btn0")
+            val k = createRefFor("box")
+
+            val g1 = createGrid(
+                k, a, b, c, d, e, f, g, h, i, j, k,
+                rows = 5,
+                columns = 3,
+                verticalGap = 25.dp,
+                horizontalGap = 25.dp,
+                spans = "0:1x3",
+                skips = "12:1x1",
+                rowWeights = "3,2,2,2,2",
+            )
+
+
+            constrain(g1) {
+                width = Dimension.matchParent
+                height = Dimension.matchParent
+            }
+            constrain(a) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(b) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(c) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(d) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(e) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(f) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(g) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(h) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(i) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(j) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(k) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+        },
+
+        modifier = Modifier.fillMaxSize()
+    ) {
+        val numArray = arrayOf("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")
+        for (num in numArray) {
+            Button(
+                modifier = Modifier.layoutId(String.format("btn%s", num)).width(120.dp),
+                onClick = {},
+            ) {
+                Text(text = num, fontSize = 45.sp)
+            }
+        }
+        Box(
+            modifier = Modifier.background(Color.Gray).layoutId("box"),
+            Alignment.BottomEnd
+        ) {
+            Text("100", fontSize = 80.sp)
+        }
+    }
+}
+
+@Preview(group = "grid2")
+@Composable
+public fun GridDslDemo2() {
+    ConstraintLayout(
+        ConstraintSet {
+            val a = createRefFor("1")
+            val b = createRefFor("2")
+            val c = createRefFor("3")
+            val d = createRefFor("4")
+            val e = createRefFor("5")
+            val g1 = createGrid(
+                a, b, c, d, e,
+                verticalGap = 10.dp,
+                horizontalGap = 10.dp,
+                columns = 1,
+            )
+
+            constrain(g1) {
+                width = Dimension.matchParent
+                height = Dimension.matchParent
+            }
+            constrain(a) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(b) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(c) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(d) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(e) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+        },
+        modifier = Modifier.fillMaxSize()
+    ) {
+        val numArray = arrayOf("1", "2", "3", "4", "5")
+        for (num in numArray) {
+            Button(
+                modifier = Modifier.layoutId(num).width(120.dp),
+                onClick = {},
+            ) {
+                Text(text = String.format("btn%s", num))
+            }
+        }
+    }
+}
+
+@Preview(group = "grid3")
+@Composable
+public fun GridDslDemo3() {
+    ConstraintLayout(
+        ConstraintSet {
+            val a = createRefFor("1")
+            val b = createRefFor("2")
+            val c = createRefFor("3")
+            val d = createRefFor("4")
+            val e = createRefFor("5")
+            val g1 = createGrid(
+                a, b, c, d, e,
+                verticalGap = 10.dp,
+                horizontalGap = 10.dp,
+                rows = 1,
+            )
+
+            constrain(g1) {
+                width = Dimension.matchParent
+                height = Dimension.matchParent
+            }
+            constrain(a) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(b) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(c) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(d) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(e) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+        },
+        modifier = Modifier.fillMaxSize()
+    ) {
+        val numArray = arrayOf("1", "2", "3", "4", "5")
+        for (num in numArray) {
+            Button(
+                modifier = Modifier.layoutId(num).width(120.dp),
+                onClick = {},
+            ) {
+                Text(text = String.format("btn%s", num))
+            }
+        }
+    }
+}
+
+@Preview(group = "grid4")
+@Composable
+public fun GridDslDemo4() {
+    ConstraintLayout(
+        ConstraintSet {
+            val a = createRefFor("1")
+            val b = createRefFor("2")
+            val c = createRefFor("3")
+            val d = createRefFor("4")
+            val e = createRefFor("5")
+            val f = createRefFor("6")
+            val g = createRefFor("7")
+            val h = createRefFor("8")
+            val g1 = createGrid(
+                e, f, g, h,
+                rows = 3,
+                columns = 3,
+                skips= "0:1x2,4:1x1,6:1x1",
+            )
+
+            val g2 = createGrid(
+                g1, a, b, c, d,
+                rows = 3,
+                columns = 3,
+                skips = "1:1x1,4:1x1,6:1x1",
+                )
+
+
+            constrain(g1) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(g2) {
+                width = Dimension.matchParent
+                height = Dimension.matchParent
+            }
+        },
+        modifier = Modifier.fillMaxSize()
+    ) {
+        val numArray = arrayOf("1", "2", "3", "4", "5", "6", "7", "8")
+        for (num in numArray) {
+            Button(
+                modifier = Modifier.layoutId(num).width(40.dp),
+                onClick = {},
+            ) {
+                Text(text = num)
+            }
+        }
+    }
+}
+
+@Preview(group = "grid5")
+@Composable
+public fun GridDslDemo5() {
+    ConstraintLayout(
+        ConstraintSet {
+            val a = createRefFor("box0")
+            val b = createRefFor("box1")
+            val c = createRefFor("box2")
+            val d = createRefFor("box3")
+            val g1 = createGrid(
+                a, b, c, d,
+                rows = 2,
+                columns = 2,
+                verticalGap = 0.dp,
+                horizontalGap = 0.dp,
+            )
+            constrain(g1) {
+                width = Dimension.matchParent
+                height = Dimension.matchParent
+            }
+        },
+        modifier = Modifier.size(200.dp),
+    ) {
+        val ids = (0 until 4).map { "box$it" }.toTypedArray()
+        ids.forEach { id ->
+            Box(
+                Modifier
+                    .layoutId(id)
+                    .background(Color.Red)
+                    .testTag(id)
+                    .size(10.dp)
+            )
+        }
+    }
+}

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/GridDslDemo.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/GridDslDemo.kt
@@ -65,6 +65,8 @@ public fun GridDslDemo1() {
             val j = createRefFor("btn0")
             val k = createRefFor("box")
 
+            val weights = arrayOf(3, 2, 2, 2)
+
             val g1 = createGrid(
                 k, a, b, c, d, e, f, g, h, i, j, k,
                 rows = 5,
@@ -73,7 +75,7 @@ public fun GridDslDemo1() {
                 horizontalGap = 25.dp,
                 spans = "0:1x3",
                 skips = "12:1x1",
-                rowWeights = "3,2,2,2,2",
+                rowWeights = weights,
             )
 
 

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/GridTestDemo.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/GridTestDemo.kt
@@ -40,7 +40,7 @@ fun testTwoByTwoDemo() {
             grid: { 
                 width: 200,
                 height: 200,
-                type: "Grid",
+                type: "grid",
                 boxesCount: 4,
                 orientation: 0,
                 rows: 2,
@@ -78,7 +78,7 @@ fun testOrientationDemo() {
             grid: { 
                 width: 200,
                 height: 200,
-                type: "Grid",
+                type: "grid",
                 boxesCount: 4,
                 orientation: 1,
                 rows: 2,
@@ -116,7 +116,7 @@ fun testRowsDemo() {
             grid: { 
                 width: 200,
                 height: 200,
-                type: "Grid",
+                type: "grid",
                 boxesCount: 4,
                 orientation: 0,
                 rows: 0,
@@ -154,7 +154,7 @@ fun testColumnsDemo() {
             grid: { 
                 width: 200,
                 height: 200,
-                type: "Grid",
+                type: "grid",
                 boxesCount: 4,
                 orientation: 0,
                 rows: 1,
@@ -192,7 +192,7 @@ fun testSpansDemo() {
             grid: { 
                 height: 200,
                 width: 200,
-                type: "Grid",
+                type: "grid",
                 orientation: 0,
                 rows: 2,
                 columns: 2,
@@ -227,7 +227,7 @@ fun testSkipsDemo() {
             grid: { 
                 height: 200,
                 width: 200,
-                type: "Grid",
+                type: "grid",
                 orientation: 0,
                 rows: 2,
                 columns: 2,
@@ -262,7 +262,7 @@ fun testRowWeightsDemo() {
             grid: { 
                 height: 200,
                 width: 200,
-                type: "Grid",
+                type: "grid",
                 orientation: 0,
                 rows: 0,
                 columns: 1,
@@ -299,7 +299,7 @@ fun testColumnWeightsDemo() {
             grid: { 
                 height: 200,
                 width: 200,
-                type: "Grid",
+                type: "grid",
                 orientation: 0,
                 rows: 1,
                 columns: 0,
@@ -340,7 +340,7 @@ fun testGapsDemo() {
             grid: { 
                 height: 200,
                 width: 200,
-                type: "Grid",
+                type: "grid",
                 orientation: 0,
                 rows: 2,
                 columns: 2,

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/RowColumnDemo.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/RowColumnDemo.kt
@@ -36,7 +36,7 @@ fun RowDemo() {
             grid: { 
                 height: "parent",
                 width: "parent",
-                type: "Row",
+                type: "row",
                 vGap: 10,
                 hGap: 10,
                 contains: ["btn1", "btn2", "btn3", "btn4", "btn5"],
@@ -65,7 +65,7 @@ fun ColumnDemo() {
             grid: { 
                 height: "parent",
                 width: "parent",
-                type: "Column",
+                type: "column",
                 vGap: 10,
                 hGap: 10,
                 contains: ["btn1", "btn2", "btn3", "btn4", "btn5"],

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/RowColumnDslDemo.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/RowColumnDslDemo.kt
@@ -56,7 +56,62 @@ public fun RowDslDemo() {
             val g1 = createRow(
                 a, b, c, d, e,
                 verticalGap = 10.dp,
-                horizontalGap = 10.dp,
+            )
+
+            constrain(g1) {
+                width = Dimension.matchParent
+                height = Dimension.matchParent
+            }
+            constrain(a) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(b) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(c) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(d) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(e) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+        },
+        modifier = Modifier.fillMaxSize()
+    ) {
+        val numArray = arrayOf("1", "2", "3", "4", "5")
+        for (num in numArray) {
+            Button(
+                modifier = Modifier.layoutId(num).width(120.dp),
+                onClick = {},
+            ) {
+                Text(text = String.format("btn%s", num))
+            }
+        }
+    }
+}
+
+@Preview(group = "row")
+@Composable
+public fun RowWeightsDslDemo() {
+    ConstraintLayout(
+        ConstraintSet {
+            val a = createRefFor("1")
+            val b = createRefFor("2")
+            val c = createRefFor("3")
+            val d = createRefFor("4")
+            val e = createRefFor("5")
+            val weights = arrayOf(3, 3, 2, 2, 1)
+            val g1 = createRow(
+                a, b, c, d, e,
+                verticalGap = 10.dp,
+                rowWeights = weights,
             )
 
             constrain(g1) {
@@ -110,8 +165,62 @@ public fun ColumnDslDemo() {
             val e = createRefFor("5")
             val g1 = createColumn(
                 a, b, c, d, e,
-                verticalGap = 10.dp,
                 horizontalGap = 10.dp,
+            )
+
+            constrain(g1) {
+                width = Dimension.matchParent
+                height = Dimension.matchParent
+            }
+            constrain(a) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(b) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(c) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(d) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(e) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+        },
+        modifier = Modifier.fillMaxSize()
+    ) {
+        val numArray = arrayOf("1", "2", "3", "4", "5")
+        for (num in numArray) {
+            Button(
+                modifier = Modifier.layoutId(num).width(120.dp),
+                onClick = {},
+            ) {
+                Text(text = String.format("btn%s", num))
+            }
+        }
+    }
+}
+@Preview(group = "column")
+@Composable
+public fun ColumnWeightsDslDemo() {
+    ConstraintLayout(
+        ConstraintSet {
+            val a = createRefFor("1")
+            val b = createRefFor("2")
+            val c = createRefFor("3")
+            val d = createRefFor("4")
+            val e = createRefFor("5")
+            val weights = arrayOf(3, 3, 2, 2, 1)
+            val g1 = createColumn(
+                a, b, c, d, e,
+                horizontalGap = 10.dp,
+                columnWeights = weights,
             )
 
             constrain(g1) {

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/RowColumnDslDemo.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/RowColumnDslDemo.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.constraintlayout
+
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.constraintlayout.compose.ConstrainedLayoutReference
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.ConstraintLayoutBaseScope
+import androidx.constraintlayout.compose.ConstraintSet
+import androidx.constraintlayout.compose.Dimension
+import androidx.constraintlayout.compose.FlowStyle
+import androidx.constraintlayout.compose.LayoutReference
+import androidx.constraintlayout.compose.Wrap
+import java.util.Arrays
+
+@Preview(group = "row")
+@Composable
+public fun RowDslDemo() {
+    ConstraintLayout(
+        ConstraintSet {
+            val a = createRefFor("1")
+            val b = createRefFor("2")
+            val c = createRefFor("3")
+            val d = createRefFor("4")
+            val e = createRefFor("5")
+            val g1 = createRow(
+                a, b, c, d, e,
+                verticalGap = 10.dp,
+                horizontalGap = 10.dp,
+            )
+
+            constrain(g1) {
+                width = Dimension.matchParent
+                height = Dimension.matchParent
+            }
+            constrain(a) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(b) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(c) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(d) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(e) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+        },
+        modifier = Modifier.fillMaxSize()
+    ) {
+        val numArray = arrayOf("1", "2", "3", "4", "5")
+        for (num in numArray) {
+            Button(
+                modifier = Modifier.layoutId(num).width(120.dp),
+                onClick = {},
+            ) {
+                Text(text = String.format("btn%s", num))
+            }
+        }
+    }
+}
+
+@Preview(group = "column")
+@Composable
+public fun ColumnDslDemo() {
+    ConstraintLayout(
+        ConstraintSet {
+            val a = createRefFor("1")
+            val b = createRefFor("2")
+            val c = createRefFor("3")
+            val d = createRefFor("4")
+            val e = createRefFor("5")
+            val g1 = createColumn(
+                a, b, c, d, e,
+                verticalGap = 10.dp,
+                horizontalGap = 10.dp,
+            )
+
+            constrain(g1) {
+                width = Dimension.matchParent
+                height = Dimension.matchParent
+            }
+            constrain(a) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(b) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(c) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(d) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+            constrain(e) {
+                width = Dimension.fillToConstraints
+                height = Dimension.fillToConstraints
+            }
+        },
+        modifier = Modifier.fillMaxSize()
+    ) {
+        val numArray = arrayOf("1", "2", "3", "4", "5")
+        for (num in numArray) {
+            Button(
+                modifier = Modifier.layoutId(num).width(120.dp),
+                onClick = {},
+            ) {
+                Text(text = String.format("btn%s", num))
+            }
+        }
+    }
+}

--- a/projects/ComposeConstraintLayout/compose/build.gradle
+++ b/projects/ComposeConstraintLayout/compose/build.gradle
@@ -39,6 +39,7 @@ android {
 
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
+        freeCompilerArgs = ['-Xjvm-default=all']
     }
 
     composeOptions {

--- a/projects/ComposeConstraintLayout/core/build.gradle
+++ b/projects/ComposeConstraintLayout/core/build.gradle
@@ -14,4 +14,5 @@ sourceSets{
 
 dependencies {
     testImplementation "junit:junit:4.13.1"
+    api("androidx.annotation:annotation:1.5.0")
 }


### PR DESCRIPTION
This PR mainly enable Grid, Row, and Column with DSL syntax. It also includes some fixes for some demos.
1. Updates ConstraintLayoutBaseScope.kt and ConstraintSetParser.java to enable Grid using DSL.
2. Add demos - GridDslDemo.kt and RowColumnDslDemo.kt
3. Add tests - GridDslTest.kt and RowColumnDslTestkt
4. Update existing demos for Grid with JSON by making the type in lowercase. 
5. Update the build.gradle - same as [#780](https://github.com/androidx/constraintlayout/pull/780)

There is an issue with padding that I need to investigate more. Also, there are some build issues with ComposeConstraintlayout project that I had to comment out some of the files.

Some of the demos
Demo1
<img width="600" alt="image" src="https://user-images.githubusercontent.com/20599348/212197149-b6c4f6c1-c5f8-4514-98fd-0fd6d638c6f1.png">

Demo4
<img width="600" alt="image" src="https://user-images.githubusercontent.com/20599348/212197531-95ae388d-b6f1-46bc-a2d4-d49920f52476.png">

Test results
<img width="570" alt="Screenshot 2023-01-12 at 2 24 16 PM" src="https://user-images.githubusercontent.com/20599348/212197587-fc1649b8-398d-4e1c-bf4c-663240e4dd2e.png">

