### PR TITLE
[Grid] Sync the updates of Skips and Spans DSL representation

### DIFF
--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/GridDslTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/GridDslTest.kt
@@ -1,0 +1,631 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.platform.isDebugInspectorInfoEnabled
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertPositionInRootIsEqualTo
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Tests for the Grid Helper
+ */
+@MediumTest
+@RunWith(AndroidJUnit4::class)
+class GridDslTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Before
+    fun setup() {
+        isDebugInspectorInfoEnabled = true
+    }
+
+    @After
+    fun tearDown() {
+        isDebugInspectorInfoEnabled = false
+    }
+
+    @Test
+    fun testTwoByTwo() {
+        val rootSize = 200.dp
+        val boxesCount = 4
+        val rows = 2
+        val columns = 2
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                boxesCount = boxesCount,
+                gridOrientation = 0,
+                numRows = rows,
+                numColumns = columns,
+                hGap = 0,
+                vGap = 0,
+                gridSpans = arrayOf(),
+                gridSkips = arrayOf(),
+                gridRowWeights = intArrayOf(),
+                gridColumnWeights = intArrayOf(),
+                gridFlags = arrayOf(),
+            )
+        }
+        var leftX = 0.dp
+        var topY = 0.dp
+        var rightX: Dp
+        var bottomY: Dp
+
+        // 10.dp is the size of a singular box
+        val gapSize = (rootSize - (10.dp * 2f)) / (columns * 2f)
+        rule.waitForIdle()
+        leftX += gapSize
+        topY += gapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(leftX, topY)
+        rightX = leftX + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(rightX, topY)
+        bottomY = topY + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(leftX, bottomY)
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(rightX, bottomY)
+    }
+
+    @Test
+    fun testOrientation() {
+        val rootSize = 200.dp
+        val boxesCount = 4
+        val rows = 2
+        val columns = 2
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                boxesCount = boxesCount,
+                gridOrientation = 1,
+                numRows = rows,
+                numColumns = columns,
+                hGap = 0,
+                vGap = 0,
+                gridSpans = arrayOf(),
+                gridSkips = arrayOf(),
+                gridRowWeights = intArrayOf(),
+                gridColumnWeights = intArrayOf(),
+                gridFlags = arrayOf(),
+            )
+        }
+        var leftX = 0.dp
+        var topY = 0.dp
+        var rightX: Dp
+        var bottomY: Dp
+
+        // 10.dp is the size of a singular box
+        val gapSize = (rootSize - (10.dp * 2f)) / (columns * 2f)
+        rule.waitForIdle()
+        leftX += gapSize
+        topY += gapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(leftX, topY)
+        rightX = leftX + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(rightX, topY)
+        bottomY = topY + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(leftX, bottomY)
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(rightX, bottomY)
+    }
+
+    @Test
+    fun testRows() {
+        val rootSize = 200.dp
+        val boxesCount = 4
+        val rows = 0
+        val columns = 1
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                boxesCount = boxesCount,
+                gridOrientation = 0,
+                numRows = rows,
+                numColumns = columns,
+                hGap = 0,
+                vGap = 0,
+                gridSpans = arrayOf(),
+                gridSkips = arrayOf(),
+                gridRowWeights = intArrayOf(),
+                gridColumnWeights = intArrayOf(),
+                gridFlags = arrayOf(),
+            )
+        }
+        var expectedX = 0.dp
+        var expectedY = 0.dp
+
+        // 10.dp is the size of a singular box
+        val hGapSize = (rootSize - 10.dp) / 2f
+        val vGapSize = (rootSize - (10.dp * 4f)) / (boxesCount * 2f)
+        rule.waitForIdle()
+        expectedX += hGapSize
+        expectedY += vGapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
+    }
+
+    @Test
+    fun testColumns() {
+        val rootSize = 200.dp
+        val boxesCount = 4
+        val rows = 1
+        val columns = 0
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                boxesCount = boxesCount,
+                gridOrientation = 0,
+                numRows = rows,
+                numColumns = columns,
+                hGap = 0,
+                vGap = 0,
+                gridSpans = arrayOf(),
+                gridSkips = arrayOf(),
+                gridRowWeights = intArrayOf(),
+                gridColumnWeights = intArrayOf(),
+                gridFlags = arrayOf(),
+            )
+        }
+        var expectedX = 0.dp
+        var expectedY = 0.dp
+
+        // 10.dp is the size of a singular box
+        val hGapSize = (rootSize - (10.dp * 4f)) / (boxesCount * 2f)
+        val vGapSize = (rootSize - 10.dp) / 2f
+        rule.waitForIdle()
+        expectedX += hGapSize
+        expectedY += vGapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
+    }
+
+    @Test
+    fun testSkips() {
+        val rootSize = 200.dp
+        val boxesCount = 3
+        val rows = 2
+        val columns = 2
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                boxesCount = boxesCount,
+                gridOrientation = 0,
+                numRows = rows,
+                numColumns = columns,
+                hGap = 0,
+                vGap = 0,
+                gridSpans = arrayOf(),
+                gridSkips = arrayOf(Skip(0, 1, 1)),
+                gridRowWeights = intArrayOf(),
+                gridColumnWeights = intArrayOf(),
+                gridFlags = arrayOf(),
+            )
+        }
+        var leftX = 0.dp
+        var topY = 0.dp
+        var rightX: Dp
+        var bottomY: Dp
+
+        // 10.dp is the size of a singular box
+        val gapSize = (rootSize - (10.dp * 2f)) / (columns * 2f)
+        rule.waitForIdle()
+        leftX += gapSize
+        topY += gapSize
+        rightX = leftX + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(rightX, topY)
+        bottomY = topY + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(leftX, bottomY)
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(rightX, bottomY)
+    }
+
+    @Test
+    fun testReversedDirectionSkips() {
+        val rootSize = 200.dp
+        val boxesCount = 2
+        val rows = 2
+        val columns = 2
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                boxesCount = boxesCount,
+                gridOrientation = 0,
+                numRows = rows,
+                numColumns = columns,
+                hGap = 0,
+                vGap = 0,
+                gridSpans = arrayOf(),
+                gridSkips = arrayOf(Skip(0, 2, 1)),
+                gridRowWeights = intArrayOf(),
+                gridColumnWeights = intArrayOf(),
+                gridFlags = arrayOf(GridFlag.SpansRespectWidgetOrder, GridFlag.SubGridByColRow)
+            )
+        }
+        var leftX = 0.dp
+        var topY = 0.dp
+        var rightX: Dp
+        var bottomY: Dp
+
+        // 10.dp is the size of a singular box
+        val gapSize = (rootSize - (10.dp * 2f)) / (columns * 2f)
+        rule.waitForIdle()
+        leftX += gapSize
+        topY += gapSize
+        rightX = leftX + 10.dp + gapSize + gapSize
+        bottomY = topY + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(leftX, bottomY)
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(rightX, bottomY)
+    }
+
+    @Test
+    fun testSpans() {
+        val rootSize = 200.dp
+        val boxesCount = 3
+        val rows = 2
+        val columns = 2
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                boxesCount = boxesCount,
+                gridOrientation = 0,
+                numRows = rows,
+                numColumns = columns,
+                hGap = 0,
+                vGap = 0,
+                gridSpans = arrayOf(Span(0, 1, 2)),
+                gridSkips = arrayOf(),
+                gridRowWeights = intArrayOf(),
+                gridColumnWeights = intArrayOf(),
+                gridFlags = arrayOf(),
+            )
+        }
+        var leftX = 0.dp
+        var topY = 0.dp
+        var rightX: Dp
+        var bottomY: Dp
+
+        // 10.dp is the size of a singular box
+        var spanLeft = (rootSize - 10.dp) / 2f
+        val gapSize = (rootSize - (10.dp * 2f)) / (columns * 2f)
+        rule.waitForIdle()
+        leftX += gapSize
+        topY += gapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(spanLeft, topY)
+        rightX = leftX + 10.dp + gapSize + gapSize
+        bottomY = topY + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(leftX, bottomY)
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(rightX, bottomY)
+    }
+
+    @Test
+    fun testOrderFirstSpans() {
+        val rootSize = 200.dp
+        val boxesCount = 3
+        val rows = 2
+        val columns = 2
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                boxesCount = boxesCount,
+                gridOrientation = 0,
+                numRows = rows,
+                numColumns = columns,
+                hGap = 0,
+                vGap = 0,
+                gridSpans = arrayOf(Span(1, 2, 1)),
+                gridSkips = arrayOf(),
+                gridRowWeights = intArrayOf(),
+                gridColumnWeights = intArrayOf(),
+                gridFlags = arrayOf(GridFlag.SpansRespectWidgetOrder),
+            )
+        }
+        var leftX = 0.dp
+        var topY = 0.dp
+        var rightX: Dp
+        var bottomY: Dp
+
+        // 10.dp is the size of a singular box
+        var spanTop = (rootSize - 10.dp) / 2f
+        val gapSize = (rootSize - (10.dp * 2f)) / (columns * 2f)
+        rule.waitForIdle()
+        leftX += gapSize
+        topY += gapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(leftX, topY)
+        rightX = leftX + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(rightX, spanTop)
+        bottomY = topY + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(leftX, bottomY)
+    }
+
+    @Test
+    fun testReversedDirectionSpans() {
+        val rootSize = 200.dp
+        val boxesCount = 3
+        val rows = 2
+        val columns = 2
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                boxesCount = boxesCount,
+                gridOrientation = 0,
+                numRows = rows,
+                numColumns = columns,
+                hGap = 0,
+                vGap = 0,
+                gridSpans = arrayOf(Span(0, 2, 1)),
+                gridSkips = arrayOf(),
+                gridRowWeights = intArrayOf(),
+                gridColumnWeights = intArrayOf(),
+                gridFlags = arrayOf(GridFlag.SubGridByColRow),
+            )
+        }
+        var leftX = 0.dp
+        var topY = 0.dp
+        var rightX: Dp
+        var bottomY: Dp
+
+        // 10.dp is the size of a singular box
+        var spanLeft = (rootSize - 10.dp) / 2f
+        val gapSize = (rootSize - (10.dp * 2f)) / (columns * 2f)
+        rule.waitForIdle()
+        leftX += gapSize
+        topY += gapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(spanLeft, topY)
+        rightX = leftX + 10.dp + gapSize + gapSize
+        bottomY = topY + 10.dp + gapSize + gapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(leftX, bottomY)
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(rightX, bottomY)
+    }
+
+    @Test
+    fun testRowWeights() {
+        val rootSize = 200.dp
+        val boxesCount = 2
+        val rows = 0
+        val columns = 1
+        val weights = intArrayOf(1, 3)
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                boxesCount = boxesCount,
+                gridOrientation = 0,
+                numRows = rows,
+                numColumns = columns,
+                hGap = 0,
+                vGap = 0,
+                gridSpans = arrayOf(),
+                gridSkips = arrayOf(),
+                gridRowWeights = weights,
+                gridColumnWeights = intArrayOf(),
+                gridFlags = arrayOf(),
+            )
+        }
+        var expectedLeft = (rootSize - 10.dp) / 2f
+        var expectedTop = 0.dp
+
+        // 10.dp is the size of a singular box
+        // first box takes the 1/4 of the height
+        val firstGapSize = (rootSize / 4 - 10.dp) / 2
+        // second box takes the 3/4 of the height
+        val secondGapSize = ((rootSize * 3 / 4) - 10.dp) / 2
+        rule.waitForIdle()
+        expectedTop += firstGapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedLeft, expectedTop)
+        expectedTop += 10.dp + firstGapSize + secondGapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedLeft, expectedTop)
+    }
+
+    @Test
+    fun testColumnWeights() {
+        val rootSize = 200.dp
+        val boxesCount = 2
+        val rows = 1
+        val columns = 0
+        val weights = intArrayOf(1, 3)
+        rule.setContent {
+            gridComposableTest(
+                modifier = Modifier.size(rootSize),
+                boxesCount = boxesCount,
+                gridOrientation = 0,
+                numRows = rows,
+                numColumns = columns,
+                hGap = 0,
+                vGap = 0,
+                gridSpans = arrayOf(),
+                gridSkips = arrayOf(),
+                gridRowWeights = intArrayOf(),
+                gridColumnWeights = weights,
+                gridFlags = arrayOf(),
+            )
+        }
+        var expectedLeft = 0.dp
+        var expectedTop = (rootSize - 10.dp) / 2f
+
+        // 10.dp is the size of a singular box
+        // first box takes the 1/4 of the width
+        val firstGapSize = (rootSize / 4 - 10.dp) / 2
+        // second box takes the 3/4 of the width
+        val secondGapSize = ((rootSize * 3 / 4) - 10.dp) / 2
+        rule.waitForIdle()
+        expectedLeft += firstGapSize
+
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedLeft, expectedTop)
+        expectedLeft += 10.dp + firstGapSize + secondGapSize
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedLeft, expectedTop)
+    }
+
+    @Test
+    fun testGaps() {
+        val rootSize = 200.dp
+        val hGap = 10.dp
+        val vGap = 20.dp
+        rule.setContent {
+            gridComposableGapTest(
+                modifier = Modifier.size(rootSize),
+                hGap = Math.round(hGap.value),
+                vGap = Math.round(vGap.value),
+            )
+        }
+        var expectedLeft = 0.dp
+        var expectedTop = 0.dp
+
+        val boxWidth = (rootSize - hGap) / 2f
+        val boxHeight = (rootSize - vGap) / 2f
+
+        rule.waitForIdle()
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(0.dp, 0.dp)
+        expectedLeft += boxWidth + hGap
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedLeft, 0.dp)
+        expectedTop += boxHeight + vGap
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(0.dp, expectedTop)
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedLeft, expectedTop)
+    }
+
+    @Composable
+    private fun gridComposableTest(
+        modifier: Modifier = Modifier,
+        numRows: Int,
+        numColumns: Int,
+        gridSpans: Array<Span>,
+        gridSkips: Array<Skip>,
+        gridRowWeights: IntArray,
+        gridColumnWeights: IntArray,
+        boxesCount: Int,
+        gridOrientation: Int,
+        vGap: Int,
+        hGap: Int,
+        gridFlags: Array<GridFlag>,
+    ) {
+        ConstraintLayout(
+            ConstraintSet {
+                val ids = (0 until boxesCount).map { "box$it" }.toTypedArray()
+                val elem = arrayListOf<LayoutReference>()
+                for (i in ids.indices) {
+                    elem.add(createRefFor(ids[i]))
+                }
+
+                val g1 = createGrid(
+                    elements = elem.toTypedArray(),
+                    orientation = gridOrientation,
+                    skips = gridSkips,
+                    spans = gridSpans,
+                    rows = numRows,
+                    columns = numColumns,
+                    verticalGap = vGap.dp,
+                    horizontalGap = hGap.dp,
+                    rowWeights = gridRowWeights,
+                    columnWeights = gridColumnWeights,
+                    flags = gridFlags,
+                )
+                constrain(g1) {
+                    width = Dimension.matchParent
+                    height = Dimension.matchParent
+                }
+            },
+            modifier = modifier
+        ) {
+            val ids = (0 until boxesCount).map { "box$it" }.toTypedArray()
+            ids.forEach { id ->
+                Box(
+                    Modifier
+                        .layoutId(id)
+                        .background(Color.Red)
+                        .testTag(id)
+                        .size(10.dp)
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun gridComposableGapTest(
+        modifier: Modifier = Modifier,
+        vGap: Int,
+        hGap: Int,
+    ) {
+        ConstraintLayout(
+            ConstraintSet {
+                val a = createRefFor("box0")
+                val b = createRefFor("box1")
+                val c = createRefFor("box2")
+                val d = createRefFor("box3")
+                val g1 = createGrid(
+                    a, b, c, d,
+                    rows = 2,
+                    columns = 2,
+                    verticalGap = vGap.dp,
+                    horizontalGap = hGap.dp,
+                )
+                constrain(g1) {
+                    width = Dimension.matchParent
+                    height = Dimension.matchParent
+                }
+                constrain(a) {
+                    width = Dimension.fillToConstraints
+                    height = Dimension.fillToConstraints
+                }
+                constrain(b) {
+                    width = Dimension.fillToConstraints
+                    height = Dimension.fillToConstraints
+                }
+                constrain(c) {
+                    width = Dimension.fillToConstraints
+                    height = Dimension.fillToConstraints
+                }
+                constrain(d) {
+                    width = Dimension.fillToConstraints
+                    height = Dimension.fillToConstraints
+                }
+            },
+            modifier = modifier,
+        ) {
+            val ids = (0 until 4).map { "box$it" }.toTypedArray()
+            ids.forEach { id ->
+                Box(
+                    Modifier
+                        .layoutId(id)
+                        .background(Color.Red)
+                        .testTag(id)
+                        .size(10.dp)
+                )
+            }
+        }
+    }
+}

--- a/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/RowColumnDslTest.kt
+++ b/constraintlayout/compose/src/androidTest/java/androidx/constraintlayout/compose/RowColumnDslTest.kt
@@ -1,0 +1,343 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.constraintlayout.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.platform.isDebugInspectorInfoEnabled
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertPositionInRootIsEqualTo
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Tests for the Grid Helper (Row / Column)
+ */
+@MediumTest
+@RunWith(AndroidJUnit4::class)
+class RowColumnDslTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Before
+    fun setup() {
+        isDebugInspectorInfoEnabled = true
+    }
+
+    @After
+    fun tearDown() {
+        isDebugInspectorInfoEnabled = false
+    }
+
+    @Test
+    fun testColumn() {
+        val rootSize = 200.dp
+        val boxesCount = 4
+        rule.setContent {
+            ColumnComposableTest(
+                modifier = Modifier.size(rootSize),
+                gridSkips = arrayOf(),
+                gridSpans = arrayOf(),
+                boxesCount = boxesCount,
+                vGap = 0,
+                gridRowWeights = intArrayOf(),
+            )
+        }
+        var expectedX = 0.dp
+        var expectedY = 0.dp
+
+        // 10.dp is the size of a singular box
+        val hGapSize = (rootSize - 10.dp) / 2f
+        val vGapSize = (rootSize - (10.dp * 4f)) / (boxesCount * 2f)
+        rule.waitForIdle()
+        expectedX += hGapSize
+        expectedY += vGapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
+    }
+
+    @Test
+    fun testColumnSkips() {
+        val rootSize = 200.dp
+        val boxesCount = 4
+        rule.setContent {
+            ColumnComposableTest(
+                modifier = Modifier.size(rootSize),
+                gridSkips = arrayOf(Skip(1, 2)),
+                gridSpans = arrayOf(),
+                boxesCount = boxesCount,
+                vGap = 0,
+                gridRowWeights = intArrayOf(),
+            )
+        }
+        var expectedX = 0.dp
+        var expectedY = 0.dp
+
+        // 10.dp is the size of a singular box
+        val hGapSize = (rootSize - 10.dp) / 2f
+        val vGapSize = (rootSize - (10.dp * 6f)) / ((boxesCount + 2) * 2f)
+        rule.waitForIdle()
+        expectedX += hGapSize
+        expectedY += vGapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp
+        expectedY += vGapSize + vGapSize + 10.dp
+        expectedY += vGapSize + vGapSize + 10.dp
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
+    }
+
+    @Test
+    fun testColumnSpans() {
+        val rootSize = 200.dp
+        val boxesCount = 4
+        rule.setContent {
+            ColumnComposableTest(
+                modifier = Modifier.size(rootSize),
+                gridSkips = arrayOf(),
+                gridSpans = arrayOf(Span(0, 2)),
+                boxesCount = boxesCount,
+                vGap = 0,
+                gridRowWeights = intArrayOf(),
+            )
+        }
+
+        // 10.dp is the size of a singular box
+        val hGapSize = (rootSize - 10.dp) / 2f
+        val vGapSize = (rootSize - (10.dp * 5f)) / ((boxesCount + 1) * 2f)
+        val rowSize = 10.dp + vGapSize * 2
+        var expectedX = 0.dp
+        var expectedY = rowSize - 5.dp
+
+        expectedX += hGapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += expectedY + vGapSize + 10.dp
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedY += vGapSize + vGapSize + 10.dp
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
+    }
+
+    @Test
+    fun testRow() {
+        val rootSize = 200.dp
+        val boxesCount = 4
+        rule.setContent {
+            RowComposableTest(
+                modifier = Modifier.size(rootSize),
+                gridSkips = arrayOf(),
+                gridSpans = arrayOf(),
+                boxesCount = boxesCount,
+                hGap = 0,
+                gridColumnWeights = intArrayOf()
+            )
+        }
+        var expectedX = 0.dp
+        var expectedY = 0.dp
+
+        // 10.dp is the size of a singular box
+        val hGapSize = (rootSize - (10.dp * 4f)) / (boxesCount * 2f)
+        val vGapSize = (rootSize - 10.dp) / 2f
+        rule.waitForIdle()
+        expectedX += hGapSize
+        expectedY += vGapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
+    }
+
+    @Test
+    fun testRowSkips() {
+        val rootSize = 200.dp
+        val boxesCount = 4
+        rule.setContent {
+            RowComposableTest(
+                modifier = Modifier.size(rootSize),
+                gridSkips = arrayOf(Skip(1, 2)),
+                gridSpans = arrayOf(),
+                boxesCount = boxesCount,
+                hGap = 0,
+                gridColumnWeights = intArrayOf()
+            )
+        }
+        var expectedX = 0.dp
+        var expectedY = 0.dp
+
+        // 10.dp is the size of a singular box
+        val hGapSize = (rootSize - (10.dp * 6f)) / ((boxesCount + 2) * 2f)
+        val vGapSize = (rootSize - 10.dp) / 2f
+        rule.waitForIdle()
+        expectedX += hGapSize
+        expectedY += vGapSize
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp
+        expectedX += hGapSize + hGapSize + 10.dp
+        expectedX += hGapSize + hGapSize + 10.dp
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
+    }
+
+    @Test
+    fun testRowSpans() {
+        val rootSize = 200.dp
+        val boxesCount = 4
+        rule.setContent {
+            RowComposableTest(
+                modifier = Modifier.size(rootSize),
+                gridSkips = arrayOf(),
+                gridSpans = arrayOf(Span(0, 2)),
+                boxesCount = boxesCount,
+                hGap = 0,
+                gridColumnWeights = intArrayOf()
+            )
+        }
+
+        // 10.dp is the size of a singular box
+        val hGapSize = (rootSize - (10.dp * 5f)) / ((boxesCount + 1) * 2f)
+        val vGapSize = (rootSize - 10.dp) / 2f
+        val columnSize = 10.dp + hGapSize * 2
+        var expectedX = columnSize - 5.dp
+        var expectedY = 0.dp
+
+        expectedY += vGapSize
+
+        rule.onNodeWithTag("box0").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += expectedX + hGapSize + 10.dp
+        rule.onNodeWithTag("box1").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp
+        rule.onNodeWithTag("box2").assertPositionInRootIsEqualTo(expectedX, expectedY)
+        expectedX += hGapSize + hGapSize + 10.dp
+        rule.onNodeWithTag("box3").assertPositionInRootIsEqualTo(expectedX, expectedY)
+    }
+
+    @Composable
+    private fun ColumnComposableTest(
+        modifier: Modifier = Modifier,
+        gridSkips: Array<Skip>,
+        gridSpans: Array<Span>,
+        gridRowWeights: IntArray,
+        boxesCount: Int,
+        vGap: Int,
+    ) {
+        ConstraintLayout(
+            ConstraintSet {
+                val ids = (0 until boxesCount).map { "box$it" }.toTypedArray()
+                val elem = arrayListOf<LayoutReference>()
+                for (i in ids.indices) {
+                    elem.add(createRefFor(ids[i]))
+                }
+
+                val g1 = createColumn(
+                    elements = elem.toTypedArray(),
+                    skips = gridSkips,
+                    spans = gridSpans,
+                    verticalGap = vGap.dp,
+                    rowWeights = gridRowWeights,
+                )
+                constrain(g1) {
+                    width = Dimension.matchParent
+                    height = Dimension.matchParent
+                }
+            },
+            modifier = modifier
+        ) {
+            val ids = (0 until boxesCount).map { "box$it" }.toTypedArray()
+            ids.forEach { id ->
+                Box(
+                    Modifier
+                        .layoutId(id)
+                        .background(Color.Red)
+                        .testTag(id)
+                        .size(10.dp)
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun RowComposableTest(
+        modifier: Modifier = Modifier,
+        gridSkips: Array<Skip>,
+        gridSpans: Array<Span>,
+        gridColumnWeights: IntArray,
+        boxesCount: Int,
+        hGap: Int,
+    ) {
+        ConstraintLayout(
+            ConstraintSet {
+                val ids = (0 until boxesCount).map { "box$it" }.toTypedArray()
+                val elem = arrayListOf<LayoutReference>()
+                for (i in ids.indices) {
+                    elem.add(createRefFor(ids[i]))
+                }
+
+                val g1 = createRow(
+                    elements = elem.toTypedArray(),
+                    horizontalGap = hGap.dp,
+                    skips = gridSkips,
+                    spans = gridSpans,
+                    columnWeights = gridColumnWeights,
+                )
+                constrain(g1) {
+                    width = Dimension.matchParent
+                    height = Dimension.matchParent
+                }
+            },
+            modifier = modifier
+        ) {
+            val ids = (0 until boxesCount).map { "box$it" }.toTypedArray()
+            ids.forEach { id ->
+                Box(
+                    Modifier
+                        .layoutId(id)
+                        .background(Color.Red)
+                        .testTag(id)
+                        .size(10.dp)
+                )
+            }
+        }
+    }
+}

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayoutBaseScope.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayoutBaseScope.kt
@@ -703,8 +703,8 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      *      val weights = intArrayOf(3, 3, 2, 2, 1)
      *      val g1 = createRow(
      *          a, b, c, d, e,
-     *          spans = "1:2"
-     *          skips = "1:1,3:2",
+     *          skips = arrayOf(Skip(1, 1), Skip(3, 2)),
+     *          spans = arrayOf(Span(1, 2)),
      *          horizontalGap = 10.dp,
      *          columnWeights = weights,
      *          padding = 10.dp,
@@ -727,16 +727,16 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      *    }
      *
      * @param elements [LayoutReference]s to be laid out by the Grid helper
-     * @param spans specify area(s) in a Row to be spanned - format: positionxsize
-     * @param skips specify area(s) in a Row to be skipped - format: positionxsize
+     * @param skips specify area(s) in a Row to be skipped - format: Skip(index, size)
+     * @param spans specify area(s) in a Row to be spanned - format: Span(index, size)
      * @param horizontalGap defines the gap between views in the x axis
      * @param columnWeights defines the weight of each column
      * @param padding sets padding around the content
      */
     fun createRow(
         vararg elements: LayoutReference,
-        spans: String = "",
-        skips: String = "",
+        skips: Array<Skip> = arrayOf(),
+        spans: Array<Span> = arrayOf(),
         horizontalGap: Dp = 0.dp,
         columnWeights: IntArray = intArrayOf(),
         padding: Dp = 0.dp,
@@ -744,13 +744,13 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
         return createGrid(
             elements = elements,
             rows = 1,
-            spans = spans,
             skips = skips,
+            spans = spans,
             horizontalGap = horizontalGap,
             columnWeights = columnWeights,
-            paddingLeft = padding,
+            paddingStart = padding,
             paddingTop = padding,
-            paddingRight = padding,
+            paddingEnd = padding,
             paddingBottom = padding,
         )
     }
@@ -768,8 +768,8 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      *      val weights = intArrayOf(3, 3, 2, 2, 1)
      *      val g1 = createRow(
      *          a, b, c, d, e,
-     *          spans = "1:2"
-     *          skips = "1:1,3:2",
+     *          skips = arrayOf(Skip(1, 1), Skip(3, 2)),
+     *          spans = arrayOf(Span(1, 2)),
      *          horizontalGap = 10.dp,
      *          columnWeights = weights,
      *          paddingHorizontal = 10.dp,
@@ -793,17 +793,17 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      *   }
      *
      * @param elements [LayoutReference]s to be laid out by the Grid helper
-     * @param spans specify area(s) in a Row to be spanned - format: positionxsize
-     * @param skips specify area(s) in a Row to be skipped - format: positionxsize
+     * @param skips specify area(s) in a Row to be skipped - format: Skip(index, size)
+     * @param spans specify area(s) in a Row to be spanned - format: Span(index, size)
      * @param horizontalGap defines the gap between views in the y axis
      * @param columnWeights defines the weight of each column
-     * @param paddingHorizontal sets paddingLeft and paddingRight of the content
+     * @param paddingHorizontal sets paddingStart and paddingEnd of the content
      * @param paddingVertical sets paddingTop and paddingBottom of the content
      */
     fun createRow(
         vararg elements: LayoutReference,
-        spans: String = "",
-        skips: String = "",
+        skips: Array<Skip> = arrayOf(),
+        spans: Array<Span> = arrayOf(),
         horizontalGap: Dp = 0.dp,
         columnWeights: IntArray = intArrayOf(),
         paddingHorizontal: Dp = 0.dp,
@@ -812,13 +812,13 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
         return createGrid(
             elements = elements,
             rows = 1,
-            spans = spans,
             skips = skips,
+            spans = spans,
             horizontalGap = horizontalGap,
             columnWeights = columnWeights,
-            paddingLeft = paddingHorizontal,
+            paddingStart = paddingHorizontal,
             paddingTop = paddingVertical,
-            paddingRight = paddingHorizontal,
+            paddingEnd = paddingHorizontal,
             paddingBottom = paddingVertical,
         )
     }
@@ -836,8 +836,8 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      *      val weights = intArrayOf(3, 3, 2, 2, 1)
      *      val g1 = createColumn(
      *          a, b, c, d, e,
-     *          spans = "1:2"
-     *          skips = "1:1,3:2",
+     *          skips = arrayOf(Skip(1, 1), Skip(3, 2)),
+     *          spans = arrayOf(Span(1, 2)),
      *          verticalGap = 10.dp,
      *          rowWeights = weights,
      *          padding = 10.dp,
@@ -860,16 +860,16 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      *    }
      *
      * @param elements [LayoutReference]s to be laid out by the Grid helper
-     * @param spans specify area(s) in a Column to be spanned - format: positionxsize
-     * @param skips specify area(s) in a Column to be skipped - format: positionxsize
+     * @param spans specify area(s) in a Column to be spanned - format: Span(index, size)
+     * @param skips specify area(s) in a Column to be skipped - format: Skip(index, size)
      * @param verticalGap defines the gap between views in the y axis
      * @param rowWeights defines the weight of each row
      * @param padding sets padding around the content
      */
     fun createColumn(
         vararg elements: LayoutReference,
-        spans: String = "",
-        skips: String = "",
+        skips: Array<Skip> = arrayOf(),
+        spans: Array<Span> = arrayOf(),
         rowWeights: IntArray = intArrayOf(),
         verticalGap: Dp = 0.dp,
         padding: Dp = 0.dp,
@@ -877,13 +877,13 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
         return createGrid(
             elements = elements,
             columns = 1,
-            spans = spans,
             skips = skips,
+            spans = spans,
             verticalGap = verticalGap,
             rowWeights = rowWeights,
-            paddingLeft = padding,
+            paddingStart = padding,
             paddingTop = padding,
-            paddingRight = padding,
+            paddingEnd = padding,
             paddingBottom = padding,
         )
     }
@@ -901,8 +901,8 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      *      val weights = intArrayOf(3, 3, 2, 2, 1)
      *      val g1 = createColumn(
      *          a, b, c, d, e,
-     *          spans = "1:2"
-     *          skips = "1:1,3:2",
+     *          skips = arrayOf(Skip(1, 1), Skip(3, 2)),
+     *          spans = arrayOf(Span(1, 2)),
      *          verticalGap = 10.dp,
      *          rowWeights = weights,
      *          padding = 10.dp,
@@ -925,17 +925,17 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      *    }
      *
      * @param elements [LayoutReference]s to be laid out by the Grid helper
-     * @param spans specify area(s) in a Column to be spanned - format: positionxsize
-     * @param skips specify area(s) in a Column to be skipped - format: positionxsize
+     * @param skips specify area(s) in a Column to be skipped - format: Skip(index, size)
+     * @param spans specify area(s) in a Column to be spanned - format: Span(index, size)
      * @param verticalGap defines the gap between views in the y axis
      * @param rowWeights defines the weight of each row
-     * @param paddingHorizontal sets paddingLeft and paddingRight of the content
+     * @param paddingHorizontal sets paddingStart and paddingEnd of the content
      * @param paddingVertical sets paddingTop and paddingBottom of the content
      */
     fun createColumn(
         vararg elements: LayoutReference,
-        spans: String = "",
-        skips: String = "",
+        skips: Array<Skip> = arrayOf(),
+        spans: Array<Span> = arrayOf(),
         verticalGap: Dp = 0.dp,
         rowWeights: IntArray = intArrayOf(),
         paddingHorizontal: Dp = 0.dp,
@@ -944,13 +944,13 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
         return createGrid(
             elements = elements,
             columns = 1,
-            spans = spans,
             skips = skips,
+            spans = spans,
             verticalGap = verticalGap,
             rowWeights = rowWeights,
-            paddingLeft = paddingHorizontal,
+            paddingStart = paddingHorizontal,
             paddingTop = paddingVertical,
-            paddingRight = paddingHorizontal,
+            paddingEnd = paddingHorizontal,
             paddingBottom = paddingVertical,
         )
     }
@@ -979,8 +979,8 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      *          columns = 3,
      *          verticalGap = 25.dp,
      *          horizontalGap = 25.dp,
-     *          spans = "0:1x3",
-     *          skips = "12:1x1",
+     *          skips = arrayOf(Skip(12, 1, 1)),
+     *          spans = arrayOf(Span(0, 1, 3)),
      *          rowWeights = weights,
      *          paddingHorizontal = 10.dp,
      *          paddingVertical = 10.dp,
@@ -1018,15 +1018,15 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      * @param rowWeights defines the weight of each row
      * @param columnWeights defines the weight of each column
      * @param skips defines the positions in a Grid to be skipped
-     *        the format of the input string is "index:rowxcol"
-     *        index - the index of the starting position
-     *        row - the number of rows to skip
-     *        col- the number of columns to skip
+     *        the format: Skip(position, rows, columns)
+     *        position - the index of the starting position
+     *        rows - the number of rows to skip
+     *        coloumns - the number of columns to skip
      * @param spans defines the spanned area(s) in Grid
-     *        the format of the input string is "index:rowxcol"
-     *        index - the index of the starting position
-     *        row - the number of rows to span
-     *        col- the number of columns to span
+     *        the format: Span(position, rows, columns)
+     *        position - the index of the starting position
+     *        rows - the number of rows to span
+     *        coloumns - the number of columns to span
      * @param padding sets padding around the content
      * @param flags set different flags to be enabled (not case-sensitive), including
      *          SubGridByColRow: reverse the width and height specification for spans/skips.
@@ -1049,8 +1049,8 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
         horizontalGap: Dp = 0.dp,
         rowWeights: IntArray = intArrayOf(),
         columnWeights: IntArray = intArrayOf(),
-        skips: String = "",
-        spans: String = "",
+        skips: Array<Skip> = arrayOf(),
+        spans: Array<Span> = arrayOf(),
         padding: Dp = 0.dp,
         flags: Array<GridFlag> = arrayOf(),
     ): ConstrainedLayoutReference {
@@ -1065,9 +1065,9 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
             columnWeights = columnWeights,
             skips = skips,
             spans = spans,
-            paddingLeft = padding,
+            paddingStart = padding,
             paddingTop = padding,
-            paddingRight = padding,
+            paddingEnd = padding,
             paddingBottom = padding,
             flags = flags,
         )
@@ -1097,8 +1097,8 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      *          columns = 3,
      *          verticalGap = 25.dp,
      *          horizontalGap = 25.dp,
-     *          spans = "0:1x3",
-     *          skips = "12:1x1",
+     *          skips = arrayOf(Skip(12, 1, 1)),
+     *          spans = arrayOf(Span(0, 1, 3)),
      *          rowWeights = weights,
      *          paddingHorizontal = 10.dp,
      *          paddingVertical = 10.dp,
@@ -1136,16 +1136,16 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      * @param columnWeights defines the weight of each column
      * @param orientation 0 if horizontal and 1 if vertical
      * @param skips defines the positions in a Grid to be skipped
-     *        the format of the input string is "index:rowxcol"
-     *        index - the index of the starting position
-     *        row - the number of rows to skip
-     *        col- the number of columns to skip
+     *        the format: Skip(position, rows, columns)
+     *        position - the index of the starting position
+     *        rows - the number of rows to skip
+     *        coloumns - the number of columns to skip
      * @param spans defines the spanned area(s) in Grid
-     *        the format of the input string is "index:rowxcol"
-     *        index - the index of the starting position
-     *        row - the number of rows to span
-     *        col- the number of columns to span
-     * @param paddingHorizontal sets paddingLeft and paddingRight of the content
+     *        the format: Span(position, rows, columns)
+     *        position - the index of the starting position
+     *        rows - the number of rows to span
+     *        coloumns - the number of columns to span
+     * @param paddingHorizontal sets paddingStart and paddingEnd of the content
      * @param paddingVertical sets paddingTop and paddingBottom of the content
      * @param flags set different flags to be enabled (not case-sensitive), including
      *          SubGridByColRow: reverse the width and height specification for spans/skips.
@@ -1168,8 +1168,8 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
         horizontalGap: Dp = 0.dp,
         rowWeights: IntArray = intArrayOf(),
         columnWeights: IntArray = intArrayOf(),
-        skips: String = "",
-        spans: String = "",
+        skips: Array<Skip> = arrayOf(),
+        spans: Array<Span> = arrayOf(),
         paddingHorizontal: Dp = 0.dp,
         paddingVertical: Dp = 0.dp,
         flags: Array<GridFlag> = arrayOf(),
@@ -1185,9 +1185,9 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
             verticalGap = verticalGap,
             skips = skips,
             spans = spans,
-            paddingLeft = paddingHorizontal,
+            paddingStart = paddingHorizontal,
             paddingTop = paddingVertical,
-            paddingRight = paddingHorizontal,
+            paddingEnd = paddingHorizontal,
             paddingBottom = paddingVertical,
             flags = flags
         )
@@ -1217,12 +1217,12 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      *          columns = 3,
      *          verticalGap = 25.dp,
      *          horizontalGap = 25.dp,
-     *          spans = "0:1x3",
-     *          skips = "12:1x1",
+     *          skips = arrayOf(Skip(12, 1, 1)),
+     *          spans = arrayOf(Span(0, 1, 3)),
      *          rowWeights = weights,
-     *          paddingLeft = 10.dp,
+     *          paddingStart = 10.dp,
      *          paddingTop = 10.dp,
-     *          paddingRight = 10.dp,
+     *          paddingEnd = 10.dp,
      *          paddingBottom = 10.dp,
      *          flags = flags,
      *      )
@@ -1258,18 +1258,18 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
      * @param rowWeights defines the weight of each row
      * @param columnWeights defines the weight of each column
      * @param skips defines the positions in a Grid to be skipped
-     *        the format of the input string is "index:rowxcol"
-     *        index - the index of the starting position
-     *        row - the number of rows to skip
-     *        col- the number of columns to skip
+     *        the format: Skip(position, rows, columns)
+     *        position - the index of the starting position
+     *        rows - the number of rows to skip
+     *        coloumns - the number of columns to skip
      * @param spans defines the spanned area(s) in Grid
-     *        the format of the input string is "index:rowxcol"
-     *        index - the index of the starting position
-     *        row - the number of rows to span
-     *        col- the number of columns to span
-     * @param paddingLeft sets paddingLeft of the content
+     *        the format: Span(position, rows, columns)
+     *        position - the index of the starting position
+     *        rows - the number of rows to span
+     *        coloumns - the number of columns to span
+     * @param paddingStart sets paddingStart of the content
      * @param paddingTop sets paddingTop of the content
-     * @param paddingRight sets paddingRight of the content
+     * @param paddingEnd sets paddingEnd of the content
      * @param paddingBottom sets paddingBottom of the content
      * @param flags set different flags to be enabled (not case-sensitive), including
      *          SubGridByColRow: reverse the width and height specification for spans/skips.
@@ -1292,11 +1292,11 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
         horizontalGap: Dp = 0.dp,
         rowWeights: IntArray = intArrayOf(),
         columnWeights: IntArray = intArrayOf(),
-        skips: String = "",
-        spans: String = "",
-        paddingLeft: Dp = 0.dp,
+        skips: Array<Skip> = arrayOf(),
+        spans: Array<Span> = arrayOf(),
+        paddingStart: Dp = 0.dp,
         paddingTop: Dp = 0.dp,
-        paddingRight: Dp = 0.dp,
+        paddingEnd: Dp = 0.dp,
         paddingBottom: Dp = 0.dp,
         flags: Array<GridFlag> = arrayOf(),
     ): ConstrainedLayoutReference {
@@ -1307,9 +1307,9 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
             elementArray.add(CLString.from(it.id.toString()))
         }
         val paddingArray = CLArray(charArrayOf()).apply {
-            add(CLNumber(paddingLeft.value))
+            add(CLNumber(paddingStart.value))
             add(CLNumber(paddingTop.value))
-            add(CLNumber(paddingRight.value))
+            add(CLNumber(paddingEnd.value))
             add(CLNumber(paddingBottom.value))
         }
         flags.forEach {
@@ -1324,6 +1324,15 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
             strColumnWeights = columnWeights.joinToString(",")
         }
 
+        var strSkips = ""
+        var strSpans = ""
+        if (skips.isNotEmpty()) {
+            strSkips = skips.joinToString(",") { it.description }
+        }
+        if (spans.isNotEmpty()) {
+            strSpans = spans.joinToString(",") { it.description }
+        }
+
         ref.asCLContainer().apply {
             put("contains", elementArray)
             putString("type", "grid")
@@ -1335,8 +1344,8 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
             put("padding", paddingArray)
             putString("rowWeights", strRowWeights)
             putString("columnWeights", strColumnWeights)
-            putString("skips", skips)
-            putString("spans", spans)
+            putString("skips", strSkips)
+            putString("spans", strSpans)
             put("flags", flagArray)
         }
 
@@ -1938,4 +1947,16 @@ class FlowStyle internal constructor(
         val SpreadInside = FlowStyle("spread_inside")
         val Packed = FlowStyle("packed")
     }
+}
+
+@JvmInline
+value class Skip(val description: String) {
+    constructor(position: Int, rows: Int, columns: Int) : this("$position:${rows}x$columns")
+    constructor(position: Int, size: Int) : this("$position:$size")
+}
+
+@JvmInline
+value class Span(val description: String) {
+    constructor(position: Int, rows: Int, columns: Int) : this("$position:${rows}x$columns")
+    constructor(position: Int, size: Int) : this("$position:$size")
 }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintSetParser.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintSetParser.java
@@ -1003,17 +1003,17 @@ public class ConstraintSetParser {
                     break;
                 case "padding":
                     CLElement paddingObject = element.get(param);
-                    int paddingLeft = 0;
+                    int paddingStart = 0;
                     int paddingTop = 0;
-                    int paddingRight = 0;
+                    int paddingEnd = 0;
                     int paddingBottom = 0;
                     if (paddingObject instanceof CLArray && ((CLArray) paddingObject).size() > 1) {
-                        paddingLeft = ((CLArray) paddingObject).getInt(0);
-                        paddingRight = paddingLeft;
+                        paddingStart = ((CLArray) paddingObject).getInt(0);
+                        paddingEnd = paddingStart;
                         paddingTop = ((CLArray) paddingObject).getInt(1);
                         paddingBottom = paddingTop;
                         if (((CLArray) paddingObject).size() > 2) {
-                            paddingRight = ((CLArray) paddingObject).getInt(2);
+                            paddingEnd = ((CLArray) paddingObject).getInt(2);
                             try {
                                 paddingBottom = ((CLArray) paddingObject).getInt(3);
                             } catch (ArrayIndexOutOfBoundsException e) {
@@ -1022,14 +1022,14 @@ public class ConstraintSetParser {
 
                         }
                     } else {
-                        paddingLeft = paddingObject.getInt();
-                        paddingTop = paddingLeft;
-                        paddingRight = paddingLeft;
-                        paddingBottom = paddingLeft;
+                        paddingStart = paddingObject.getInt();
+                        paddingTop = paddingStart;
+                        paddingEnd = paddingStart;
+                        paddingBottom = paddingStart;
                     }
-                    grid.setPaddingLeft(paddingLeft);
+                    grid.setPaddingStart(paddingStart);
                     grid.setPaddingTop(paddingTop);
-                    grid.setPaddingRight(paddingRight);
+                    grid.setPaddingEnd(paddingEnd);
                     grid.setPaddingBottom(paddingBottom);
                     break;
                 case "flags":

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/GridReference.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/helpers/GridReference.java
@@ -48,14 +48,14 @@ public class GridReference extends HelperReference {
     private GridCore mGrid;
 
     /**
-     * padding left
+     * padding start
      */
-    private int mPaddingLeft = 0;
+    private int mPaddingStart = 0;
 
     /**
-     * padding right
+     * padding end
      */
-    private int mPaddingRight = 0;
+    private int mPaddingEnd = 0;
 
     /**
      * padding top
@@ -121,32 +121,32 @@ public class GridReference extends HelperReference {
      * get padding left
      * @return padding left
      */
-    public int getPaddingLeft() {
-        return mPaddingLeft;
+    public int getPaddingStart() {
+        return mPaddingStart;
     }
 
     /**
      * set padding left
-     * @param paddingLeft padding left to be set
+     * @param paddingStart padding left to be set
      */
-    public void setPaddingLeft(int paddingLeft) {
-        mPaddingLeft = paddingLeft;
+    public void setPaddingStart(int paddingStart) {
+        mPaddingStart = paddingStart;
     }
 
     /**
      * get padding right
      * @return padding right
      */
-    public int getPaddingRight() {
-        return mPaddingRight;
+    public int getPaddingEnd() {
+        return mPaddingEnd;
     }
 
     /**
      * set padding right
-     * @param paddingRight padding right to be set
+     * @param paddingEnd padding right to be set
      */
-    public void setPaddingRight(int paddingRight) {
-        mPaddingRight = paddingRight;
+    public void setPaddingEnd(int paddingEnd) {
+        mPaddingEnd = paddingEnd;
     }
 
     /**

--- a/demoProjects/ExampleComposeGrid/app/build.gradle
+++ b/demoProjects/ExampleComposeGrid/app/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation "androidx.compose.ui:ui:$compose_ui_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_ui_version"
     implementation 'androidx.compose.material:material:1.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout-compose:1.1.0-alpha07'
+    implementation "androidx.constraintlayout:constraintlayout-compose:$constraintlayout_compose_version"
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/demoProjects/ExampleComposeGrid/build.gradle
+++ b/demoProjects/ExampleComposeGrid/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     ext {
         compose_ui_version = '1.2.0'
+        constraintlayout_compose_version = '1.1.0-alpha08'
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/GridDslDemo.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/GridDslDemo.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.ConstraintSet
 import androidx.constraintlayout.compose.Dimension
+import androidx.constraintlayout.compose.Skip
+import androidx.constraintlayout.compose.Span
 
 @Preview(group = "grid1")
 @Composable
@@ -65,8 +67,8 @@ public fun GridDslDemo1() {
                 columns = 3,
                 verticalGap = 25.dp,
                 horizontalGap = 25.dp,
-                spans = "0:1x3",
-                skips = "12:1x1",
+                spans = arrayOf(Span(0,1,3)),
+                skips = arrayOf(Skip(12, 1, 1)),
                 rowWeights = weights,
             )
 
@@ -270,14 +272,14 @@ public fun GridDslDemo4() {
                 e, f, g, h,
                 rows = 3,
                 columns = 3,
-                skips= "0:1x2,4:1x1,6:1x1",
+                skips = arrayOf(Skip(0, 1, 2), Skip(4, 1, 1), Skip(6, 1,1))
             )
 
             val g2 = createGrid(
                 g1, a, b, c, d,
                 rows = 3,
                 columns = 3,
-                skips = "1:1x1,4:1x1,6:1x1",
+                skips = arrayOf(Skip(1, 1, 1), Skip(4, 1, 1), Skip(6, 1,1)),
             )
 
 

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/GridDslMedium.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/GridDslMedium.kt
@@ -59,8 +59,8 @@ public fun GridDslKeypad() {
                 columns = 3,
                 verticalGap = 25.dp,
                 horizontalGap = 25.dp,
-                spans = "0:1x3",
-                skips = "12:1x1",
+                spans = arrayOf(Span(0, 1, 3)),
+                skips = arrayOf(Skip(12, 1, 1)),
                 rowWeights = weights,
             )
 
@@ -156,7 +156,7 @@ public fun GridDslMediumCalculator() {
                 columns = 4,
                 verticalGap = 10.dp,
                 horizontalGap = 10.dp,
-                spans = "0:2x4,24:1x2",
+                spans = arrayOf(Span(0, 2, 4), Span(24, 1, 2)),
             )
 
             constrain(g1) {
@@ -288,14 +288,14 @@ public fun GridDslMediumNested() {
                 btn5, btn6, btn7, btn8,
                 rows = 3,
                 columns = 3,
-                skips= "0:1x2,4:1x1,6:1x1",
+                skips = arrayOf(Skip(0, 1, 2), Skip(4, 1, 1), Skip(6, 1, 1))
             )
 
             val g2 = createGrid(
                 g1, btn1, btn2, btn3, btn4,
                 rows = 3,
                 columns = 3,
-                skips = "1:1x1,4:1x1,6:1x1",
+                skips = arrayOf(Skip(1, 1, 1), Skip(4, 1, 1), Skip(6, 1, 1))
             )
 
             constrain(g1) {


### PR DESCRIPTION
Sync the update of the Skips and Spans DSL representation from String to a custom object based on the suggestions from the API Council. Two tests, RowColumnDslTest.kt and GridDslTest.kt are also synced back to the Github repo.
