### PR TITLE
[Row & Column feature parity] LastBaseline alignment experiment

### DIFF
--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstrainScope.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstrainScope.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.LayoutScopeMarker
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.layout.FirstBaseline
+import androidx.compose.ui.layout.LastBaseline
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.core.parser.CLArray
@@ -82,6 +83,11 @@ class ConstrainScope internal constructor(
      * The [FirstBaseline] of the layout - can be constrained using [BaselineAnchorable.linkTo].
      */
     val baseline: BaselineAnchorable = ConstraintBaselineAnchorable(containerObject)
+
+    /**
+     * The [LastBaseline] of the layout - can be constrained using [LastBaselineAnchorable.linkTo].
+     */
+    val lastBaseline: LastBaselineAnchorable = ConstraintLastBaselineAnchorable(containerObject)
 
     /**
      * The width of the [ConstraintLayout] child.
@@ -399,6 +405,7 @@ class ConstrainScope internal constructor(
         containerObject.remove("top")
         containerObject.remove("bottom")
         containerObject.remove("baseline")
+        containerObject.remove("lastBaseline")
     }
 
     /**
@@ -524,6 +531,23 @@ private class ConstraintBaselineAnchorable constructor(
     }
 
     /**
+     * Adds a link towards a [ConstraintLayoutBaseScope.LastBaselineAnchor].
+     */
+    override fun linkTo(
+        anchor: ConstraintLayoutBaseScope.LastBaselineAnchor,
+        margin: Dp,
+        goneMargin: Dp
+    ) {
+        val constraintArray = CLArray(charArrayOf()).apply {
+            add(CLString.from(anchor.id.toString()))
+            add(CLString.from("lastBaseline"))
+            add(CLNumber(margin.value))
+            add(CLNumber(goneMargin.value))
+        }
+        containerObject.put("baseline", constraintArray)
+    }
+
+    /**
      * Adds a link towards a [ConstraintLayoutBaseScope.HorizontalAnchor].
      */
     override fun linkTo(
@@ -539,5 +563,65 @@ private class ConstraintBaselineAnchorable constructor(
             add(CLNumber(goneMargin.value))
         }
         containerObject.put("baseline", constraintArray)
+    }
+}
+
+/**
+ * Represents the [LastBaseline] of a layout that can be anchored
+ * using [linkTo] in their `Modifier.constrainAs` blocks.
+ */
+private class ConstraintLastBaselineAnchorable constructor(
+    private val containerObject: CLObject
+) : LastBaselineAnchorable {
+    /**
+     * Adds a link towards a [ConstraintLayoutBaseScope.BaselineAnchor].
+     */
+    override fun linkTo(
+        anchor: ConstraintLayoutBaseScope.BaselineAnchor,
+        margin: Dp,
+        goneMargin: Dp
+    ) {
+        val constraintArray = CLArray(charArrayOf()).apply {
+            add(CLString.from(anchor.id.toString()))
+            add(CLString.from("baseline"))
+            add(CLNumber(margin.value))
+            add(CLNumber(goneMargin.value))
+        }
+        containerObject.put("lastBaseline", constraintArray)
+    }
+
+    /**
+     * Adds a link towards a [ConstraintLayoutBaseScope.LastBaselineAnchor].
+     */
+    override fun linkTo(
+        anchor: ConstraintLayoutBaseScope.LastBaselineAnchor,
+        margin: Dp,
+        goneMargin: Dp
+    ) {
+        val constraintArray = CLArray(charArrayOf()).apply {
+            add(CLString.from(anchor.id.toString()))
+            add(CLString.from("lastBaseline"))
+            add(CLNumber(margin.value))
+            add(CLNumber(goneMargin.value))
+        }
+        containerObject.put("lastBaseline", constraintArray)
+    }
+
+    /**
+     * Adds a link towards a [ConstraintLayoutBaseScope.HorizontalAnchor].
+     */
+    override fun linkTo(
+        anchor: ConstraintLayoutBaseScope.HorizontalAnchor,
+        margin: Dp,
+        goneMargin: Dp
+    ) {
+        val targetAnchorName = AnchorFunctions.horizontalAnchorIndexToAnchorName(anchor.index)
+        val constraintArray = CLArray(charArrayOf()).apply {
+            add(CLString.from(anchor.id.toString()))
+            add(CLString.from(targetAnchorName))
+            add(CLNumber(margin.value))
+            add(CLNumber(goneMargin.value))
+        }
+        containerObject.put("lastBaseline", constraintArray)
     }
 }

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayout.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayout.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.layout.AlignmentLine
 import androidx.compose.ui.layout.FirstBaseline
+import androidx.compose.ui.layout.LastBaseline
 import androidx.compose.ui.layout.LayoutIdParentData
 import androidx.compose.ui.layout.Measurable
 import androidx.compose.ui.layout.MeasurePolicy
@@ -1210,6 +1211,8 @@ internal open class Measurer(
         val baseline =
             if (currentPlaceable != null && state.isBaselineNeeded(constraintWidget)) {
                 currentPlaceable[FirstBaseline]
+            } else if (currentPlaceable != null && state.isLastBaselineNeeded(constraintWidget)) {
+                currentPlaceable[LastBaseline]
             } else {
                 AlignmentLine.Unspecified
             }

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayoutBaseScope.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintLayoutBaseScope.kt
@@ -19,6 +19,7 @@ package androidx.constraintlayout.compose
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.layout.FirstBaseline
+import androidx.compose.ui.layout.LastBaseline
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.core.parser.CLArray
@@ -101,6 +102,19 @@ abstract class ConstraintLayoutBaseScope internal constructor(extendFrom: CLObje
     // TODO(popam): investigate if this can be just a HorizontalAnchor
     @Stable
     data class BaselineAnchor internal constructor(
+        internal val id: Any,
+        val reference: LayoutReference
+    )
+
+    /**
+     * Represents a horizontal anchor corresponding to the [LastBaseline] of a layout that other
+     * layouts can link to in their `Modifier.constrainAs` or `constrain` blocks.
+     *
+     * @param reference The [LayoutReference] that this anchor belongs to.
+     */
+    // TODO(popam): investigate if this can be just a HorizontalAnchor
+    @Stable
+    data class LastBaselineAnchor internal constructor(
         internal val id: Any,
         val reference: LayoutReference
     )
@@ -1740,6 +1754,12 @@ class ConstrainedLayoutReference(override val id: Any) : LayoutReference(id) {
      */
     @Stable
     val baseline = ConstraintLayoutBaseScope.BaselineAnchor(id, this)
+
+    /**
+     * The lastBaseline anchor of this layout.
+     */
+    @Stable
+    val lastBaseline = ConstraintLayoutBaseScope.LastBaselineAnchor(id, this)
 }
 
 /**
@@ -1918,6 +1938,7 @@ class VerticalAlign internal constructor(
         val Bottom = VerticalAlign("bottom")
         val Center = VerticalAlign("center")
         val Baseline = VerticalAlign("baseline")
+        val LastBaseline = VerticalAlign("lastBaseline")
     }
 }
 

--- a/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintScopeCommon.kt
+++ b/constraintlayout/compose/src/main/java/androidx/constraintlayout/compose/ConstraintScopeCommon.kt
@@ -18,6 +18,7 @@ package androidx.constraintlayout.compose
 
 import android.util.Log
 import androidx.compose.ui.layout.FirstBaseline
+import androidx.compose.ui.layout.LastBaseline
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.core.parser.CLArray
@@ -64,6 +65,15 @@ interface HorizontalAnchorable {
         margin: Dp = 0.dp,
         goneMargin: Dp = 0.dp
     )
+
+    /**
+     * Adds a link towards a [ConstraintLayoutBaseScope.LastBaselineAnchor].
+     */
+    fun linkTo(
+        anchor: ConstraintLayoutBaseScope.LastBaselineAnchor,
+        margin: Dp = 0.dp,
+        goneMargin: Dp = 0.dp
+    )
 }
 
 @JvmDefaultWithCompatibility
@@ -77,6 +87,49 @@ interface BaselineAnchorable {
      */
     fun linkTo(
         anchor: ConstraintLayoutBaseScope.BaselineAnchor,
+        margin: Dp = 0.dp,
+        goneMargin: Dp = 0.dp
+    )
+
+    /**
+     * Adds a link towards a [ConstraintLayoutBaseScope.LastBaselineAnchor].
+     */
+    fun linkTo(
+        anchor: ConstraintLayoutBaseScope.LastBaselineAnchor,
+        margin: Dp = 0.dp,
+        goneMargin: Dp = 0.dp
+    )
+
+    /**
+     * Adds a link towards a [ConstraintLayoutBaseScope.HorizontalAnchor].
+     */
+    fun linkTo(
+        anchor: ConstraintLayoutBaseScope.HorizontalAnchor,
+        margin: Dp = 0.dp,
+        goneMargin: Dp = 0.dp
+    )
+}
+
+@JvmDefaultWithCompatibility
+/**
+ * Represents the [LastBaseline] of a layout that can be anchored
+ * using [linkTo] in their `Modifier.constrainAs` blocks.
+ */
+interface LastBaselineAnchorable {
+    /**
+     * Adds a link towards a [ConstraintLayoutBaseScope.BaselineAnchor].
+     */
+    fun linkTo(
+        anchor: ConstraintLayoutBaseScope.BaselineAnchor,
+        margin: Dp = 0.dp,
+        goneMargin: Dp = 0.dp
+    )
+
+    /**
+     * Adds a link towards a [ConstraintLayoutBaseScope.LastBaselineAnchor].
+     */
+    fun linkTo(
+        anchor: ConstraintLayoutBaseScope.LastBaselineAnchor,
         margin: Dp = 0.dp,
         goneMargin: Dp = 0.dp
     )
@@ -142,6 +195,20 @@ internal abstract class BaseHorizontalAnchorable(
         val constraintArray = CLArray(charArrayOf()).apply {
             add(CLString.from(anchor.id.toString()))
             add(CLString.from("baseline"))
+            add(CLNumber(margin.value))
+            add(CLNumber(goneMargin.value))
+        }
+        containerObject.put(anchorName, constraintArray)
+    }
+
+    final override fun linkTo(
+        anchor: ConstraintLayoutBaseScope.LastBaselineAnchor,
+        margin: Dp,
+        goneMargin: Dp
+    ) {
+        val constraintArray = CLArray(charArrayOf()).apply {
+            add(CLString.from(anchor.id.toString()))
+            add(CLString.from("lastBaseline"))
             add(CLNumber(margin.value))
             add(CLNumber(goneMargin.value))
         }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintReference.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintReference.java
@@ -87,7 +87,9 @@ public class ConstraintReference implements Reference {
     protected int mMarginBottomGone = 0;
 
     int mMarginBaseline = 0;
+    int mMarginLastBaseline = 0;
     int mMarginBaselineGone = 0;
+    int mMarginLastBaselineGone = 0;
 
     float mPivotX = Float.NaN;
     float mPivotY = Float.NaN;
@@ -118,12 +120,19 @@ public class ConstraintReference implements Reference {
     protected Object mTopToTop = null;
     protected Object mTopToBottom = null;
     @Nullable Object mTopToBaseline = null;
+    @Nullable Object mTopToLastBaseline = null;
     protected Object mBottomToTop = null;
     protected Object mBottomToBottom = null;
     @Nullable Object mBottomToBaseline = null;
+    @Nullable Object mBottomToLastBaseline = null;
     Object mBaselineToBaseline = null;
+    Object mBaselineToLastBaseline = null;
     Object mBaselineToTop = null;
     Object mBaselineToBottom = null;
+    Object mLastBaselineToTop = null;
+    Object mLastBaselineToBottom = null;
+    Object mLastBaselineToBaseline = null;
+    Object mLastBaselineToLastBaseline = null;
     Object mCircularConstraint = null;
     private float mCircularAngle;
     private float mCircularDistance;
@@ -292,6 +301,7 @@ public class ConstraintReference implements Reference {
     public ConstraintReference clearVertical() {
         top().clear();
         baseline().clear();
+        lastBaseline().clear();
         bottom().clear();
         return this;
     }
@@ -488,6 +498,12 @@ public class ConstraintReference implements Reference {
     }
 
     // @TODO: add description
+    public ConstraintReference lastBaseline() {
+        mLast = State.Constraint.LASTBASELINE_TO_LASTBASELINE;
+        return this;
+    }
+
+    // @TODO: add description
     public void addCustomColor(String name, int color) {
         mCustomColors.put(name, color);
     }
@@ -514,8 +530,13 @@ public class ConstraintReference implements Reference {
         mBottomToTop = get(mBottomToTop);
         mBottomToBottom = get(mBottomToBottom);
         mBaselineToBaseline = get(mBaselineToBaseline);
+        mBaselineToLastBaseline = get(mBaselineToLastBaseline);
         mBaselineToTop = get(mBaselineToTop);
         mBaselineToBottom = get(mBaselineToBottom);
+        mLastBaselineToBaseline = get(mLastBaselineToBaseline);
+        mLastBaselineToLastBaseline = get(mLastBaselineToLastBaseline);
+        mLastBaselineToTop = get(mLastBaselineToTop);
+        mLastBaselineToBottom = get(mLastBaselineToBottom);
     }
 
     // @TODO: add description
@@ -594,6 +615,12 @@ public class ConstraintReference implements Reference {
         return this;
     }
 
+    ConstraintReference topToLastBaseline(Object reference) {
+        mLast = State.Constraint.TOP_TO_LASTBASELINE;
+        mTopToLastBaseline = reference;
+        return this;
+    }
+
     // @TODO: add description
     public ConstraintReference bottomToTop(Object reference) {
         mLast = State.Constraint.BOTTOM_TO_TOP;
@@ -614,10 +641,23 @@ public class ConstraintReference implements Reference {
         return this;
     }
 
+    ConstraintReference bottomToLastBaseline(Object reference) {
+        mLast = State.Constraint.BOTTOM_TO_LASTBASELINE;
+        mBottomToLastBaseline = reference;
+        return this;
+    }
+
     // @TODO: add description
     public ConstraintReference baselineToBaseline(Object reference) {
         mLast = State.Constraint.BASELINE_TO_BASELINE;
         mBaselineToBaseline = reference;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference baselineToLastBaseline(Object reference) {
+        mLast = State.Constraint.BASELINE_TO_LASTBASELINE;
+        mBaselineToLastBaseline = reference;
         return this;
     }
 
@@ -632,6 +672,34 @@ public class ConstraintReference implements Reference {
     public ConstraintReference baselineToBottom(Object reference) {
         mLast = State.Constraint.BASELINE_TO_BOTTOM;
         mBaselineToBottom = reference;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference lastBaselineToTop(Object reference) {
+        mLast = State.Constraint.LASTBASELINE_TO_TOP;
+        mLastBaselineToTop = reference;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference lastBaselineToBottom(Object reference) {
+        mLast = State.Constraint.LASTBASELINE_TO_BOTTOM;
+        mLastBaselineToBottom = reference;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference lastBaselineToBaseline(Object reference) {
+        mLast = State.Constraint.LASTBASELINE_TO_BASELINE;
+        mLastBaselineToBaseline = reference;
+        return this;
+    }
+
+    // @TODO: add description
+    public ConstraintReference lastBaselineToLastBaseline(Object reference) {
+        mLast = State.Constraint.LASTBASELINE_TO_LASTBASELINE;
+        mLastBaselineToLastBaseline = reference;
         return this;
     }
 
@@ -731,20 +799,30 @@ public class ConstraintReference implements Reference {
                 break;
                 case TOP_TO_TOP:
                 case TOP_TO_BOTTOM:
-                case TOP_TO_BASELINE: {
+                case TOP_TO_BASELINE:
+                case TOP_TO_LASTBASELINE: {
                     mMarginTop = value;
                 }
                 break;
                 case BOTTOM_TO_TOP:
                 case BOTTOM_TO_BOTTOM:
-                case BOTTOM_TO_BASELINE: {
+                case BOTTOM_TO_BASELINE:
+                case BOTTOM_TO_LASTBASELINE: {
                     mMarginBottom = value;
                 }
                 break;
                 case BASELINE_TO_BOTTOM:
                 case BASELINE_TO_TOP:
-                case BASELINE_TO_BASELINE: {
+                case BASELINE_TO_BASELINE:
+                case BASELINE_TO_LASTBASELINE: {
                     mMarginBaseline = value;
+                }
+                break;
+                case LASTBASELINE_TO_BOTTOM:
+                case LASTBASELINE_TO_TOP:
+                case LASTBASELINE_TO_BASELINE:
+                case LASTBASELINE_TO_LASTBASELINE: {
+                    mMarginLastBaseline = value;
                 }
                 break;
                 case CIRCULAR_CONSTRAINT: {
@@ -791,20 +869,30 @@ public class ConstraintReference implements Reference {
                 break;
                 case TOP_TO_TOP:
                 case TOP_TO_BOTTOM:
-                case TOP_TO_BASELINE: {
+                case TOP_TO_BASELINE:
+                case TOP_TO_LASTBASELINE: {
                     mMarginTopGone = value;
                 }
                 break;
                 case BOTTOM_TO_TOP:
                 case BOTTOM_TO_BOTTOM:
-                case BOTTOM_TO_BASELINE: {
+                case BOTTOM_TO_BASELINE:
+                case BOTTOM_TO_LASTBASELINE: {
                     mMarginBottomGone = value;
                 }
                 break;
                 case BASELINE_TO_TOP:
                 case BASELINE_TO_BOTTOM:
-                case BASELINE_TO_BASELINE: {
+                case BASELINE_TO_BASELINE:
+                case BASELINE_TO_LASTBASELINE: {
                     mMarginBaselineGone = value;
+                }
+                break;
+                case LASTBASELINE_TO_TOP:
+                case LASTBASELINE_TO_BOTTOM:
+                case LASTBASELINE_TO_BASELINE:
+                case LASTBASELINE_TO_LASTBASELINE: {
+                    mMarginLastBaselineGone = value;
                 }
                 break;
                 default:
@@ -855,9 +943,11 @@ public class ConstraintReference implements Reference {
             case TOP_TO_TOP:
             case TOP_TO_BOTTOM:
             case TOP_TO_BASELINE:
+            case TOP_TO_LASTBASELINE:
             case BOTTOM_TO_TOP:
             case BOTTOM_TO_BOTTOM:
-            case BOTTOM_TO_BASELINE: {
+            case BOTTOM_TO_BASELINE:
+            case BOTTOM_TO_LASTBASELINE: {
                 mVerticalBias = value;
             }
             break;
@@ -890,6 +980,11 @@ public class ConstraintReference implements Reference {
         mBottomToBottom = null;
         mMarginBottom = 0;
         mBaselineToBaseline = null;
+        mLastBaselineToTop = null;
+        mLastBaselineToBottom = null;
+        mLastBaselineToLastBaseline = null;
+        mLastBaselineToBaseline = null;
+        mMarginLastBaseline = 0;
         mCircularConstraint = null;
         mHorizontalBias = 0.5f;
         mVerticalBias = 0.5f;
@@ -940,26 +1035,46 @@ public class ConstraintReference implements Reference {
                 break;
                 case TOP_TO_TOP:
                 case TOP_TO_BOTTOM:
-                case TOP_TO_BASELINE: {
+                case TOP_TO_BASELINE:
+                case TOP_TO_LASTBASELINE: {
                     mTopToTop = null;
                     mTopToBottom = null;
                     mTopToBaseline = null;
+                    mTopToLastBaseline = null;
                     mMarginTop = 0;
                     mMarginTopGone = 0;
                 }
                 break;
                 case BOTTOM_TO_TOP:
                 case BOTTOM_TO_BOTTOM:
-                case BOTTOM_TO_BASELINE: {
+                case BOTTOM_TO_BASELINE:
+                case BOTTOM_TO_LASTBASELINE: {
                     mBottomToTop = null;
                     mBottomToBottom = null;
                     mBottomToBaseline = null;
+                    mBottomToLastBaseline = null;
                     mMarginBottom = 0;
                     mMarginBottomGone = 0;
                 }
                 break;
                 case BASELINE_TO_BASELINE: {
                     mBaselineToBaseline = null;
+                }
+                break;
+                case LASTBASELINE_TO_LASTBASELINE: {
+                    mLastBaselineToLastBaseline = null;
+                }
+                break;
+                case LASTBASELINE_TO_BASELINE: {
+                    mLastBaselineToBaseline = null;
+                }
+                break;
+                case LASTBASELINE_TO_TOP: {
+                    mLastBaselineToTop = null;
+                }
+                break;
+                case LASTBASELINE_TO_BOTTOM: {
+                    mLastBaselineToBottom = null;
                 }
                 break;
                 case CIRCULAR_CONSTRAINT: {
@@ -1046,7 +1161,8 @@ public class ConstraintReference implements Reference {
                         ConstraintAnchor.Type.BOTTOM), mMarginTop, mMarginTopGone, false);
             }
             break;
-            case TOP_TO_BASELINE: {
+            case TOP_TO_BASELINE:
+            case TOP_TO_LASTBASELINE: {
                 widget.immediateConnect(ConstraintAnchor.Type.TOP, target,
                         ConstraintAnchor.Type.BASELINE, mMarginTop, mMarginTopGone);
             }
@@ -1061,22 +1177,28 @@ public class ConstraintReference implements Reference {
                         ConstraintAnchor.Type.BOTTOM), mMarginBottom, mMarginBottomGone, false);
             }
             break;
-            case BOTTOM_TO_BASELINE: {
+            case BOTTOM_TO_BASELINE:
+            case BOTTOM_TO_LASTBASELINE: {
                 widget.immediateConnect(ConstraintAnchor.Type.BOTTOM, target,
                         ConstraintAnchor.Type.BASELINE, mMarginBottom, mMarginBottomGone);
             }
             break;
-            case BASELINE_TO_BASELINE: {
+            case BASELINE_TO_BASELINE:
+            case BASELINE_TO_LASTBASELINE:
+            case LASTBASELINE_TO_BASELINE:
+            case LASTBASELINE_TO_LASTBASELINE: {
                 widget.immediateConnect(ConstraintAnchor.Type.BASELINE, target,
                         ConstraintAnchor.Type.BASELINE, mMarginBaseline, mMarginBaselineGone);
             }
             break;
-            case BASELINE_TO_TOP: {
+            case BASELINE_TO_TOP:
+            case LASTBASELINE_TO_TOP: {
                 widget.immediateConnect(ConstraintAnchor.Type.BASELINE,
                         target, ConstraintAnchor.Type.TOP, mMarginBaseline, mMarginBaselineGone);
             }
             break;
-            case BASELINE_TO_BOTTOM: {
+            case BASELINE_TO_BOTTOM:
+            case LASTBASELINE_TO_BOTTOM: {
                 widget.immediateConnect(ConstraintAnchor.Type.BASELINE, target,
                         ConstraintAnchor.Type.BOTTOM, mMarginBaseline, mMarginBaselineGone);
             }
@@ -1105,13 +1227,27 @@ public class ConstraintReference implements Reference {
         applyConnection(mConstraintWidget, mTopToTop, State.Constraint.TOP_TO_TOP);
         applyConnection(mConstraintWidget, mTopToBottom, State.Constraint.TOP_TO_BOTTOM);
         applyConnection(mConstraintWidget, mTopToBaseline, State.Constraint.TOP_TO_BASELINE);
+        applyConnection(mConstraintWidget, mTopToLastBaseline,
+                State.Constraint.TOP_TO_LASTBASELINE);
         applyConnection(mConstraintWidget, mBottomToTop, State.Constraint.BOTTOM_TO_TOP);
         applyConnection(mConstraintWidget, mBottomToBottom, State.Constraint.BOTTOM_TO_BOTTOM);
         applyConnection(mConstraintWidget, mBottomToBaseline, State.Constraint.BOTTOM_TO_BASELINE);
+        applyConnection(mConstraintWidget, mBottomToLastBaseline,
+                State.Constraint.BOTTOM_TO_LASTBASELINE);
         applyConnection(mConstraintWidget, mBaselineToBaseline,
                 State.Constraint.BASELINE_TO_BASELINE);
+        applyConnection(mConstraintWidget, mBaselineToLastBaseline,
+                State.Constraint.BASELINE_TO_LASTBASELINE);
         applyConnection(mConstraintWidget, mBaselineToTop, State.Constraint.BASELINE_TO_TOP);
         applyConnection(mConstraintWidget, mBaselineToBottom, State.Constraint.BASELINE_TO_BOTTOM);
+        applyConnection(mConstraintWidget, mLastBaselineToBaseline,
+                State.Constraint.LASTBASELINE_TO_BASELINE);
+        applyConnection(mConstraintWidget, mLastBaselineToLastBaseline,
+                State.Constraint.LASTBASELINE_TO_LASTBASELINE);
+        applyConnection(mConstraintWidget, mLastBaselineToTop,
+                State.Constraint.LASTBASELINE_TO_TOP);
+        applyConnection(mConstraintWidget, mLastBaselineToBottom,
+                State.Constraint.LASTBASELINE_TO_BOTTOM);
         applyConnection(mConstraintWidget, mCircularConstraint,
                 State.Constraint.CIRCULAR_CONSTRAINT);
     }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintSetParser.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/ConstraintSetParser.java
@@ -411,6 +411,7 @@ public class ConstraintSetParser {
                             base.remove("top");
                             base.remove("bottom");
                             base.remove("baseline");
+                            base.remove("lastBaseline");
                             base.remove("center");
                             base.remove("centerHorizontally");
                             base.remove("centerVertically");
@@ -1867,6 +1868,10 @@ public class ConstraintSetParser {
                             state.baselineNeededFor(targetReference.getKey());
                             reference.topToBaseline(targetReference);
                             break;
+                        case "lastBaseline":
+                            state.lastBaselineNeededFor(targetReference.getKey());
+                            reference.topToLastBaseline(targetReference);
+                            break;
                     }
                     break;
                 case "bottom":
@@ -1880,6 +1885,9 @@ public class ConstraintSetParser {
                         case "baseline":
                             state.baselineNeededFor(targetReference.getKey());
                             reference.bottomToBaseline(targetReference);
+                        case "lastBaseline":
+                            state.lastBaselineNeededFor(targetReference.getKey());
+                            reference.bottomToLastBaseline(targetReference);
                     }
                     break;
                 case "baseline":
@@ -1889,6 +1897,11 @@ public class ConstraintSetParser {
                             state.baselineNeededFor(targetReference.getKey());
                             reference.baselineToBaseline(targetReference);
                             break;
+                        case "lastBaseline":
+                            state.lastBaselineNeededFor(reference.getKey());
+                            state.lastBaselineNeededFor(targetReference.getKey());
+                            reference.baselineToLastBaseline(targetReference);
+                            break;
                         case "top":
                             state.baselineNeededFor(reference.getKey());
                             reference.baselineToTop(targetReference);
@@ -1896,6 +1909,28 @@ public class ConstraintSetParser {
                         case "bottom":
                             state.baselineNeededFor(reference.getKey());
                             reference.baselineToBottom(targetReference);
+                            break;
+                    }
+                    break;
+                case "lastBaseline":
+                    switch (anchor) {
+                        case "baseline":
+                            state.lastBaselineNeededFor(reference.getKey());
+                            state.lastBaselineNeededFor(targetReference.getKey());
+                            reference.lastBaselineToBaseline(targetReference);
+                            break;
+                        case "lastBaseline":
+                            state.lastBaselineNeededFor(reference.getKey());
+                            state.lastBaselineNeededFor(targetReference.getKey());
+                            reference.lastBaselineToLastBaseline(targetReference);
+                            break;
+                        case "top":
+                            state.lastBaselineNeededFor(reference.getKey());
+                            reference.lastBaselineToTop(targetReference);
+                            break;
+                        case "bottom":
+                            state.lastBaselineNeededFor(reference.getKey());
+                            reference.lastBaselineToBottom(targetReference);
                             break;
                     }
                     break;
@@ -1983,6 +2018,11 @@ public class ConstraintSetParser {
                         state.baselineNeededFor(reference.getKey());
                         state.baselineNeededFor(targetReference.getKey());
                         reference.baselineToBaseline(targetReference);
+                        break;
+                    case "lastBaseline":
+                        state.lastBaselineNeededFor(reference.getKey());
+                        state.lastBaselineNeededFor(targetReference.getKey());
+                        reference.lastBaselineToLastBaseline(targetReference);
                         break;
                 }
             }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/State.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/state/State.java
@@ -68,12 +68,19 @@ public class State {
         TOP_TO_TOP,
         TOP_TO_BOTTOM,
         TOP_TO_BASELINE,
+        TOP_TO_LASTBASELINE,
         BOTTOM_TO_TOP,
         BOTTOM_TO_BOTTOM,
         BOTTOM_TO_BASELINE,
+        BOTTOM_TO_LASTBASELINE,
         BASELINE_TO_BASELINE,
+        BASELINE_TO_LASTBASELINE,
         BASELINE_TO_TOP,
+        LASTBASELINE_TO_TOP,
         BASELINE_TO_BOTTOM,
+        LASTBASELINE_TO_BOTTOM,
+        LASTBASELINE_TO_BASELINE,
+        LASTBASELINE_TO_LASTBASELINE,
         CENTER_HORIZONTALLY,
         CENTER_VERTICALLY,
         CIRCULAR_CONSTRAINT
@@ -687,5 +694,36 @@ public class State {
             mDirtyBaselineNeededWidgets = false;
         }
         return mBaselineNeededWidgets.contains(constraintWidget);
+    }
+
+    // ================= add lastBaseline code================================
+    ArrayList<Object> mLastBaselineNeeded = new ArrayList<>();
+    ArrayList<ConstraintWidget> mLastBaselineNeededWidgets = new ArrayList<>();
+    boolean mDirtyLastBaselineNeededWidgets = true;
+
+    /**
+     * Baseline is needed for this object
+     */
+    public void lastBaselineNeededFor(Object id) {
+        mLastBaselineNeeded.add(id);
+        mDirtyLastBaselineNeededWidgets = true;
+    }
+
+    /**
+     * Does this constraintWidget need a lastBaseline
+     *
+     * @return true if the constraintWidget needs a lastBaseline
+     */
+    public boolean isLastBaselineNeeded(ConstraintWidget constraintWidget) {
+        if (mDirtyLastBaselineNeededWidgets) {
+            mLastBaselineNeededWidgets.clear();
+            for (Object id : mLastBaselineNeeded) {
+                ConstraintWidget widget = mReferences.get(id).getConstraintWidget();
+                if (widget != null) mLastBaselineNeededWidgets.add(widget);
+            }
+
+            mDirtyLastBaselineNeededWidgets = false;
+        }
+        return mLastBaselineNeededWidgets.contains(constraintWidget);
     }
 }

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/widgets/ConstraintAnchor.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/widgets/ConstraintAnchor.java
@@ -100,7 +100,8 @@ public class ConstraintAnchor {
     /**
      * Define the type of anchor
      */
-    public enum Type {NONE, LEFT, TOP, RIGHT, BOTTOM, BASELINE, CENTER, CENTER_X, CENTER_Y}
+    public enum Type {NONE, LEFT, TOP, RIGHT, BOTTOM, BASELINE,
+        LAST_BASELINE, CENTER, CENTER_X, CENTER_Y}
 
     private static final int UNSET_GONE_MARGIN = Integer.MIN_VALUE;
 
@@ -286,14 +287,17 @@ public class ConstraintAnchor {
             if (mType == Type.BASELINE
                     && (!anchor.getOwner().hasBaseline() || !getOwner().hasBaseline())) {
                 return false;
+            } else if (mType == Type.LAST_BASELINE
+                    && (!anchor.getOwner().hasLastBaseline() || !getOwner().hasLastBaseline())) {
+                return false;
             }
             return true;
         }
         switch (mType) {
             case CENTER: {
                 // allow everything but baseline and center_x/center_y
-                return target != Type.BASELINE && target != Type.CENTER_X
-                        && target != Type.CENTER_Y;
+                return target != Type.BASELINE && target != Type.LAST_BASELINE
+                        && target != Type.CENTER_X && target != Type.CENTER_Y;
             }
             case LEFT:
             case RIGHT: {
@@ -311,7 +315,8 @@ public class ConstraintAnchor {
                 }
                 return isCompatible;
             }
-            case BASELINE: {
+            case BASELINE:
+            case LAST_BASELINE: {
                 if (target == Type.LEFT || target == Type.RIGHT) {
                     return false;
                 }
@@ -338,6 +343,7 @@ public class ConstraintAnchor {
             case BOTTOM:
                 return true;
             case BASELINE:
+            case LAST_BASELINE:
             case CENTER:
             case CENTER_X:
             case CENTER_Y:
@@ -361,7 +367,7 @@ public class ConstraintAnchor {
         }
         switch (mType) {
             case CENTER: {
-                return target != Type.BASELINE;
+                return target != Type.BASELINE && target != Type.LAST_BASELINE;
             }
             case LEFT:
             case RIGHT:
@@ -371,9 +377,10 @@ public class ConstraintAnchor {
             case TOP:
             case BOTTOM:
             case CENTER_Y:
-            case BASELINE: {
-                return target == Type.TOP || target == Type.BOTTOM
-                        || target == Type.CENTER_Y || target == Type.BASELINE;
+            case BASELINE:
+            case LAST_BASELINE: {
+                return target == Type.TOP || target == Type.BOTTOM || target == Type.CENTER_Y
+                        || target == Type.BASELINE || target == Type.LAST_BASELINE;
             }
             case NONE:
                 return false;
@@ -419,6 +426,7 @@ public class ConstraintAnchor {
             case TOP:
             case BOTTOM:
             case BASELINE:
+            case LAST_BASELINE:
             case NONE:
                 return true;
         }
@@ -525,6 +533,7 @@ public class ConstraintAnchor {
                 return mOwner.mTop;
             }
             case BASELINE:
+            case LAST_BASELINE:
             case CENTER:
             case CENTER_X:
             case CENTER_Y:

--- a/constraintlayout/core/src/main/java/androidx/constraintlayout/core/widgets/ConstraintWidget.java
+++ b/constraintlayout/core/src/main/java/androidx/constraintlayout/core/widgets/ConstraintWidget.java
@@ -190,6 +190,9 @@ public class ConstraintWidget {
         if (mHasBaseline) {
             mBaseline.setFinalValue(y1 + mBaselineDistance);
         }
+        if (mHasLastBaseline) {
+            mLastBaseline.setFinalValue(y1 + mLastBaselineDistance);
+        }
         mResolvedVertical = true;
         if (LinearSystem.FULL_DEBUG) {
             System.out.println("*** SET FINAL VERTICAL FOR " + getDebugName()
@@ -208,6 +211,20 @@ public class ConstraintWidget {
         mTop.setFinalValue(y1);
         mBottom.setFinalValue(y2);
         mBaseline.setFinalValue(baselineValue);
+        mResolvedVertical = true;
+    }
+
+    // @TODO: add description
+    public void setFinalLastBaseline(int lastBaselineValue) {
+        if (!mHasLastBaseline) {
+            return;
+        }
+        int y1 = lastBaselineValue - mLastBaselineDistance;
+        int y2 = y1 + mHeight;
+        mY = y1;
+        mTop.setFinalValue(y1);
+        mBottom.setFinalValue(y2);
+        mLastBaseline.setFinalValue(lastBaselineValue);
         mResolvedVertical = true;
     }
 
@@ -255,7 +272,8 @@ public class ConstraintWidget {
             return horizontalTargets < 2;
         } else {
             int verticalTargets = (mTop.mTarget != null ? 1 : 0)
-                    + (mBottom.mTarget != null ? 1 : 0) + (mBaseline.mTarget != null ? 1 : 0);
+                    + (mBottom.mTarget != null ? 1 : 0)
+                    + (mBaseline.mTarget != null || mLastBaseline.mTarget != null ? 1 : 0);
             return verticalTargets < 2;
         }
     }
@@ -333,6 +351,7 @@ public class ConstraintWidget {
     private int[] mMaxDimension = {Integer.MAX_VALUE, Integer.MAX_VALUE};
     public float mCircleConstraintAngle = Float.NaN;
     private boolean mHasBaseline = false;
+    private boolean mHasLastBaseline = false;
     private boolean mInPlaceholder;
 
     private boolean mInVirtualLayout = false;
@@ -383,6 +402,14 @@ public class ConstraintWidget {
 
     public boolean getHasBaseline() {
         return mHasBaseline;
+    }
+
+    public boolean getHasLastBaseline() {
+        return mHasLastBaseline;
+    }
+
+    public void setHasLastBaseline(boolean hasLastBaseline) {
+        this.mHasLastBaseline = hasLastBaseline;
     }
 
     public boolean isInPlaceholder() {
@@ -457,6 +484,8 @@ public class ConstraintWidget {
     public ConstraintAnchor mRight = new ConstraintAnchor(this, ConstraintAnchor.Type.RIGHT);
     public ConstraintAnchor mBottom = new ConstraintAnchor(this, ConstraintAnchor.Type.BOTTOM);
     public ConstraintAnchor mBaseline = new ConstraintAnchor(this, ConstraintAnchor.Type.BASELINE);
+    public ConstraintAnchor mLastBaseline = new ConstraintAnchor(this,
+            ConstraintAnchor.Type.LAST_BASELINE);
     ConstraintAnchor mCenterX = new ConstraintAnchor(this, ConstraintAnchor.Type.CENTER_X);
     ConstraintAnchor mCenterY = new ConstraintAnchor(this, ConstraintAnchor.Type.CENTER_Y);
     public ConstraintAnchor mCenter = new ConstraintAnchor(this, ConstraintAnchor.Type.CENTER);
@@ -499,6 +528,9 @@ public class ConstraintWidget {
 
     // Baseline distance relative to the top of the widget
     int mBaselineDistance = 0;
+
+    // LastBaseline distance relative to the top of the widget
+    int mLastBaselineDistance = 0;
 
     // Minimum sizes for the widget
     protected int mMinWidth;
@@ -730,6 +762,7 @@ public class ConstraintWidget {
         serializeAnchor(ret, "right", mRight);
         serializeAnchor(ret, "bottom", mBottom);
         serializeAnchor(ret, "baseline", mBaseline);
+        serializeAnchor(ret, "lastBaseline", mLastBaseline);
         serializeAnchor(ret, "centerX", mCenterX);
         serializeAnchor(ret, "centerY", mCenterY);
         serializeCircle(ret, mCenter, mCircleConstraintAngle);
@@ -1330,6 +1363,15 @@ public class ConstraintWidget {
      */
     public boolean hasBaseline() {
         return mHasBaseline;
+    }
+
+    /**
+     * Return true if this widget has a lastBaseline
+     *
+     * @return true if the widget has a lastBaseline, false otherwise
+     */
+    public boolean hasLastBaseline() {
+        return mHasLastBaseline;
     }
 
     /**
@@ -2233,7 +2275,8 @@ public class ConstraintWidget {
     /**
      * Given a type of anchor, returns the corresponding anchor.
      *
-     * @param anchorType type of the anchor (LEFT, TOP, RIGHT, BOTTOM, BASELINE, CENTER_X, CENTER_Y)
+     * @param anchorType type of the anchor (LEFT, TOP, RIGHT, BOTTOM, BASELINE, LAST_BASELINE,
+     *                   CENTER_X, CENTER_Y)
      * @return the matching anchor
      */
     public ConstraintAnchor getAnchor(ConstraintAnchor.Type anchorType) {
@@ -2252,6 +2295,9 @@ public class ConstraintWidget {
             }
             case BASELINE: {
                 return mBaseline;
+            }
+            case LAST_BASELINE: {
+                return mLastBaseline;
             }
             case CENTER_X: {
                 return mCenterX;
@@ -3763,6 +3809,7 @@ public class ConstraintWidget {
         getSceneString(ret, "right", mRight);
         getSceneString(ret, "bottom", mBottom);
         getSceneString(ret, "baseline", mBaseline);
+        serializeAnchor(ret, "lastBaseline", mLastBaseline);
         getSceneString(ret, "centerX", mCenterX);
         getSceneString(ret, "centerY", mCenterY);
         getSceneString(ret, "    width",

--- a/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/LastBaselineDemo.kt
+++ b/projects/ComposeConstraintLayout/app/src/main/java/com/example/constraintlayout/LastBaselineDemo.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.constraintlayout
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.constraintlayout.compose.*
+
+@Preview(group = "baseline")
+@Composable
+fun LastBaselineDSL() {
+    ConstraintLayout(
+        ConstraintSet {
+            val a = createRefFor("num1")
+            val b = createRefFor("num2")
+            constrain(a) {
+                start.linkTo(parent.start)
+                end.linkTo(b.start)
+                top.linkTo(parent.top)
+                bottom.linkTo(parent.bottom)
+            }
+            constrain(b) {
+                top.linkTo(a.lastBaseline)
+                start.linkTo(a.end)
+                end.linkTo(parent.end)
+            }
+        },
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Button(
+            modifier = Modifier.layoutId("num1").width(100.dp),
+            onClick = {},
+        ) {
+            Text(text = String.format("Text-%s", 1), fontSize = 30.sp)
+        }
+
+        Button(
+            modifier = Modifier.layoutId("num2").size(200.dp),
+            onClick = {},
+        ) {
+            Text(text = String.format("Text-%s", 2), fontSize = 30.sp)
+        }
+    }
+}
+
+@Preview(group = "baseline1")
+@Composable
+fun LastBaselineJSON() {
+    ConstraintLayout(
+        androidx.constraintlayout.compose.ConstraintSet(
+            """
+        {
+            num1 : {
+              left: ['parent', 'left'],
+              right: ['num2', 'left'],
+              lastBaseline: ['num2', 'top']
+            },
+            num2 : {
+              top: ['parent', 'top'],
+              bottom: ['parent', 'bottom'],
+              left: ['num1', 'right'],
+              right: ['parent', 'right'],
+            }
+
+        }
+        """.trimIndent()
+        ),
+        modifier = Modifier.fillMaxSize()) {
+        val numArray = arrayOf("1", "2")
+        for (num in numArray) {
+            Button(
+                modifier = Modifier.layoutId("num$num").width(100.dp),
+                onClick = {},
+            ) {
+                Text(text = String.format("Text-%s", num), fontSize = 30.sp)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR is created to experiment how to enable LastBaseline alignment. Currently, we only support FirstBaseline alignment in ConstraintLayout Compose.

Some examples can be seen below (based on LastBaselineDemo.kt).

### Top to LastBaseline
![image](https://user-images.githubusercontent.com/20599348/231611490-1fd72851-c4c9-4cd3-b280-fdc1a807af64.png)

### Bottom to LastBaseline
![image](https://user-images.githubusercontent.com/20599348/231611673-769e56f7-743d-46b0-9596-f909358ef022.png)

### Baseline to LastBaseline
![image](https://user-images.githubusercontent.com/20599348/231611811-3fb2d04e-ef22-4e6a-afb1-3eff5581d797.png)
