### PR TITLE
Best Practice : Use final keyword for Constant String declarations

### DIFF
--- a/toolsAndroid/CLAnalyst/app/src/main/java/android/support/clanalyst/DumpCL.java
+++ b/toolsAndroid/CLAnalyst/app/src/main/java/android/support/clanalyst/DumpCL.java
@@ -48,7 +48,7 @@ import java.util.HashMap;
  * DumpCL.asString(cl) returns a json5 string
  */
 public class DumpCL {
-    private static String TAG = "ML_DEBUG";
+    private static final String TAG = "ML_DEBUG";
     HashMap<Integer, String> names = new HashMap<>();
 
     private DumpCL() {


### PR DESCRIPTION
Made the TAG String parameter to final since it is constant. The static keyword means the value is the same for every instance of the class. The final keyword means once the variable is assigned a value it can never be changed. The combination of static final in Java is how to create a constant value.